### PR TITLE
Statically calculate stack sizes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ regex = "1.1"
 [dependencies]
 abgc = { git="https://github.com/softdevteam/abgc" }
 abgc_derive = { git="https://github.com/softdevteam/abgc" }
+arrayvec = "0.5"
 cfgrammar = "0.4"
 getopts = "0.2"
 indexmap = "1.0"

--- a/src/lib/compiler/ast_to_instrs.rs
+++ b/src/lib/compiler/ast_to_instrs.rs
@@ -8,6 +8,7 @@
 // terms.
 
 use std::{
+    cmp::max,
     collections::hash_map::{self, HashMap},
     path::Path,
 };
@@ -256,33 +257,37 @@ impl<'a> Compiler<'a> {
                 exprs,
             } => {
                 let bytecode_off = self.instrs.len();
-                let num_vars = self.c_block(true, &params, vars_lexemes, exprs)?;
+                let (num_vars, max_stack) = self.c_block(true, &params, vars_lexemes, exprs)?;
                 Ok(cobjects::MethodBody::User {
                     num_vars,
                     bytecode_off,
+                    max_stack,
                 })
             }
         }
     }
 
-    fn c_expr(&mut self, expr: &ast::Expr) -> Result<(), Vec<(Lexeme<StorageT>, String)>> {
+    /// Evaluate an expression, returning `Ok(max_stack_size)` if successful.
+    fn c_expr(&mut self, expr: &ast::Expr) -> Result<usize, Vec<(Lexeme<StorageT>, String)>> {
         match expr {
             ast::Expr::Assign { id, expr } => {
                 let (depth, var_num) = self.find_var(&id)?;
-                self.c_expr(expr)?;
+                let max_stack = self.c_expr(expr)?;
                 if depth == self.vars_stack.len() - 1 {
                     self.instrs.push(Instr::InstVarSet(var_num));
                 } else {
                     self.instrs.push(Instr::VarSet(depth, var_num));
                 }
-                Ok(())
+                debug_assert!(max_stack > 0);
+                Ok(max_stack)
             }
             ast::Expr::BinaryMsg { lhs, op, rhs } => {
-                self.c_expr(lhs)?;
-                self.c_expr(rhs)?;
+                let mut stack_size = self.c_expr(lhs)?;
+                stack_size = max(stack_size, 1 + self.c_expr(rhs)?);
                 let send_off = self.send_off((self.lexer.lexeme_str(&op).to_string(), 1));
                 self.instrs.push(Instr::Send(send_off));
-                Ok(())
+                debug_assert!(stack_size > 0);
+                Ok(stack_size)
             }
             ast::Expr::Block {
                 params,
@@ -296,13 +301,15 @@ impl<'a> Compiler<'a> {
                     bytecode_end: 0,
                     num_params: params.len(),
                     num_vars: 0,
+                    max_stack: 0,
                 });
                 self.closure_depth += 1;
-                let num_vars = self.c_block(false, params, vars, exprs)?;
+                let (num_vars, max_stack) = self.c_block(false, params, vars, exprs)?;
                 self.closure_depth -= 1;
                 self.blocks[block_off].bytecode_end = self.instrs.len();
                 self.blocks[block_off].num_vars = num_vars;
-                Ok(())
+                self.blocks[block_off].max_stack = max_stack;
+                Ok(1)
             }
             ast::Expr::Double { is_negative, val } => {
                 let s = if *is_negative {
@@ -313,7 +320,7 @@ impl<'a> Compiler<'a> {
                 match s.parse::<f64>() {
                     Ok(i) => {
                         self.instrs.push(Instr::Double(i));
-                        Ok(())
+                        Ok(1)
                     }
                     Err(e) => Err(vec![(*val, format!("{}", e))]),
                 }
@@ -327,38 +334,42 @@ impl<'a> Compiler<'a> {
                         }
                         let const_off = self.const_off(cobjects::Const::Int(i));
                         self.instrs.push(Instr::Const(const_off));
-                        Ok(())
+                        Ok(1)
                     }
                     Err(e) => Err(vec![(*val, format!("{}", e))]),
                 }
             }
             ast::Expr::KeywordMsg { receiver, msglist } => {
-                self.c_expr(receiver)?;
+                let mut max_stack = self.c_expr(receiver)?;
                 let mut mn = String::new();
-                for (kw, expr) in msglist {
+                for (i, (kw, expr)) in msglist.into_iter().enumerate() {
                     mn.push_str(self.lexer.lexeme_str(&kw));
-                    self.c_expr(expr)?;
+                    let expr_stack = self.c_expr(expr)?;
+                    max_stack = max(max_stack, 1 + i + expr_stack);
                 }
                 let send_off = self.send_off((mn, msglist.len()));
                 self.instrs.push(Instr::Send(send_off));
-                Ok(())
+                debug_assert!(max_stack > 0);
+                Ok(max_stack)
             }
             ast::Expr::UnaryMsg { receiver, ids } => {
-                self.c_expr(receiver)?;
+                let max_stack = self.c_expr(receiver)?;
                 for id in ids {
                     let send_off = self.send_off((self.lexer.lexeme_str(&id).to_string(), 0));
                     self.instrs.push(Instr::Send(send_off));
                 }
-                Ok(())
+                debug_assert!(max_stack > 0);
+                Ok(max_stack)
             }
             ast::Expr::Return(expr) => {
-                self.c_expr(expr)?;
+                let max_stack = self.c_expr(expr)?;
                 if self.closure_depth == 0 {
                     self.instrs.push(Instr::Return);
                 } else {
                     self.instrs.push(Instr::ClosureReturn(self.closure_depth));
                 }
-                Ok(())
+                debug_assert!(max_stack > 0);
+                Ok(max_stack)
             }
             ast::Expr::String(lexeme) => {
                 // XXX are there string escaping rules we need to take account of?
@@ -367,7 +378,7 @@ impl<'a> Compiler<'a> {
                 let s = s_orig[1..s_orig.len() - 1].to_owned();
                 let const_off = self.const_off(cobjects::Const::String(s));
                 self.instrs.push(Instr::Const(const_off));
-                Ok(())
+                Ok(1)
             }
             ast::Expr::VarLookup(lexeme) => {
                 match self.find_var(&lexeme) {
@@ -386,18 +397,22 @@ impl<'a> Compiler<'a> {
                         _ => return Err(e),
                     },
                 }
-                Ok(())
+                Ok(1)
             }
         }
     }
 
+    /// Evaluate an expression, returning `Ok(max_stack_size)` if successful. Note that there is an
+    /// implicit assumption that primitives never need more stack size than they take in (e.g. if
+    /// they push an item on to the stack, they must have popped at least one element off it
+    /// beforehand).
     fn c_block(
         &mut self,
         is_method: bool,
         params: &[Lexeme<StorageT>],
         vars_lexemes: &[Lexeme<StorageT>],
         exprs: &[ast::Expr],
-    ) -> Result<usize, Vec<(Lexeme<StorageT>, String)>> {
+    ) -> Result<(usize, usize), Vec<(Lexeme<StorageT>, String)>> {
         let mut vars = HashMap::new();
         if is_method {
             // The VM assumes that the first variable of a method is "self".
@@ -431,10 +446,12 @@ impl<'a> Compiler<'a> {
 
         let num_vars = vars.len();
         self.vars_stack.push(vars);
+        let mut max_stack = 0;
         for (i, e) in exprs.iter().enumerate() {
             // We deliberately bomb out at the first error in a method on the basis that
             // it's likely to lead to many repetitive errors.
-            self.c_expr(e)?;
+            let stack_size = self.c_expr(e)?;
+            max_stack = max(max_stack, stack_size);
             if i != exprs.len() - 1 {
                 self.instrs.push(Instr::Pop);
             }
@@ -444,11 +461,12 @@ impl<'a> Compiler<'a> {
             self.instrs.push(Instr::Pop);
             debug_assert_eq!(*self.vars_stack.last().unwrap().get("self").unwrap(), 0);
             self.instrs.push(Instr::VarLookup(0, 0));
+            max_stack = max(max_stack, 1);
         }
         self.instrs.push(Instr::Return);
         self.vars_stack.pop();
 
-        Ok(num_vars)
+        Ok((num_vars, max_stack))
     }
 
     /// Find the variable `name` in the variable stack returning a tuple `Some((depth, var_num))`

--- a/src/lib/compiler/cobjects.rs
+++ b/src/lib/compiler/cobjects.rs
@@ -43,6 +43,7 @@ pub enum MethodBody {
         num_vars: usize,
         /// The offset of this method's bytecode in its parent class.
         bytecode_off: usize,
+        max_stack: usize,
     },
 }
 
@@ -51,4 +52,5 @@ pub struct Block {
     pub bytecode_end: usize,
     pub num_params: usize,
     pub num_vars: usize,
+    pub max_stack: usize,
 }

--- a/src/lib/vm/core.rs
+++ b/src/lib/vm/core.rs
@@ -328,7 +328,7 @@ impl VM {
                     let cls = rcv.get_class(self);
                     let (meth_cls_val, meth) =
                         stry!(stry!(cls.downcast::<Class>(self)).get_method(self, &name));
-                    self.current_frame().set_sp(self.stack_len());
+                    self.current_frame().set_sp(self.stack_len() - *nargs);
                     let r = match meth.body {
                         MethodBody::Primitive(Primitive::Restart) => {
                             self.stack_truncate(stack_start);
@@ -541,6 +541,7 @@ impl VM {
     }
 
     fn stack_truncate(&self, i: usize) {
+        debug_assert!(i <= unsafe { &mut *self.stack.get() }.len());
         unsafe { &mut *self.stack.get() }.truncate(i);
     }
 }

--- a/src/lib/vm/core.rs
+++ b/src/lib/vm/core.rs
@@ -232,7 +232,6 @@ impl VM {
                 bytecode_off,
             } => {
                 let meth_cls = meth_cls_val.downcast::<Class>(self)?;
-                self.stack_push(rcv.clone());
                 let nargs = args.len();
                 for a in args {
                     self.stack_push(a);

--- a/src/lib/vm/objects/class.rs
+++ b/src/lib/vm/objects/class.rs
@@ -42,6 +42,7 @@ pub struct BlockInfo {
     pub bytecode_end: usize,
     pub num_params: usize,
     pub num_vars: usize,
+    pub max_stack: usize,
 }
 
 impl Obj for Class {
@@ -84,9 +85,11 @@ impl Class {
                 cobjects::MethodBody::User {
                     num_vars,
                     bytecode_off,
+                    max_stack,
                 } => MethodBody::User {
                     num_vars,
                     bytecode_off,
+                    max_stack,
                 },
             };
             let meth = Method {
@@ -104,6 +107,7 @@ impl Class {
                 bytecode_end: b.bytecode_end,
                 num_params: b.num_params,
                 num_vars: b.num_vars,
+                max_stack: b.max_stack,
             })
             .collect();
 

--- a/src/lib/vm/objects/method.rs
+++ b/src/lib/vm/objects/method.rs
@@ -36,6 +36,7 @@ pub enum MethodBody {
         num_vars: usize,
         /// The offset of this method's bytecode in its parent class.
         bytecode_off: usize,
+        max_stack: usize,
     },
 }
 


### PR DESCRIPTION
This PR is mostly about precalculating the maximum stack size a block can possibly use at run-time so that we can remove some dynamic checks. This allows to use a fixed-size SOM stack, which means that we can avoid checking whether resizing (etc.) is necessary
(i.e. we can push elements onto the stack without any branching). This gives us roughly a 2.5% gain on our little while benchmark.

The main bulk of this PR is in https://github.com/softdevteam/yksom/commit/7d4ab33a6b5da7012d88788c9d9224398392f14c; the other commits are relatively minor.
