### PR TITLE
Remove ValResult

### DIFF
--- a/src/lib/vm/mod.rs
+++ b/src/lib/vm/mod.rs
@@ -17,32 +17,6 @@
 //! [`Val::downcast`](vm::val::Val::downcast) (or
 //! [`Val::try_downcast`](vm::val::Val::try_downcast)) it to a concrete implementation of `Obj`.
 
-/// If a `ValResult` represents an error, percolate it up the call stack.
-#[macro_export]
-macro_rules! vtry {
-    ($elem:expr) => {{
-        let o = $elem;
-        if o.is_val() {
-            unsafe { o.unwrap_unsafe() }
-        } else {
-            return o;
-        }
-    }};
-}
-
-/// If a `Result<T, Box<VMError>>` represents an error, then convert the `Box<VMError>` into a
-/// `ValResult` and percolate that up the call stack.
-#[macro_export]
-macro_rules! rtry {
-    ($elem:expr) => {{
-        let e = $elem;
-        match e {
-            Ok(o) => o,
-            Err(e) => return ValResult::from_boxvmerror(e),
-        }
-    }};
-}
-
 pub mod core;
 pub mod objects;
 pub mod val;

--- a/src/lib/vm/objects/class.rs
+++ b/src/lib/vm/objects/class.rs
@@ -18,7 +18,7 @@ use crate::{
     vm::{
         core::{VMError, VM},
         objects::{Method, MethodBody, Obj, ObjType, StaticObjType, String_},
-        val::{NotUnboxable, Val, ValResult},
+        val::{NotUnboxable, Val},
     },
 };
 
@@ -63,7 +63,7 @@ impl StaticObjType for Class {
 }
 
 impl Class {
-    pub fn from_ccls(vm: &VM, ccls: cobjects::Class) -> ValResult {
+    pub fn from_ccls(vm: &VM, ccls: cobjects::Class) -> Result<Val, Box<VMError>> {
         let supercls = match ccls.supercls {
             Some(ref x) => match x.as_str() {
                 "Block" => Some(vm.block_cls.clone()),
@@ -111,10 +111,10 @@ impl Class {
         for c in ccls.consts {
             consts.push(match c {
                 cobjects::Const::String(s) => String_::new(vm, s),
-                cobjects::Const::Int(i) => vtry!(Val::from_isize(vm, i)),
+                cobjects::Const::Int(i) => Val::from_isize(vm, i)?,
             });
         }
-        ValResult::from_val(Val::from_obj(
+        Ok(Val::from_obj(
             vm,
             Class {
                 name: String_::new(vm, ccls.name),
@@ -130,8 +130,8 @@ impl Class {
         ))
     }
 
-    pub fn name(&self, _: &VM) -> ValResult {
-        ValResult::from_val(self.name.clone())
+    pub fn name(&self, _: &VM) -> Result<Val, Box<VMError>> {
+        Ok(self.name.clone())
     }
 
     pub fn get_method(&self, vm: &VM, msg: &str) -> Result<(Val, &Method), Box<VMError>> {

--- a/src/lib/vm/objects/double.rs
+++ b/src/lib/vm/objects/double.rs
@@ -15,7 +15,7 @@ use num_traits::ToPrimitive;
 use crate::vm::{
     core::{VMError, VM},
     objects::{ArbInt, Obj, ObjType, StaticObjType, String_},
-    val::{NotUnboxable, Val, ValResult},
+    val::{NotUnboxable, Val},
 };
 
 #[derive(Debug, GcLayout)]
@@ -35,59 +35,59 @@ impl Obj for Double {
         vm.double_cls.clone()
     }
 
-    fn to_strval(&self, vm: &VM) -> ValResult {
+    fn to_strval(&self, vm: &VM) -> Result<Val, Box<VMError>> {
         let mut buf = ryu::Buffer::new();
-        ValResult::from_val(String_::new(vm, buf.format(self.val).to_owned()))
+        Ok(String_::new(vm, buf.format(self.val).to_owned()))
     }
 
-    fn add(&self, vm: &VM, other: Val) -> ValResult {
+    fn add(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
         if let Some(rhs) = other.as_isize(vm) {
-            ValResult::from_val(Double::new(vm, self.val + (rhs as f64)))
+            Ok(Double::new(vm, self.val + (rhs as f64)))
         } else if let Some(rhs) = other.try_downcast::<Double>(vm) {
-            ValResult::from_val(Double::new(vm, self.val + rhs.val))
+            Ok(Double::new(vm, self.val + rhs.val))
         } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
             match rhs.bigint().to_f64() {
-                Some(i) => ValResult::from_val(Double::new(vm, self.val + i)),
-                None => ValResult::from_vmerror(VMError::CantRepresentAsDouble),
+                Some(i) => Ok(Double::new(vm, self.val + i)),
+                None => Err(Box::new(VMError::CantRepresentAsDouble)),
             }
         } else {
-            ValResult::from_vmerror(VMError::NotANumber {
+            Err(Box::new(VMError::NotANumber {
                 got: other.dyn_objtype(vm),
-            })
+            }))
         }
     }
 
-    fn sub(&self, vm: &VM, other: Val) -> ValResult {
+    fn sub(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
         if let Some(rhs) = other.as_isize(vm) {
-            ValResult::from_val(Double::new(vm, self.val - (rhs as f64)))
+            Ok(Double::new(vm, self.val - (rhs as f64)))
         } else if let Some(rhs) = other.try_downcast::<Double>(vm) {
-            ValResult::from_val(Double::new(vm, self.val - rhs.val))
+            Ok(Double::new(vm, self.val - rhs.val))
         } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
             match rhs.bigint().to_f64() {
-                Some(i) => ValResult::from_val(Double::new(vm, self.val - i)),
-                None => ValResult::from_vmerror(VMError::CantRepresentAsDouble),
+                Some(i) => Ok(Double::new(vm, self.val - i)),
+                None => Err(Box::new(VMError::CantRepresentAsDouble)),
             }
         } else {
-            ValResult::from_vmerror(VMError::NotANumber {
+            Err(Box::new(VMError::NotANumber {
                 got: other.dyn_objtype(vm),
-            })
+            }))
         }
     }
 
-    fn mul(&self, vm: &VM, other: Val) -> ValResult {
+    fn mul(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
         if let Some(rhs) = other.as_isize(vm) {
-            ValResult::from_val(Double::new(vm, self.val * (rhs as f64)))
+            Ok(Double::new(vm, self.val * (rhs as f64)))
         } else if let Some(rhs) = other.try_downcast::<Double>(vm) {
-            ValResult::from_val(Double::new(vm, self.val * rhs.val))
+            Ok(Double::new(vm, self.val * rhs.val))
         } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
             match rhs.bigint().to_f64() {
-                Some(i) => ValResult::from_val(Double::new(vm, self.val * i)),
-                None => ValResult::from_vmerror(VMError::CantRepresentAsDouble),
+                Some(i) => Ok(Double::new(vm, self.val * i)),
+                None => Err(Box::new(VMError::CantRepresentAsDouble)),
             }
         } else {
-            ValResult::from_vmerror(VMError::NotANumber {
+            Err(Box::new(VMError::NotANumber {
                 got: other.dyn_objtype(vm),
-            })
+            }))
         }
     }
 }

--- a/src/lib/vm/objects/mod.rs
+++ b/src/lib/vm/objects/mod.rs
@@ -49,8 +49,8 @@ use abgc::{self, Gc};
 use natrob::narrowable_abgc;
 
 use crate::vm::{
-    core::VM,
-    val::{Val, ValResult},
+    core::{VMError, VM},
+    val::Val,
 };
 
 /// The SOM type of objects.
@@ -76,62 +76,62 @@ pub trait Obj: std::fmt::Debug + abgc::GcLayout {
     fn get_class(&self, vm: &VM) -> Val;
 
     /// Convert this object to a `Val` that represents a SOM string.
-    fn to_strval(&self, _: &VM) -> ValResult {
+    fn to_strval(&self, _: &VM) -> Result<Val, Box<VMError>> {
         unimplemented!();
     }
 
     /// Produce a new `Val` which adds `other` to this.
-    fn add(&self, _: &VM, _: Val) -> ValResult {
+    fn add(&self, _: &VM, _: Val) -> Result<Val, Box<VMError>> {
         unimplemented!();
     }
 
     /// Produce a new `Val` which subtracts `other` from this.
-    fn sub(&self, _: &VM, _: Val) -> ValResult {
+    fn sub(&self, _: &VM, _: Val) -> Result<Val, Box<VMError>> {
         unimplemented!();
     }
 
     /// Produce a new `Val` which multiplies `other` to this.
-    fn mul(&self, _: &VM, _: Val) -> ValResult {
+    fn mul(&self, _: &VM, _: Val) -> Result<Val, Box<VMError>> {
         unimplemented!();
     }
 
     /// Produce a new `Val` which divides `other` from this.
-    fn div(&self, _: &VM, _: Val) -> ValResult {
+    fn div(&self, _: &VM, _: Val) -> Result<Val, Box<VMError>> {
         unimplemented!();
     }
 
     /// Produce a new `Val` which shifts `self` `other` bits to the left.
-    fn shl(&self, _: &VM, _: Val) -> ValResult {
+    fn shl(&self, _: &VM, _: Val) -> Result<Val, Box<VMError>> {
         unimplemented!();
     }
 
     /// Does this `Val` equal `other`?
-    fn equals(&self, _: &VM, _: Val) -> ValResult {
+    fn equals(&self, _: &VM, _: Val) -> Result<Val, Box<VMError>> {
         unimplemented!();
     }
 
     /// Does this `Val` not equal `other`?
-    fn not_equals(&self, _: &VM, _: Val) -> ValResult {
+    fn not_equals(&self, _: &VM, _: Val) -> Result<Val, Box<VMError>> {
         unimplemented!();
     }
 
     /// Is this `Val` greater than `other`?
-    fn greater_than(&self, _: &VM, _: Val) -> ValResult {
+    fn greater_than(&self, _: &VM, _: Val) -> Result<Val, Box<VMError>> {
         unimplemented!();
     }
 
     /// Is this `Val` greater than or equal to `other`?
-    fn greater_than_equals(&self, _: &VM, _: Val) -> ValResult {
+    fn greater_than_equals(&self, _: &VM, _: Val) -> Result<Val, Box<VMError>> {
         unimplemented!();
     }
 
     /// Is this `Val` less than `other`?
-    fn less_than(&self, _: &VM, _: Val) -> ValResult {
+    fn less_than(&self, _: &VM, _: Val) -> Result<Val, Box<VMError>> {
         unimplemented!();
     }
 
     /// Is this `Val` less than or equal to `other`?
-    fn less_than_equals(&self, _: &VM, _: Val) -> ValResult {
+    fn less_than_equals(&self, _: &VM, _: Val) -> Result<Val, Box<VMError>> {
         unimplemented!();
     }
 }

--- a/src/lib/vm/objects/string_.rs
+++ b/src/lib/vm/objects/string_.rs
@@ -14,9 +14,9 @@ use std::str;
 use abgc_derive::GcLayout;
 
 use crate::vm::{
-    core::VM,
+    core::{VMError, VM},
     objects::{Obj, ObjType, StaticObjType},
-    val::{NotUnboxable, Val, ValResult},
+    val::{NotUnboxable, Val},
 };
 
 #[derive(Debug, GcLayout)]
@@ -52,20 +52,20 @@ impl String_ {
     }
 
     /// Concatenate this string with another string and return the result.
-    pub fn concatenate(&self, vm: &VM, other: Val) -> ValResult {
-        let other_str: &String_ = rtry!(other.downcast(vm));
+    pub fn concatenate(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
+        let other_str: &String_ = other.downcast(vm)?;
 
         // Since strings are immutable, concatenating an empty string means we don't need to
         // make a new string.
         if self.s.is_empty() {
-            return ValResult::from_val(other);
+            return Ok(other);
         } else if other_str.s.is_empty() {
-            return ValResult::from_val(Val::recover(self));
+            return Ok(Val::recover(self));
         }
 
         let mut new = String::with_capacity(self.s.len() + other_str.s.len());
         new.push_str(&self.s);
         new.push_str(&other_str.s);
-        ValResult::from_val(String_::new(vm, new))
+        Ok(String_::new(vm, new))
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,8 @@
 // at your option. This file may not be copied, modified, or distributed except according to those
 // terms.
 
+#![feature(box_patterns)]
+
 use std::{
     env,
     io::{stderr, Write},
@@ -43,14 +45,11 @@ fn main() {
     let vm = VM::new(matches.opt_strs("cp"));
     let cls = vm.compile(&Path::new(&matches.free[0]).canonicalize().unwrap(), true);
     let app = Inst::new(&vm, cls);
-    let vr = vm.send(app, "run", vec![]);
-    if vr.is_err() {
-        match *vr.unwrap_err() {
-            VMError::Exit => (),
-            e => {
-                eprintln!("{:?}", e);
-                process::exit(1);
-            }
+    match vm.send(app, "run", vec![]) {
+        Ok(_) | Err(box VMError::Exit) => (),
+        Err(e) => {
+            eprintln!("{:?}", e);
+            process::exit(1);
         }
     }
 }


### PR DESCRIPTION
This was introduced because I thought we would need a ternary return type to deal with SOM's closure returns. However, the recent reorganisation of the core interpreter loop has removed that need (the ternary aspect now being confined purely to the few functions related to message sends). We now only need a binary return type which means we're better off simply using the normal `Result` type (which has the pleasant bonus of allowing us to use the `?` operator).

This commit thus removes the custom `ValResult` type and replaces it with `Result<Val, Box<VMError>>`. Most of this commit was performed by `srep`, with a small number of fix-ups by hand.

There appears to be a tiny performance benefit from this PR, but it's small enough that it's not really worth worrying about (my guess is that in a couple of places rustc can statically remove `Result` types which it couldn't do with `ValResult`).