### PR TITLE
Not using "dyn" for trait objects is now deprecated.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -12,7 +12,7 @@ use lrlex::LexerBuilder;
 use lrpar::CTParserBuilder;
 use rerun_except::rerun_except;
 
-fn main() -> Result<(), Box<std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     rerun_except(&["/lang_tests/*.som"])?;
 
     let lex_rule_ids_map = CTParserBuilder::new()

--- a/src/lib/compiler/ast_to_instrs.rs
+++ b/src/lib/compiler/ast_to_instrs.rs
@@ -21,7 +21,7 @@ use super::{
 };
 
 pub struct Compiler<'a> {
-    lexer: &'a Lexer<StorageT>,
+    lexer: &'a dyn Lexer<StorageT>,
     path: &'a Path,
     instrs: Vec<Instr>,
     sends: IndexMap<(String, usize), usize>,
@@ -31,7 +31,7 @@ pub struct Compiler<'a> {
 
 impl<'a> Compiler<'a> {
     pub fn compile(
-        lexer: &Lexer<StorageT>,
+        lexer: &dyn Lexer<StorageT>,
         path: &Path,
         astcls: &ast::Class,
     ) -> Result<cobjects::Class, String> {


### PR DESCRIPTION
Fixing these (thanks to `cargo fix`) removes a large number of warnings.