### PR TITLE
Port to the natrob library.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ lazy_static = "1.3"
 regex = "1.1"
 
 [dependencies]
-abgc = { git = "https://github.com/softdevteam/abgc" }
-abgc_derive = { git = "https://github.com/softdevteam/abgc" }
+abgc = { git="https://github.com/softdevteam/abgc" }
+abgc_derive = { git="https://github.com/softdevteam/abgc" }
 cfgrammar = "0.4"
 getopts = "0.2"
 indexmap = "1.0"
@@ -39,3 +39,4 @@ lrlex = "0.4"
 lrpar = "0.4"
 num_enum = "0.3"
 num-traits = "0.2"
+natrob = { git="https://github.com/softdevteam/natrob", features=["abgc"] }


### PR DESCRIPTION
The top-level `downcast` function isn't hugely elegant, but it is simple: we might be able to find a nicer way of doing this in future.