### PR TITLE
Add local variables and assignments

### DIFF
--- a/src/lib/compiler/ast.rs
+++ b/src/lib/compiler/ast.rs
@@ -21,7 +21,6 @@ pub struct Class {
 #[derive(Debug)]
 pub struct Method {
     pub name: MethodName,
-    pub temps: Vec<Lexeme<StorageT>>,
     pub body: MethodBody,
 }
 
@@ -34,7 +33,10 @@ pub enum MethodName {
 #[derive(Debug)]
 pub enum MethodBody {
     Primitive,
-    Body { exprs: Vec<Expr> },
+    Body {
+        locals: Vec<Lexeme<StorageT>>,
+        exprs: Vec<Expr>,
+    },
 }
 
 #[derive(Debug)]

--- a/src/lib/compiler/ast.rs
+++ b/src/lib/compiler/ast.rs
@@ -34,13 +34,17 @@ pub enum MethodName {
 pub enum MethodBody {
     Primitive,
     Body {
-        locals: Vec<Lexeme<StorageT>>,
+        vars: Vec<Lexeme<StorageT>>,
         exprs: Vec<Expr>,
     },
 }
 
 #[derive(Debug)]
 pub enum Expr {
+    Assign {
+        id: Lexeme<StorageT>,
+        expr: Box<Expr>,
+    },
     KeywordMsg {
         receiver: Box<Expr>,
         msglist: Vec<(Lexeme<StorageT>, Expr)>,

--- a/src/lib/compiler/ast_to_instrs.rs
+++ b/src/lib/compiler/ast_to_instrs.rs
@@ -152,7 +152,8 @@ impl<'a> Compiler<'a> {
                 "println" => Ok(cobjects::MethodBody::Primitive(Primitive::PrintLn)),
                 _ => Err(vec![(name.0, format!("Unknown primitive '{}'", name.1))]),
             },
-            ast::MethodBody::Body { exprs } => {
+            ast::MethodBody::Body { locals, exprs } => {
+                assert!(locals.is_empty());
                 let body_idx = self.instrs.len();
                 // We implicitly assume that the VM sets SELF_VAR to self.
                 for e in exprs {

--- a/src/lib/compiler/cobjects.rs
+++ b/src/lib/compiler/cobjects.rs
@@ -34,7 +34,11 @@ pub struct Method {
 pub enum MethodBody {
     /// A built-in primitive.
     Primitive(Primitive),
-    /// User bytecode: the `usize` gives the starting offset of this method's bytecode in the
-    /// parent class.
-    User(usize),
+    /// User bytecode.
+    User {
+        /// How many variables does this method define?
+        num_vars: usize,
+        /// The offset of this method's bytecode in its parent class.
+        bytecode_off: usize,
+    },
 }

--- a/src/lib/compiler/instrs.rs
+++ b/src/lib/compiler/instrs.rs
@@ -13,8 +13,8 @@ pub enum Instr {
     Primitive(Primitive),
     Return,
     Send(usize),
-    VarLookup(u32),
-    VarSet(u32),
+    VarLookup(usize),
+    VarSet(usize),
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -27,4 +27,4 @@ pub enum Primitive {
 }
 
 /// The index of the "self" variable.
-pub const SELF_VAR: u32 = 0;
+pub const SELF_VAR: usize = 0;

--- a/src/lib/compiler/som.y
+++ b/src/lib/compiler/som.y
@@ -70,7 +70,7 @@ MethodNameBinOp -> Result<(), ()>:
     ;
 MethodBody -> Result<MethodBody, ()>:
       "PRIMITIVE" { Ok(MethodBody::Primitive) }
-    | "(" NameDefs BlockExprs ")" { Ok(MethodBody::Body{ locals: $2?, exprs: $3? }) }
+    | "(" NameDefs BlockExprs ")" { Ok(MethodBody::Body{ vars: $2?, exprs: $3? }) }
     ;
 BlockExprs -> Result<Vec<Expr>, ()>:
       Exprs DotOpt "^" Expr DotOpt { unimplemented!() }
@@ -79,7 +79,7 @@ BlockExprs -> Result<Vec<Expr>, ()>:
     | { Ok(vec![]) }
     ;
 DotOpt -> Result<(), ()>:
-      "." { unimplemented!() }
+      "." { Ok(()) }
     | { Ok(()) }
     ;
 Exprs -> Result<Vec<Expr>, ()>:
@@ -87,11 +87,11 @@ Exprs -> Result<Vec<Expr>, ()>:
     | Exprs "." Expr { flattenr($1, $3) }
     ;
 Expr -> Result<Expr, ()>:
-      Assign { unimplemented!() }
+      Assign { $1 }
     | KeywordMsg { $1 }
     ;
-Assign -> Result<(), ()>:
-      "ID" ":=" Expr { unimplemented!() };
+Assign -> Result<Expr, ()>:
+      "ID" ":=" Expr { Ok(Expr::Assign{id: map_err($1)?, expr: Box::new($3?)}) };
 Unit -> Result<Expr, ()>:
       "ID" { Ok(Expr::VarLookup(map_err($1)?)) }
     | Literal { $1 }


### PR DESCRIPTION
Needs #12 to be merged first.

This PR adds local variables to SOM methods: assigning and reading from variables. The first commit first sorts some mess out in the grammar (mea culpa): the second commit is the meat of things.

This allows us to run programs such as the following:

```
Hello = (
    run = (
        | t1 t2 |
        t1 := 'Hello '.
        t2 := t1 concatenate: 'world'.
        t2 println.
    )
)
```

which prints out ... wait for it ... "Hello world".