### PR TITLE
Move from enum-primitive-derive to num_enum.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,10 +32,10 @@ regex = "1.1"
 abgc = { git = "https://github.com/softdevteam/abgc" }
 abgc_derive = { git = "https://github.com/softdevteam/abgc" }
 cfgrammar = "0.4"
-enum-primitive-derive = "0.1"
 getopts = "0.2"
 indexmap = "1.0"
 itertools = "0.8"
 lrlex = "0.4"
 lrpar = "0.4"
+num_enum = "0.3"
 num-traits = "0.2"


### PR DESCRIPTION
enum-primitive-derive isn't maintained and doesn't have a very nice way of converting a number into an enum. num_enum is a little better in that regard and is actively maintained, so we might even be able to drop the try_into at some point.