### PR TITLE
Add basic integer support.

### DIFF
--- a/lang_tests/int1.som
+++ b/lang_tests/int1.som
@@ -1,0 +1,9 @@
+"
+VM:
+  status: success
+  stdout: 1
+"
+
+int1 = (
+    run = ( 1 asString println )
+)

--- a/lang_tests/int2.som
+++ b/lang_tests/int2.som
@@ -1,0 +1,22 @@
+"
+VM:
+  status: success
+  stdout:
+    2
+    0
+    -1
+    1
+    20
+    4
+"
+
+int2 = (
+    run = (
+        (1 + 1) asString println.
+        (1 - 1) asString println.
+        ((1 - 1) - 1) asString println.
+        (1 - (1 - 1)) asString println.
+        (2 + 3 * 4) asString println.
+        (20 / 5) asString println.
+    )
+)

--- a/lang_tests/int3.som
+++ b/lang_tests/int3.som
@@ -1,0 +1,9 @@
+"
+VM:
+  status: error
+  stderr: Overflow
+"
+
+int3 = (
+    run = ( 4611686018427387904 + 4611686018427387904 )
+)

--- a/lang_tests/int4.som
+++ b/lang_tests/int4.som
@@ -1,0 +1,9 @@
+"
+VM:
+  status: error
+  stderr: Overflow
+"
+
+int4 = (
+    run = ( 4611686018427387904 * 2 )
+)

--- a/lang_tests/int5.som
+++ b/lang_tests/int5.som
@@ -1,0 +1,9 @@
+"
+VM:
+  status: error
+  stderr: DivisionByZero
+"
+
+int5 = (
+    run = ( 10 / 0 )
+)

--- a/lib/SOM/Integer.som
+++ b/lib/SOM/Integer.som
@@ -1,0 +1,8 @@
+Integer = (
+    + argument  = primitive
+    - argument  = primitive
+    * argument  = primitive
+    / argument  = primitive
+
+    asString    = primitive
+)

--- a/src/lib/compiler/ast.rs
+++ b/src/lib/compiler/ast.rs
@@ -27,6 +27,7 @@ pub struct Method {
 
 #[derive(Debug)]
 pub enum MethodName {
+    BinaryOp(Lexeme<StorageT>, Option<Lexeme<StorageT>>),
     Id(Lexeme<StorageT>),
     Keywords(Vec<(Lexeme<StorageT>, Lexeme<StorageT>)>),
 }
@@ -46,11 +47,17 @@ pub enum Expr {
         id: Lexeme<StorageT>,
         expr: Box<Expr>,
     },
+    BinaryMsg {
+        lhs: Box<Expr>,
+        op: Lexeme<StorageT>,
+        rhs: Box<Expr>,
+    },
     Block {
         params: Vec<Lexeme<StorageT>>,
         vars: Vec<Lexeme<StorageT>>,
         exprs: Vec<Expr>,
     },
+    Int(Lexeme<StorageT>),
     KeywordMsg {
         receiver: Box<Expr>,
         msglist: Vec<(Lexeme<StorageT>, Expr)>,

--- a/src/lib/compiler/cobjects.rs
+++ b/src/lib/compiler/cobjects.rs
@@ -13,6 +13,7 @@ use crate::compiler::instrs::{Instr, Primitive};
 
 #[derive(Eq, Hash, PartialEq)]
 pub enum Const {
+    Int(isize),
     String(String),
 }
 

--- a/src/lib/compiler/instrs.rs
+++ b/src/lib/compiler/instrs.rs
@@ -30,10 +30,15 @@ pub enum Builtin {
 
 #[derive(Clone, Copy, Debug)]
 pub enum Primitive {
+    Add,
+    AsString,
     Class,
     Concatenate,
+    Div,
+    Mul,
     Name,
     New,
     PrintLn,
+    Sub,
     Value,
 }

--- a/src/lib/compiler/som.y
+++ b/src/lib/compiler/som.y
@@ -41,32 +41,32 @@ NameDefs -> Result<Vec<Lexeme<StorageT>>, ()>:
 MethodName -> Result<MethodName, ()>:
       "ID" { Ok(MethodName::Id(map_err($1)?)) }
     | MethodNameKeywords { Ok(MethodName::Keywords($1?)) }
-    | MethodNameBin { unimplemented!() }
+    | MethodNameBin { $1 }
     ;
 MethodNameKeywords -> Result<Vec<(Lexeme<StorageT>, Lexeme<StorageT>)>, ()>:
       "KEYWORD" "ID" { Ok(vec![(map_err($1)?, map_err($2)?)]) }
     | MethodNameKeywords "KEYWORD" "ID" { flattenr($1, Ok((map_err($2)?, map_err($3)?))) }
     ;
-MethodNameBin -> Result<(), ()>:
-      MethodNameBinOp Argument { unimplemented!() };
+MethodNameBin -> Result<MethodName, ()>:
+      MethodNameBinOp Argument { Ok(MethodName::BinaryOp($1?, $2?)) };
 // We'd like to just use BinOp here, rather than introducing MethodNameBinOp,
 // but then the "|" symbol conflicts with NameDefs. In other words, you can't
 // have "|" as a method name in SOM.
-MethodNameBinOp -> Result<(), ()>:
+MethodNameBinOp -> Result<Lexeme<StorageT>, ()>:
       "BINOPSEQ" { unimplemented!() }
-    | "~" { unimplemented!() }
-    | "&" { unimplemented!() }
-    | "*" { unimplemented!() }
-    | "/" { unimplemented!() }
-    | "\\" { unimplemented!() }
-    | "+" { unimplemented!() }
-    | "-" { unimplemented!() }
-    | "=" { unimplemented!() }
-    | ">" { unimplemented!() }
-    | "<" { unimplemented!() }
-    | "," { unimplemented!() }
-    | "@" { unimplemented!() }
-    | "%" { unimplemented!() }
+    | "~" { Ok(map_err($1)?) }
+    | "&" { Ok(map_err($1)?) }
+    | "*" { Ok(map_err($1)?) }
+    | "/" { Ok(map_err($1)?) }
+    | "\\" { Ok(map_err($1)?) }
+    | "+" { Ok(map_err($1)?) }
+    | "-" { Ok(map_err($1)?) }
+    | "=" { Ok(map_err($1)?) }
+    | ">" { Ok(map_err($1)?) }
+    | "<" { Ok(map_err($1)?) }
+    | "," { Ok(map_err($1)?) }
+    | "@" { Ok(map_err($1)?) }
+    | "%" { Ok(map_err($1)?) }
     ;
 MethodBody -> Result<MethodBody, ()>:
       "PRIMITIVE" { Ok(MethodBody::Primitive) }
@@ -111,7 +111,7 @@ KeywordMsgList -> Result<Vec<(Lexeme<StorageT>, Expr)>, ()>:
     | "KEYWORD" BinaryMsg { Ok(vec![(map_err($1)?, $2?)]) }
     ;
 BinaryMsg -> Result<Expr, ()>:
-      UnaryMsg BinOp BinaryMsg { unimplemented!() }
+      BinaryMsg BinOp UnaryMsg { Ok(Expr::BinaryMsg{ lhs: Box::new($1?), op: $2?, rhs: Box::new($3?) }) }
     | UnaryMsg { $1 }
     ;
 UnaryMsg -> Result<Expr, ()>:
@@ -124,26 +124,26 @@ IdList -> Result<Vec<Lexeme<StorageT>>, ()>:
       "ID" { Ok(vec![map_err($1)?]) }
     | IdList "ID" { flattenr($1, map_err($2)) }
     ;
-BinOp -> Result<(), ()>:
+BinOp -> Result<Lexeme<StorageT>, ()>:
       "BINOPSEQ" { unimplemented!() }
-    | "~" { unimplemented!() }
-    | "&" { unimplemented!() }
-    | "|" { unimplemented!() }
-    | "*" { unimplemented!() }
-    | "/" { unimplemented!() }
-    | "\\" { unimplemented!() }
-    | "+" { unimplemented!() }
-    | "-" { unimplemented!() }
-    | "=" { unimplemented!() }
-    | ">" { unimplemented!() }
-    | "<" { unimplemented!() }
-    | "," { unimplemented!() }
-    | "@" { unimplemented!() }
-    | "%" { unimplemented!() }
+    | "~" { Ok(map_err($1)?) }
+    | "&" { Ok(map_err($1)?) }
+    | "|" { Ok(map_err($1)?) }
+    | "*" { Ok(map_err($1)?) }
+    | "/" { Ok(map_err($1)?) }
+    | "\\" { Ok(map_err($1)?) }
+    | "+" { Ok(map_err($1)?) }
+    | "-" { Ok(map_err($1)?) }
+    | "=" { Ok(map_err($1)?) }
+    | ">" { Ok(map_err($1)?) }
+    | "<" { Ok(map_err($1)?) }
+    | "," { Ok(map_err($1)?) }
+    | "@" { Ok(map_err($1)?) }
+    | "%" { Ok(map_err($1)?) }
     ;
 Literal -> Result<Expr, ()>:
       "STRING" { Ok(Expr::String(map_err($1)?)) }
-    | "INT" { unimplemented!() }
+    | "INT" { Ok(Expr::Int(map_err($1)?)) }
     | "-" "INT" { unimplemented!() }
     | "DOUBLE" { unimplemented!() }
     | "-" "DOUBLE" { unimplemented!() }
@@ -160,8 +160,8 @@ BlockParams -> Result<(), ()>:
       "PARAM" Argument { unimplemented!() }
     | BlockParams "PARAM" Argument { unimplemented!() }
     ;
-Argument -> Result<(), ()>:
-      "ID" { unimplemented!() }
+Argument -> Result<Option<Lexeme<StorageT>>, ()>:
+      "ID" { Ok(Some(map_err($1)?)) }
     | { unimplemented!() }
     ;
 StringConst -> Result<(), ()>:


### PR DESCRIPTION
Including support for +, -, *, and /. Note that SOM (like most Smalltalks) parses expressions such as "2 + 3 * 4" as "(2 + 3) * 4": it has no concept of operator precedence, treating all binary operations as left associative.