### PR TITLE
Fix boxing of ints

### DIFF
--- a/src/lib/vm/vm.rs
+++ b/src/lib/vm/vm.rs
@@ -26,6 +26,8 @@ pub const SOM_EXTENSION: &str = "som";
 pub enum VMError {
     UnknownMethod(String),
     Exit,
+    CantRepresentAsIsize,
+    CantRepresentAsUsize,
 }
 
 pub struct VM {
@@ -90,7 +92,7 @@ impl VM {
 
     /// Send the message `msg` to the receiver `rcv` with arguments `args`.
     pub fn send(&self, rcv: Val, msg: &str, args: &[Val]) -> Result<Val, VMError> {
-        let cls_gcobj = rcv.gc_obj(self).get_class(self).gc_obj(self);
+        let cls_gcobj = rcv.gc_obj(self)?.get_class(self).gc_obj(self)?;
         let cls: &Class = cls_gcobj.as_any().downcast_ref().unwrap();
         let meth = cls.get_method(self, msg)?;
 
@@ -108,7 +110,7 @@ impl VM {
             }
             Primitive::PrintLn => {
                 // XXX println should be on System, not on string
-                let str_gcobj = rcv.gc_obj(self);
+                let str_gcobj = rcv.gc_obj(self)?;
                 let string: &String_ = str_gcobj.as_any().downcast_ref().unwrap();
                 println!("{}", string.as_str());
                 Ok(self.nil.clone())


### PR DESCRIPTION
There is an element of "2 for 1" in this PR. https://github.com/softdevteam/yksom/commit/23a03e051d3cdfc2505cc5fff7ae8f46d0642dd6 fixes an infinite recursion problem in boxing integers. While doing that, I noticed that we had become highly inconsistent in the return types we used, particularly in integer creating/boxing/unboxing.  https://github.com/softdevteam/yksom/commit/833ddb8fc562c06b15dfb6dca0c812c3f6420e60 fixes that problem.