### PR TITLE
Add Gc::new.

### DIFF
--- a/src/lib/vm/gc.rs
+++ b/src/lib/vm/gc.rs
@@ -80,14 +80,14 @@ impl<T: GcLayout> Gc<T> {
 
 impl<T: GcLayout> Drop for Gc<T> {
     fn drop(&mut self) {
-        let clones = unsafe { &mut *self.ptr }.clones;
+        let clones = unsafe { &*self.ptr }.clones;
         if clones == 1 {
             unsafe {
                 ptr::drop_in_place(self.ptr);
                 dealloc(self.ptr as *mut u8, self.layout());
             }
         } else {
-            unsafe { &mut *self.ptr }.clones = clones - 1;
+            unsafe { &mut *self.ptr }.clones -= 1;
         }
     }
 }

--- a/src/lib/vm/objects.rs
+++ b/src/lib/vm/objects.rs
@@ -303,7 +303,7 @@ impl Drop for ThinObj {
         unsafe {
             let obj_ptr = self_ptr.add(size_of::<ThinObj>());
             let fat_ptr =
-                transmute::<(*mut u8, usize), &mut dyn Obj>((obj_ptr as *mut u8, self.vtable));
+                transmute::<(*mut u8, usize), *mut dyn Obj>((obj_ptr as *mut u8, self.vtable));
             ptr::drop_in_place(fat_ptr);
         }
     }


### PR DESCRIPTION
This adds a simple `Gc::new` function which creates a new GC'd object of an arbitrary type (previously we only offered the indirect `GcBox::alloc` approach. This is likely to be useful in several places.