### PR TITLE
Drop memory properly

### DIFF
--- a/src/lib/vm/gc.rs
+++ b/src/lib/vm/gc.rs
@@ -111,9 +111,11 @@ impl<T: GcLayout> Deref for GcBox<T> {
     type Target = T;
 
     fn deref(&self) -> &T {
-        let valptr = unsafe { (self as *const GcBox<T> as *const u8).add(size_of::<GcBox<T>>()) }
-            as *const T;
-        unsafe { &*valptr }
+        unsafe {
+            let valptr =
+                (self as *const GcBox<T> as *const u8).add(size_of::<GcBox<T>>()) as *const T;
+            &*valptr
+        }
     }
 }
 

--- a/src/lib/vm/objects.rs
+++ b/src/lib/vm/objects.rs
@@ -158,7 +158,7 @@ impl Drop for Val {
         match self.valkind() {
             ValKind::GCBOX => {
                 if self.val != 0 {
-                    unsafe { Gc::<ThinObj>::from_raw(self.val as *const _) };
+                    drop(unsafe { Gc::<ThinObj>::from_raw(self.val as *const _) });
                 }
             }
             ValKind::INT => (),

--- a/src/lib/vm/objects.rs
+++ b/src/lib/vm/objects.rs
@@ -17,6 +17,7 @@ use std::{
     mem::{forget, size_of, transmute},
     ops::{CoerceUnsized, Deref},
     path::PathBuf,
+    ptr,
 };
 
 use enum_primitive_derive::Primitive;
@@ -239,6 +240,16 @@ impl Deref for ThinObj {
             let self_ptr = self as *const Self;
             let obj_ptr = self_ptr.add(1);
             transmute((obj_ptr, self.vtable))
+        }
+    }
+}
+
+impl Drop for ThinObj {
+    fn drop(&mut self) {
+        let self_ptr = self as *const Self;
+        unsafe {
+            let obj_ptr = self_ptr.add(1);
+            ptr::drop_in_place::<Obj>(transmute((obj_ptr, self.vtable)));
         }
     }
 }

--- a/src/lib/vm/vm.rs
+++ b/src/lib/vm/vm.rs
@@ -25,6 +25,7 @@ pub const SOM_EXTENSION: &str = "som";
 #[derive(Debug)]
 pub enum VMError {
     UnknownMethod(String),
+    Exit,
 }
 
 pub struct VM {
@@ -136,7 +137,7 @@ impl VM {
                 _ => unimplemented!(),
             }
         }
-        process::exit(0);
+        Err(VMError::Exit)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ use std::{
 
 use getopts::Options;
 
-use yksom::vm::VM;
+use yksom::vm::vm::{VMError, VM};
 
 fn usage(prog: &str) -> ! {
     let path = Path::new(prog);
@@ -43,5 +43,11 @@ fn main() {
     let vm = VM::new(matches.opt_strs("cp"));
     let cls = vm.compile(&Path::new(&matches.free[0]).canonicalize().unwrap());
     let obj = vm.send(cls, "new", &[]).unwrap();
-    vm.send(obj, "run", &[]).unwrap();
+    match vm.send(obj, "run", &[]) {
+        Ok(_) | Err(VMError::Exit) => (),
+        Err(e) => {
+            println!("{:?}", e);
+            process::exit(1);
+        }
+    }
 }


### PR DESCRIPTION
Previously we didn't drop memory in many cases. Running `valgrind` on hello world shows this clearly:

```
==3110== HEAP SUMMARY:
==3110==     in use at exit: 8,389 bytes in 44 blocks
==3110==   total heap usage: 27,864 allocs, 27,820 frees, 17,935,698 bytes allocated
==3110==
==3110== LEAK SUMMARY:
==3110==    definitely lost: 0 bytes in 0 blocks
==3110==    indirectly lost: 0 bytes in 0 blocks
==3110==      possibly lost: 0 bytes in 0 blocks
==3110==    still reachable: 8,389 bytes in 44 blocks
==3110==         suppressed: 0 bytes in 0 blocks
```

This PR fixes that.

First, some of those leaks are because we called `process::exit` without giving parent frames the chance to `drop` items. This is fixed in https://github.com/softdevteam/yksom/commit/1cc668dbf3e719d4167c0329cb293101453c20db.

Second, `Gc`/`GcBox`/`ThinObj` didn't call `drop` at all, mostly because I wasn't really sure how to do this on trait objects. `Box::drop` has this wonderful comment:

```
// FIXME: Do nothing, drop is currently performed by compiler.
```

Fortunately `ptr::drop_in_place` does what we want. https://github.com/softdevteam/yksom/commit/f272e3f5c2e50ce4c1cf10453b9734263e113e03 has the relevant fixes.

With this, we no longer leak any memory on hello world:

```
==2881== HEAP SUMMARY:
==2881==     in use at exit: 48 bytes in 2 blocks
==2881==   total heap usage: 27,864 allocs, 27,862 frees, 17,935,698 bytes allocated
==2881==
==2881== LEAK SUMMARY:
==2881==    definitely lost: 0 bytes in 0 blocks
==2881==    indirectly lost: 0 bytes in 0 blocks
==2881==      possibly lost: 0 bytes in 0 blocks
==2881==    still reachable: 48 bytes in 2 blocks
==2881==         suppressed: 0 bytes in 0 blocks
```

The 2 blocks that show up in `valgrind` are to do with mutexes, so we're not responsible for them.