### PR TITLE
Test framework

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,20 @@ name = "yksom"
 name = "yksom"
 path = "src/lib/mod.rs"
 
+[[test]]
+name = "lang_tests"
+path = "lang_tests/run.rs"
+harness = false
+
 [build-dependencies]
 cfgrammar = "0.3"
 lrlex = "0.3"
 lrpar = "0.3"
+
+[dev-dependencies]
+lazy_static = "1.3"
+regex = "1.1"
+termcolor = "1.0"
 
 [dependencies]
 cfgrammar = "0.3"

--- a/lang_tests/hello_world1.som
+++ b/lang_tests/hello_world1.som
@@ -1,0 +1,8 @@
+"
+Run-time output:
+  Hello world
+"
+
+Hello_World1 = (
+    run = ( 'Hello world' println )
+)

--- a/lang_tests/hello_world2.som
+++ b/lang_tests/hello_world2.som
@@ -1,0 +1,13 @@
+"
+Run-time output:
+  Hello world
+"
+
+Hello = (
+    run = (
+        | t1 t2 |
+        t1 := 'Hello '.
+        t2 := t1 concatenate: 'world'.
+        t2 println.
+    )
+)

--- a/lang_tests/run.rs
+++ b/lang_tests/run.rs
@@ -1,0 +1,215 @@
+// Copyright (c) 2019 King's College London created by the Software Development Team
+// <http://soft-dev.org/>
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
+
+/// This is a simple test runner for testing the output of SOM scripts at compile-time and
+/// run-time. Each ".som" file in this directory will be run against yksom. Each file must start
+/// with a comment in the following format:
+///
+/// ```text
+///   <type>:
+///     <body>
+/// ```
+///
+/// where:
+///
+///   * `<type>` is one of "Compile-time error", "Run-time error", or "Run-time output".
+///   * `<body>` is fuzzy text which will be matched against yksom's output literally except
+///     the following three exceptions:
+///       * All leading/trailing whitespace in both `<body>` and yksom's output is ignored.
+///       * A line consisting solely of `...` is a wildcard which skips as many lines as necessary
+///         in order to match the subsequent line. It is an error to have two consecutive lines
+///         consisting of `...`.
+///       * A line starting with `...` but ending in non-whitespace matches the end portion of
+///         that string.
+use std::{
+    fs::{read_dir, read_to_string},
+    io::{self, Write},
+    path::PathBuf,
+    process::{self, Command},
+};
+
+use lazy_static::lazy_static;
+use regex::{Regex, RegexBuilder};
+use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
+
+const SOM_EXT: &'static str = "som";
+const SOM_LIBS_PATH: &'static str = "lib/SOM/";
+const TESTS_DIR: &'static str = "lang_tests";
+const WILDCARD: &'static str = "...";
+
+enum ExpType {
+    CompileTimeError,
+    RunTimeError,
+    RunTimeOutput,
+}
+
+lazy_static! {
+    static ref EXPECTED: Regex = RegexBuilder::new(r#"^"(.*?)^""#)
+        .multi_line(true)
+        .dot_matches_new_line(true)
+        .build()
+        .unwrap();
+}
+
+fn find_tests() -> Vec<PathBuf> {
+    let mut tests_path = PathBuf::new();
+    tests_path.push(env!("CARGO_MANIFEST_DIR"));
+    tests_path.push(TESTS_DIR);
+    read_dir(&tests_path)
+        .unwrap()
+        .map(|x| x.unwrap().path())
+        .filter(|x| x.extension().unwrap() == SOM_EXT)
+        .collect()
+}
+
+fn write_with_colour(s: &str, colour: Color) {
+    let mut stderr = StandardStream::stderr(ColorChoice::Always);
+    stderr.set_color(ColorSpec::new().set_fg(Some(colour))).ok();
+    io::stderr().write_all(s.as_bytes()).ok();
+    stderr.reset().ok();
+}
+
+fn output_failure(test_name: &str, output: process::Output) {
+    write_with_colour("FAILED", Color::Red);
+    eprintln!("\n---- {} stdout ----", test_name);
+    io::stderr().write_all(&output.stdout).unwrap();
+    eprintln!("\n---- {} stderr ----", test_name);
+    io::stderr().write_all(&output.stderr).unwrap();
+}
+
+fn output_success() {
+    write_with_colour("ok", Color::Green);
+}
+
+fn fuzzy_match(pattern: &str, s: &[u8]) -> bool {
+    let plines = pattern.trim().lines().map(|x| x.trim()).collect::<Vec<_>>();
+    let slines = std::str::from_utf8(s)
+        .unwrap()
+        .trim()
+        .lines()
+        .map(|x| x.trim())
+        .collect::<Vec<_>>();
+
+    let mut pi = 0;
+    let mut si = 0;
+
+    while pi < plines.len() && si < slines.len() {
+        if plines[pi] == WILDCARD {
+            pi += 1;
+            if pi == plines.len() {
+                return true;
+            }
+            if plines[pi] == WILDCARD {
+                panic!("Can't have '{}' on two consecutive lines.", WILDCARD);
+            }
+            while si < slines.len() {
+                if plines[pi] == slines[si] {
+                    break;
+                }
+                si += 1;
+            }
+            if si == slines.len() {
+                return false;
+            }
+        } else if (plines[pi].starts_with(WILDCARD)
+            && slines[si].ends_with(plines[pi][WILDCARD.len()..].trim()))
+            || plines[pi] == slines[si]
+        {
+            pi += 1;
+            si += 1;
+        } else {
+            return false;
+        }
+    }
+    true
+}
+
+fn run_test(path: PathBuf) -> bool {
+    let test_name = path.file_name().unwrap().to_str().unwrap();
+    eprint!("test lang_tests::{} ... ", test_name);
+    let d = read_to_string(&path).unwrap();
+    let exp = EXPECTED
+        .captures(&d)
+        .expect(&format!(
+            "{} doesn't contain expected test output",
+            test_name
+        ))
+        .get(1)
+        .unwrap()
+        .as_str()
+        .trim();
+    let exptype = match &*exp.lines().nth(0).unwrap().trim().to_lowercase() {
+        "compile-time error:" => ExpType::CompileTimeError,
+        "run-time error:" => ExpType::RunTimeError,
+        "run-time output:" => ExpType::RunTimeOutput,
+        x => panic!("Unknown type '{}'", x),
+    };
+    let expbody = exp.lines().skip(1).collect::<Vec<_>>().join("\n");
+
+    let output = Command::new("cargo")
+        .args(&[
+            "run",
+            "-q",
+            #[cfg(not(debug_assertions))]
+            "--release",
+            "--",
+            "--cp",
+            SOM_LIBS_PATH,
+            path.to_str().unwrap(),
+        ])
+        .output()
+        .expect("Couldn't run command");
+
+    match exptype {
+        ExpType::CompileTimeError | ExpType::RunTimeError => {
+            if output.status.success() {
+                output_failure(test_name, output);
+                false
+            } else {
+                if fuzzy_match(&expbody, &output.stderr) {
+                    output_success();
+                    true
+                } else {
+                    output_failure(test_name, output);
+                    false
+                }
+            }
+        }
+        ExpType::RunTimeOutput => {
+            if !output.status.success() {
+                output_failure(test_name, output);
+                false
+            } else {
+                if fuzzy_match(&expbody, &output.stdout) {
+                    output_success();
+                    true
+                } else {
+                    output_failure(test_name, output);
+                    false
+                }
+            }
+        }
+    }
+}
+
+fn main() {
+    let all_tests = find_tests();
+    eprint!("\nrunning {} tests", all_tests.len());
+    let mut any_failed = false;
+    for t in all_tests {
+        eprintln!();
+        if !run_test(t) {
+            any_failed = true;
+        }
+    }
+    eprintln!("\n");
+    if any_failed {
+        process::exit(1);
+    }
+}

--- a/lang_tests/unassigned_var.som
+++ b/lang_tests/unassigned_var.som
@@ -1,0 +1,11 @@
+"
+Run-time error:
+  UnassignedVar(1)
+"
+
+Unassigned_Var = (
+    run = (
+        |v|
+        v println.
+    )
+)

--- a/lang_tests/unknown_var.som
+++ b/lang_tests/unknown_var.som
@@ -1,0 +1,12 @@
+"
+Compile-time error:
+  ...unknown_var.som', line 10, column 9:
+    unknown := '1'.
+  Unknown variable 'unknown'
+"
+
+UnknownVar = (
+    run = (
+        unknown := '1'.
+    )
+)

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,7 @@ fn main() {
     match vm.send(obj, "run", &[]) {
         Ok(_) | Err(VMError::Exit) => (),
         Err(e) => {
-            println!("{:?}", e);
+            eprintln!("{:?}", e);
             process::exit(1);
         }
     }


### PR DESCRIPTION
This PR adds a simple testing framework for language level tests. It makes most sense to check it out locally and see what it does, but, in essence:

```
    Finished dev [unoptimized + debuginfo] target(s) in 28.29s
     Running target/debug/deps/yksom-a28e908f2324d21c

running 8 tests
test vm::gc::tests::test_gc_new ... ok
test vm::objects::tests::test_gcbox_cast ... ok
test vm::objects::tests::test_cast ... ok
test vm::objects::tests::test_boxed_int ... ok
test vm::objects::tests::test_isize ... ok
test vm::objects::tests::test_recovery ... ok
test vm::objects::tests::test_usize ... ok
test vm::vm::tests::test_frame ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running target/debug/deps/yksom-13f099066134e3d5

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running target/debug/deps/lang_tests-f087493fcadd08c6

running 5 tests
test lang_tests::hello_world1.som ... ok
test lang_tests::hello_world2.som ... ok
test lang_tests::unassigned_var.som ... ok
test lang_tests::unknown_method.som ... ok
test lang_tests::unknown_var.som ... ok

   Doc-tests yksom

running 2 tests
test src/lib/vm/objects.rs - vm::objects (line 16) ... ignored
test src/lib/vm/objects.rs - vm::objects (line 23) ... ignored

test result: ok. 0 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out
```

where `test lang_tests ...` are the new language level tests enabled by this PR.