### PR TITLE
Get normal Rust references to objects when needed

### DIFF
--- a/src/lib/vm/objects.rs
+++ b/src/lib/vm/objects.rs
@@ -380,7 +380,7 @@ pub struct Class<'a> {
     pub name: Val,
     pub path: PathBuf,
     pub supercls: Option<&'a Class<'a>>,
-    pub methods: HashMap<String, Gc<Method>>,
+    pub methods: HashMap<String, Method>,
     pub instrs: Vec<Instr>,
     pub consts: Vec<Val>,
     pub sends: Vec<(String, usize)>,
@@ -428,7 +428,7 @@ impl<'a> Class<'a> {
                 name: cmeth.name.clone(),
                 body,
             };
-            methods.insert(cmeth.name, Gc::new(meth));
+            methods.insert(cmeth.name, meth);
         }
         let consts = ccls
             .consts
@@ -455,10 +455,10 @@ impl<'a> Class<'a> {
         Ok(self.name.clone())
     }
 
-    pub fn get_method(&self, vm: &VM, msg: &str) -> Result<(Val, Gc<Method>), VMError> {
+    pub fn get_method(&self, vm: &VM, msg: &str) -> Result<(Val, &Method), VMError> {
         self.methods
             .get(msg)
-            .map(|x| Ok((Val::recover(self), Gc::clone(x))))
+            .map(|x| Ok((Val::recover(self), x)))
             .unwrap_or_else(|| match self.supercls {
                 Some(scls) => scls.get_method(vm, msg),
                 None => Err(VMError::UnknownMethod(msg.to_owned())),

--- a/src/lib/vm/vm.rs
+++ b/src/lib/vm/vm.rs
@@ -8,7 +8,6 @@
 // terms.
 
 use std::{
-    any::TypeId,
     mem::size_of,
     ops::RangeBounds,
     path::{Path, PathBuf},
@@ -18,7 +17,7 @@ use std::{
 
 use static_assertions::const_assert_eq;
 
-use super::objects::{Class, Inst, MethodBody, String_, Val};
+use super::objects::{Class, Inst, MethodBody, ObjType, String_, Val};
 use crate::compiler::{
     compile,
     instrs::{Instr, Primitive, SELF_VAR},
@@ -35,7 +34,7 @@ pub enum VMError {
     /// The VM is trying to exit.
     Exit,
     /// A dynamic type error.
-    TypeError { expected: TypeId, got: TypeId },
+    TypeError { expected: ObjType, got: ObjType },
     /// An unknown method.
     UnknownMethod(String),
 }


### PR DESCRIPTION
The big problem with our previous `Val` scheme is that you had to call `Val::tobj()` in order to get something you could then turn into a `&T` normal Rust reference. Because `tobj` returns a temporary value (since it might have to box an unboxed value), this meant that you couldn't store references to a `Val`'s underlying object without jumping through hoops.

This PR fixes that, in two main stages. First, we introduce our own type ID scheme (https://github.com/softdevteam/yksom/commit/d42c95d51140a3a1d7d0eda52830e1cd7f12a896) instead of using `TypeId` (which uses the `'static` lifetime, which causes us various problems). Then we introduce a new function `Val::gcbox_cast` (https://github.com/softdevteam/yksom/commit/143e4f6b4020e1583b9030aafec2c682d879adfb) which allows one to cast a `Val` directly to a specific `&T` (where `T` is a struct implementing `Obj`). To be clear, this is generally dangerous, because `gcbox_cast` can't box things: if you call it on an unboxed int, for example, you'll get a `VMError`. But it's useful for things like storing direct Rust references to super classes. In other words, `gcbox_cast` should be used very sparingly.