### PR TITLE
Recompile less often.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ harness = false
 cfgrammar = "0.4"
 lrlex = "0.4"
 lrpar = "0.4"
+rerun_except = "0.1"
 
 [dev-dependencies]
 lang_tester = "0.2"

--- a/build.rs
+++ b/build.rs
@@ -14,13 +14,17 @@ extern crate lrpar;
 use cfgrammar::yacc::YaccKind;
 use lrlex::LexerBuilder;
 use lrpar::CTParserBuilder;
+use rerun_except::rerun_except;
 
 fn main() -> Result<(), Box<std::error::Error>> {
+    rerun_except(&["/lang_tests/*.som"])?;
+
     let lex_rule_ids_map = CTParserBuilder::new()
         .yacckind(YaccKind::Grmtools)
         .process_file_in_src("lib/compiler/som.y")?;
     LexerBuilder::new()
         .rule_ids_map(lex_rule_ids_map)
         .process_file_in_src("lib/compiler/som.l")?;
+
     Ok(())
 }

--- a/build.rs
+++ b/build.rs
@@ -7,10 +7,6 @@
 // at your option. This file may not be copied, modified, or distributed except according to those
 // terms.
 
-extern crate cfgrammar;
-extern crate lrlex;
-extern crate lrpar;
-
 use cfgrammar::yacc::YaccKind;
 use lrlex::LexerBuilder;
 use lrpar::CTParserBuilder;


### PR DESCRIPTION
Using `rerun_except` helps avoid unnecessary rebuilds just because we've changed a language test.