### PR TITLE
Simplify bytecode

### DIFF
--- a/src/lib/compiler/ast_to_instrs.rs
+++ b/src/lib/compiler/ast_to_instrs.rs
@@ -400,8 +400,7 @@ impl<'a> Compiler<'a> {
                             // With twos complement, `0-i` will always succeed, but just in case...
                             i = 0isize.checked_sub(i).unwrap();
                         }
-                        let const_off = self.const_off(cobjects::Const::Int(i));
-                        self.instrs.push(Instr::Const(const_off));
+                        self.instrs.push(Instr::Int(i));
                         Ok(1)
                     }
                     Err(e) => Err(vec![(*val, format!("{}", e))]),

--- a/src/lib/compiler/cobjects.rs
+++ b/src/lib/compiler/cobjects.rs
@@ -11,11 +11,6 @@ use std::path::PathBuf;
 
 use crate::compiler::instrs::{Instr, Primitive};
 
-#[derive(Eq, Hash, PartialEq)]
-pub enum Const {
-    String(String),
-}
-
 pub struct Class {
     pub name: String,
     pub path: PathBuf,
@@ -24,8 +19,8 @@ pub struct Class {
     pub methods: Vec<Method>,
     pub blocks: Vec<Block>,
     pub instrs: Vec<Instr>,
-    pub consts: Vec<Const>,
     pub sends: Vec<(String, usize)>,
+    pub strings: Vec<String>,
 }
 
 pub struct Method {

--- a/src/lib/compiler/cobjects.rs
+++ b/src/lib/compiler/cobjects.rs
@@ -13,7 +13,6 @@ use crate::compiler::instrs::{Instr, Primitive};
 
 #[derive(Eq, Hash, PartialEq)]
 pub enum Const {
-    Int(isize),
     String(String),
 }
 

--- a/src/lib/compiler/instrs.rs
+++ b/src/lib/compiler/instrs.rs
@@ -12,7 +12,6 @@ pub enum Instr {
     Block(usize),
     Builtin(Builtin),
     ClosureReturn(usize),
-    Const(usize),
     Double(f64),
     InstVarLookup(usize),
     InstVarSet(usize),
@@ -20,6 +19,7 @@ pub enum Instr {
     Pop,
     Return,
     Send(usize),
+    String(usize),
     VarLookup(usize, usize),
     VarSet(usize, usize),
 }

--- a/src/lib/compiler/instrs.rs
+++ b/src/lib/compiler/instrs.rs
@@ -16,6 +16,7 @@ pub enum Instr {
     Double(f64),
     InstVarLookup(usize),
     InstVarSet(usize),
+    Int(isize),
     Pop,
     Return,
     Send(usize),

--- a/src/lib/vm/core.rs
+++ b/src/lib/vm/core.rs
@@ -321,6 +321,10 @@ impl VM {
                     inst.inst_var_set(n, self.stack_peek());
                     pc += 1;
                 }
+                Instr::Int(i) => {
+                    self.stack_push(stry!(Val::from_isize(self, i)));
+                    pc += 1;
+                }
                 Instr::Pop => {
                     self.stack_pop();
                     pc += 1;

--- a/src/lib/vm/core.rs
+++ b/src/lib/vm/core.rs
@@ -303,10 +303,6 @@ impl VM {
                     }
                     panic!("Return from escaped block");
                 }
-                Instr::Const(coff) => {
-                    self.stack_push(cls.consts[coff].clone());
-                    pc += 1;
-                }
                 Instr::Double(i) => {
                     self.stack_push(Double::new(self, i));
                     pc += 1;
@@ -375,6 +371,10 @@ impl VM {
                         }
                         SendReturn::Val => (),
                     }
+                    pc += 1;
+                }
+                Instr::String(string_off) => {
+                    self.stack_push(cls.strings[string_off].clone());
                     pc += 1;
                 }
                 Instr::VarLookup(d, n) => {

--- a/src/lib/vm/objects/class.rs
+++ b/src/lib/vm/objects/class.rs
@@ -115,7 +115,6 @@ impl Class {
         for c in ccls.consts {
             consts.push(match c {
                 cobjects::Const::String(s) => String_::new(vm, s),
-                cobjects::Const::Int(i) => Val::from_isize(vm, i)?,
             });
         }
         Ok(Val::from_obj(

--- a/src/lib/vm/objects/class.rs
+++ b/src/lib/vm/objects/class.rs
@@ -31,8 +31,8 @@ pub struct Class {
     pub methods: HashMap<String, Method>,
     pub blockinfos: Vec<BlockInfo>,
     pub instrs: Vec<Instr>,
-    pub consts: Vec<Val>,
     pub sends: Vec<(String, usize)>,
+    pub strings: Vec<Val>,
 }
 
 /// Minimal information about a SOM block.
@@ -111,12 +111,11 @@ impl Class {
             })
             .collect();
 
-        let mut consts = Vec::with_capacity(ccls.consts.len());
-        for c in ccls.consts {
-            consts.push(match c {
-                cobjects::Const::String(s) => String_::new(vm, s),
-            });
-        }
+        let strings = ccls
+            .strings
+            .into_iter()
+            .map(|s| String_::new(vm, s))
+            .collect();
         Ok(Val::from_obj(
             vm,
             Class {
@@ -127,8 +126,8 @@ impl Class {
                 methods,
                 blockinfos,
                 instrs: ccls.instrs,
-                consts,
                 sends: ccls.sends,
+                strings,
             },
         ))
     }


### PR DESCRIPTION
This PR slightly simplifies yksom's bytecode (well, not that it's "byte"code, but you get the idea) by getting rid of the idea of a constant pool of integers and strings. This seemed like a good idea when I didn't understand SOM, but it's now clearly overkill: the idea of pooled integers, in particular, makes very little sense in the presence of tagged integers. Once integers are removed, then the only thing left is strings, at which point we don't have a constant pool but a string pool. The two commits make these two changes in order.