### PR TITLE
Handle keyword arguments

### DIFF
--- a/lib/SOM/String.som
+++ b/lib/SOM/String.som
@@ -1,3 +1,5 @@
 String = (
     println = primitive
+    concatenate: argument = primitive
+"    + argument            = ( ^self concatenate: argument asString )"
 )

--- a/src/lib/compiler/ast.rs
+++ b/src/lib/compiler/ast.rs
@@ -28,6 +28,7 @@ pub struct Method {
 #[derive(Debug)]
 pub enum MethodName {
     Id(Lexeme<StorageT>),
+    Keywords(Vec<(Lexeme<StorageT>, Lexeme<StorageT>)>),
 }
 
 #[derive(Debug)]

--- a/src/lib/compiler/ast_to_instrs.rs
+++ b/src/lib/compiler/ast_to_instrs.rs
@@ -113,24 +113,33 @@ impl<'a> Compiler<'a> {
         let mut vars = HashMap::new();
         vars.insert("self", 0);
         self.vars_stack.push(vars);
-        let (name, body) = match astmeth.name {
+        let (name, args) = match astmeth.name {
             ast::MethodName::Id(lexeme) => {
-                let name = self.lexer.lexeme_str(&lexeme).to_string();
-                let body = self.c_body((lexeme, &name), &astmeth.body)?;
-                (name, body)
+                ((lexeme, self.lexer.lexeme_str(&lexeme).to_string()), vec![])
+            }
+            ast::MethodName::Keywords(ref pairs) => {
+                let name = pairs
+                    .iter()
+                    .map(|x| self.lexer.lexeme_str(&x.0))
+                    .collect::<String>();
+                let args = pairs.iter().map(|x| x.1).collect::<Vec<_>>();
+                ((pairs[0].0, name), args)
             }
         };
+        let body = self.c_body((name.0, &name.1), args, &astmeth.body)?;
         self.vars_stack.pop();
-        Ok(cobjects::Method { name, body })
+        Ok(cobjects::Method { name: name.1, body })
     }
 
     fn c_body(
         &mut self,
         name: (Lexeme<StorageT>, &str),
+        _args: Vec<Lexeme<StorageT>>,
         body: &ast::MethodBody,
     ) -> Result<cobjects::MethodBody, Vec<(Lexeme<StorageT>, String)>> {
         match body {
             ast::MethodBody::Primitive => match name.1 {
+                "concatenate:" => Ok(cobjects::MethodBody::Primitive(Primitive::Concatenate)),
                 "new" => Ok(cobjects::MethodBody::Primitive(Primitive::New)),
                 "println" => Ok(cobjects::MethodBody::Primitive(Primitive::PrintLn)),
                 _ => Err(vec![(name.0, format!("Unknown primitive '{}'", name.1))]),

--- a/src/lib/compiler/ast_to_instrs.rs
+++ b/src/lib/compiler/ast_to_instrs.rs
@@ -170,7 +170,9 @@ impl<'a> Compiler<'a> {
             }
             ast::Expr::String(lexeme) => {
                 // XXX are there string escaping rules we need to take account of?
-                let s = self.lexer.lexeme_str(&lexeme).to_string();
+                let s_orig = self.lexer.lexeme_str(&lexeme);
+                // Strip off the beginning/end quotes.
+                let s = s_orig[1..s_orig.len() - 1].to_owned();
                 let const_off = self.const_off(cobjects::Const::String(s));
                 self.instrs.push(Instr::Const(const_off));
                 Ok(())

--- a/src/lib/compiler/instrs.rs
+++ b/src/lib/compiler/instrs.rs
@@ -17,6 +17,7 @@ pub enum Instr {
 
 #[derive(Clone, Copy, Debug)]
 pub enum Primitive {
+    Concatenate,
     New,
     PrintLn,
 }

--- a/src/lib/compiler/som.y
+++ b/src/lib/compiler/som.y
@@ -48,11 +48,11 @@ Temps -> Result<Vec<Lexeme<StorageT>>, ()>:
     ;
 MethodName -> Result<MethodName, ()>:
       "ID" { Ok(MethodName::Id(map_err($1)?)) }
-    | MethodNameKeywords { unimplemented!() }
+    | MethodNameKeywords { Ok(MethodName::Keywords($1?)) }
     | MethodNameBin { unimplemented!() }
     ;
-MethodNameKeywords -> Result<(), ()>:
-      "KEYWORD" "ID" { unimplemented!() }
+MethodNameKeywords -> Result<Vec<(Lexeme<StorageT>, Lexeme<StorageT>)>, ()>:
+      "KEYWORD" "ID" { Ok(vec![(map_err($1)?, map_err($2)?)]) }
     | MethodNameKeywords "KEYWORD" "ID" { unimplemented!() }
     ;
 MethodNameBin -> Result<(), ()>:

--- a/src/lib/compiler/som.y
+++ b/src/lib/compiler/som.y
@@ -78,7 +78,6 @@ MethodNameBinOp -> Result<(), ()>:
     ;
 Argument -> Result<(), ()>:
       "ID" { unimplemented!() }
-    | "PRIMITIVE" { unimplemented!() }
     | { unimplemented!() }
     ;
 MethodBody -> Result<MethodBody, ()>:

--- a/src/lib/compiler/som.y
+++ b/src/lib/compiler/som.y
@@ -32,7 +32,7 @@ MethodsOpt -> Result<Vec<Method>, ()>:
     ;
 Methods -> Result<Vec<Method>, ()>:
       Method { Ok(vec![$1?]) }
-    | Methods Method { flatten($1, $2) }
+    | Methods Method { flattenr($1, $2) }
     ;
 ClassMethods -> Result<(), ()>:
           "SEPARATOR" InstanceFields MethodsOpt { unimplemented!() }
@@ -96,7 +96,7 @@ DotOpt -> Result<(), ()>:
     ;
 Exprs -> Result<Vec<Expr>, ()>:
       Expr { Ok(vec![$1?]) }
-    | Exprs "." Expr { flatten($1, $3) }
+    | Exprs "." Expr { flattenr($1, $3) }
     ;
 Expr -> Result<Expr, ()>:
       Assign { unimplemented!() }
@@ -115,7 +115,7 @@ KeywordMsg -> Result<Expr, ()>:
     | BinaryMsg { $1 }
     ;
 KeywordMsgList -> Result<Vec<(Lexeme<StorageT>, Expr)>, ()>:
-      KeywordMsgList "KEYWORD" BinaryMsg { flatten($1, Ok((map_err($2)?, $3?))) }
+      KeywordMsgList "KEYWORD" BinaryMsg { flattenr($1, Ok((map_err($2)?, $3?))) }
     | "KEYWORD" BinaryMsg { Ok(vec![(map_err($1)?, $2?)]) }
     ;
 BinaryMsg -> Result<Expr, ()>:
@@ -130,7 +130,7 @@ IdListOpt -> Result<Vec<Lexeme<StorageT>>, ()>:
     ;
 IdList -> Result<Vec<Lexeme<StorageT>>, ()>:
       "ID" { Ok(vec![map_err($1)?]) }
-    | IdList "ID" { flatten($1, map_err($2)) }
+    | IdList "ID" { flattenr($1, map_err($2)) }
     ;
 BinOp -> Result<(), ()>:
       "BINOPSEQ" { unimplemented!() }
@@ -191,7 +191,8 @@ fn map_err<StorageT>(r: Result<Lexeme<StorageT>, Lexeme<StorageT>>)
     r.map_err(|_| ())
 }
 
-fn flatten<T>(lhs: Result<Vec<T>, ()>, rhs: Result<T, ()>) -> Result<Vec<T>, ()> {
+/// Flatten `rhs` into `lhs`.
+fn flattenr<T>(lhs: Result<Vec<T>, ()>, rhs: Result<T, ()>) -> Result<Vec<T>, ()> {
     let mut flt = lhs?;
     flt.push(rhs?);
     Ok(flt)

--- a/src/lib/compiler/som.y
+++ b/src/lib/compiler/som.y
@@ -52,8 +52,8 @@ MethodName -> Result<MethodName, ()>:
     | MethodNameBin { unimplemented!() }
     ;
 MethodNameKeywords -> Result<(), ()>:
-      "KEYWORD" Argument { unimplemented!() }
-    | MethodNameKeywords "KEYWORD" Argument { unimplemented!() }
+      "KEYWORD" "ID" { unimplemented!() }
+    | MethodNameKeywords "KEYWORD" "ID" { unimplemented!() }
     ;
 MethodNameBin -> Result<(), ()>:
       MethodNameBinOp Argument { unimplemented!() };
@@ -75,10 +75,6 @@ MethodNameBinOp -> Result<(), ()>:
     | "," { unimplemented!() }
     | "@" { unimplemented!() }
     | "%" { unimplemented!() }
-    ;
-Argument -> Result<(), ()>:
-      "ID" { unimplemented!() }
-    | { unimplemented!() }
     ;
 MethodBody -> Result<MethodBody, ()>:
       "PRIMITIVE" { Ok(MethodBody::Primitive) }
@@ -167,6 +163,10 @@ BlockParamsOpt -> Result<(), ()>:
 BlockParams -> Result<(), ()>:
       "PARAM" Argument { unimplemented!() }
     | BlockParams "PARAM" Argument { unimplemented!() }
+    ;
+Argument -> Result<(), ()>:
+      "ID" { unimplemented!() }
+    | { unimplemented!() }
     ;
 StringConst -> Result<(), ()>:
       "#" "STRING" { unimplemented!() }

--- a/src/lib/vm/objects.rs
+++ b/src/lib/vm/objects.rs
@@ -537,6 +537,25 @@ impl String_ {
     pub fn as_str(&self) -> &str {
         &self.s
     }
+
+    /// Concatenate this string with another string and return the result.
+    pub fn concatenate(&self, vm: &VM, other: Val) -> Result<Val, VMError> {
+        let other_gcobj = other.gc_obj(vm)?;
+        let other_str: &String_ = other_gcobj.cast()?;
+
+        // Since strings are immutable, concatenating an empty string means we don't need to
+        // make a new string.
+        if self.s.is_empty() {
+            return Ok(other);
+        } else if other_str.s.is_empty() {
+            return Ok(Val::recover(self));
+        }
+
+        let mut new = String::with_capacity(self.s.len() + other_str.s.len());
+        new.push_str(&self.s);
+        new.push_str(&other_str.s);
+        Ok(String_::new(vm, new))
+    }
 }
 
 #[cfg(test)]

--- a/src/lib/vm/vm.rs
+++ b/src/lib/vm/vm.rs
@@ -105,6 +105,11 @@ impl VM {
 
     fn exec_primitive(&self, prim: Primitive, rcv: Val, args: &[Val]) -> Result<Val, VMError> {
         match prim {
+            Primitive::Concatenate => {
+                let rcv_gcobj = rcv.gc_obj(self)?;
+                let rcv_str: &String_ = rcv_gcobj.cast()?;
+                rcv_str.concatenate(self, args[0].clone())
+            }
             Primitive::New => {
                 assert_eq!(args.len(), 0);
                 Ok(Inst::new(self, rcv))

--- a/src/lib/vm/vm.rs
+++ b/src/lib/vm/vm.rs
@@ -119,7 +119,7 @@ impl VM {
                 let str_gcobj = rcv.gc_obj(self)?;
                 let string: &String_ = str_gcobj.cast()?;
                 println!("{}", string.as_str());
-                Ok(self.nil.clone())
+                Ok(rcv)
             }
         }
     }

--- a/src/lib/vm/vm.rs
+++ b/src/lib/vm/vm.rs
@@ -128,11 +128,11 @@ impl VM {
                     pc += 1;
                 }
                 Instr::Send(moff) => {
-                    let rcv = frame.stack_pop();
                     let (ref name, nargs) = &cls.sends[moff];
                     let args = frame
                         .stack_drain(frame.stack_len() - nargs..)
                         .collect::<Vec<_>>();
+                    let rcv = frame.stack_pop();
                     let r = self.send(rcv, &name, &args)?;
                     frame.stack_push(r);
                     pc += 1;

--- a/src/lib/vm/vm.rs
+++ b/src/lib/vm/vm.rs
@@ -25,11 +25,16 @@ pub const SOM_EXTENSION: &str = "som";
 
 #[derive(Debug, PartialEq)]
 pub enum VMError {
-    UnknownMethod(String),
-    Exit,
+    /// A number which can't be represented in an `isize`.
     CantRepresentAsIsize,
+    /// A number which can't be represented in an `usize`.
     CantRepresentAsUsize,
+    /// The VM is trying to exit.
+    Exit,
+    /// A dynamic type error.
     TypeError { expected: TypeId, got: TypeId },
+    /// An unknown method.
+    UnknownMethod(String),
 }
 
 pub struct VM {


### PR DESCRIPTION
This PR handles SOM keyword messages somewhat properly (i.e. functions which take named arguments, which is a Smalltalk staple). This is enough for us to implement the concatenate message on strings, at least.  The following program:
    
```
      run = (('Hello, World from' concatenate: ' SOM') println )
```

prints "Hello, World from SOM". The main commit is https://github.com/softdevteam/yksom/pull/6/commits/5099036889bbd438484c3fe49ef9ad0450506adc; the other commits are mostly tidying up minor issues and should be fairly easy to assess.