### PR TITLE
Generate cargo doc information on gh-pages for each PR.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,11 @@ before_script:
 script:
     - cargo +nightly fmt --all -- --check
     - cargo test
+    - cargo doc --no-deps
+deploy:
+    provider: pages
+    skip-cleanup: true
+    github-token: $GITHUB_TOKEN
+    local-dir: target/doc
+    on:
+        branch: master


### PR DESCRIPTION
Shamelessly copied from grmtools. I don't think I can test this before it's merged, but I might be very wrong. Any thoughts?