### PR TITLE
Ignore core dumps.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Cargo.lock
 target/
+*.core


### PR DESCRIPTION
It's not useful for these to show up in "git status", or for their presence to trigger a rebuild through rerun_except.