### PR TITLE
Fix our buildbot config for old versions of git.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -15,7 +15,7 @@ rustup component add --toolchain nightly rustfmt-preview || cargo +nightly insta
 cargo +nightly fmt --all -- --check
 cargo test
 
-if [ "`git branch --show-current`" = "staging" ]; then
+if [ "X`git rev-parse --abbrev-ref HEAD`" = "Xstaging" ]; then
     cargo doc --no-deps
     cd target/doc
     git init


### PR DESCRIPTION
The version of git on our buildbot machine doesn't have `git branch --show-current`, leading to our buildbot script failing (but, annoyingly, in a way that doesn't lead to an error).