### PR TITLE
Change the name on gh-pages of the internal API documentation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,11 @@ script:
     - cargo +nightly fmt --all -- --check
     - cargo test
     - cargo doc --no-deps
+    - mv target/doc/yksom target/api
 deploy:
     provider: pages
     skip-cleanup: true
     github-token: $GITHUB_TOKEN
-    local-dir: target/doc
+    local-dir: target/api
     on:
         branch: master


### PR DESCRIPTION
Instead of being `yksom/yksom`, this will make it appear as `yksom/api` (leaving us wiggle room if we want to put non-API docs on gh-pages later).