### PR TITLE
Reading from an unassigned SOM variable should return 'nil'.

### DIFF
--- a/lang_tests/unassigned_var.som
+++ b/lang_tests/unassigned_var.som
@@ -1,10 +1,9 @@
 "
 VM:
-  status: error
-  stderr: UnassignedVar(1)
+  stdout: nil
 "
 
-Unassigned_Var = (
+unassigned_var = (
     run = (
         |v|
         v println.


### PR DESCRIPTION
Previously we threw an error in such cases. While, arguably, that might be better language design, it doesn't match SOM's semantics. So this commit fixes that.

The implementation is not particularly efficient in a reference counted GC (we increment nil's reference count only to decrement it on the first assignment to a var), but it's probably not worth optimising this at this stage.