### PR TITLE
Allow object references to be converted back into ThinCells/Gcs.

### DIFF
--- a/src/lib/vm/gc.rs
+++ b/src/lib/vm/gc.rs
@@ -56,7 +56,7 @@ impl<T: GcLayout> Gc<T> {
 
     /// Recreate the `Gc<T>` pointing to `valptr`. If `valptr` was not originally directly created
     /// by `Gc`/`GcBox` then undefined behaviour will result.
-    pub unsafe fn recover(valptr: *const T) -> Gc<T> {
+    pub unsafe fn recover(valptr: *const T) -> Self {
         Gc::clone_from_raw(GcBox::recover(valptr))
     }
 

--- a/src/lib/vm/gc.rs
+++ b/src/lib/vm/gc.rs
@@ -54,6 +54,12 @@ impl<T: GcLayout> Gc<T> {
         }
     }
 
+    /// Recreate the `Gc<T>` pointing to `valptr`. If `valptr` was not originally directly created
+    /// by `Gc`/`GcBox` then undefined behaviour will result.
+    pub unsafe fn recover(valptr: *const T) -> Gc<T> {
+        Gc::clone_from_raw(GcBox::recover(valptr))
+    }
+
     /// Clone the GC object `gcc`. Note that this is an associated method.
     pub fn clone(gcc: &Gc<T>) -> Self {
         unsafe { &mut *gcc.ptr }.clones += 1;
@@ -104,6 +110,12 @@ impl<T: GcLayout> GcBox<T> {
         unsafe { &mut *gcbptr }.clones = 1;
         let valptr = unsafe { (gcbptr as *mut u8).add(valoff) } as *mut T;
         (gcbptr, valptr)
+    }
+
+    /// Recreate the `GcBox<T>` pointing to `valptr`. If `valptr` was not originally directly
+    /// created by `GcBox` then undefined behaviour will result.
+    pub unsafe fn recover(valptr: *const T) -> *mut GcBox<T> {
+        (valptr as *const u8).sub(size_of::<GcBox<T>>()) as *mut GcBox<T>
     }
 }
 

--- a/src/lib/vm/objects.rs
+++ b/src/lib/vm/objects.rs
@@ -322,7 +322,7 @@ impl Obj for Class {
 }
 
 impl Class {
-    pub fn from_ccls(vm: &VM, ccls: cobjects::Class) -> Self {
+    pub fn from_ccls(vm: &VM, ccls: cobjects::Class) -> Val {
         let mut methods = HashMap::with_capacity(ccls.methods.len());
         for cmeth in ccls.methods.into_iter() {
             let body = match cmeth.body {
@@ -342,13 +342,16 @@ impl Class {
                 cobjects::Const::String(s) => String_::new(vm, s),
             })
             .collect();
-        Class {
-            path: ccls.path,
-            methods,
-            instrs: ccls.instrs,
-            consts,
-            sends: ccls.sends,
-        }
+        Val::from_obj(
+            vm,
+            Class {
+                path: ccls.path,
+                methods,
+                instrs: ccls.instrs,
+                consts,
+                sends: ccls.sends,
+            },
+        )
     }
 
     pub fn get_method(&self, _: &VM, msg: &str) -> Result<&Method, VMError> {

--- a/src/lib/vm/objects.rs
+++ b/src/lib/vm/objects.rs
@@ -101,7 +101,7 @@ impl Val {
     /// Convert `obj` into a `Val`. `Obj` must previously have been created via `Obj::from_off` and
     /// then turned into an actual object with `gc_obj`: failure to follow these steps results in
     /// undefined behaviour.
-    pub fn recover(_: &VM, obj: &Obj) -> Self {
+    pub fn recover(obj: &Obj) -> Self {
         unsafe {
             let ptr = ThinObj::recover(obj);
             Val {
@@ -619,7 +619,7 @@ mod tests {
             let v = String_::new(&vm, "s".to_owned());
             let v_gcobj = v.gc_obj(&vm).unwrap();
             let v_int: &Obj = v_gcobj.deref().deref();
-            let v_recovered = Val::recover(&vm, v_int);
+            let v_recovered = Val::recover(v_int);
             assert_eq!(v_recovered.val, v.val);
             v_recovered
         };

--- a/src/lib/vm/vm.rs
+++ b/src/lib/vm/vm.rs
@@ -59,8 +59,7 @@ impl VM {
     /// Compile the file at `path`.
     pub fn compile(&self, path: &Path) -> Val {
         let ccls = compile(path);
-        let cls = Class::from_ccls(self, ccls);
-        Val::from_obj(self, cls)
+        Class::from_ccls(self, ccls)
     }
 
     fn find_class(&self, name: &str) -> Result<PathBuf, ()> {


### PR DESCRIPTION
Without this we can't write VM functions that return `&self` as a `Val`, because `&self` will be a reference to a concrete struct, and we can't turn that into a Val, because `Val::from_obj` takes a `T`, not an `&T`. At its simplest, this means we couldn't write the following identity function:

```
  struct S;

  impl Obj for S {}

  impl S {
      fn identity(&self) -> Val {
          // what goes here?
      }
  }
```

This commit adds a way to turn a `&T` back into a ThinObj/GcBox/Gc. It allows us to express the identity function as follows:

```
  impl S {
      fn identity(&self) -> Val {
          Val::restore(self)
      }
  }
```

This is clearly dangerous, because it assumes that the memory pointed to by `&self` is part of a ThinObj/GcBox combo. If that isn't true, all sorts of bad things will happen. Fortunately it's relatively easy to obey this constraint by always passing new instances immediately to `Val::from_obj`.

[I spent considerable time working out if I could enforce this constraint in the type system. My conclusion is that I probably could, but at the cost of making the code hugely unergonomic.]
