### PR TITLE
Add an inline cache

### DIFF
--- a/lib/SOM/String.som
+++ b/lib/SOM/String.som
@@ -1,5 +1,6 @@
 String = (
     concatenate: argument = primitive
+    + argument = ( ^self concatenate: argument asString )
     asString = (^self)
     print = ( system printString: self )
 )

--- a/src/lib/compiler/ast_to_instrs.rs
+++ b/src/lib/compiler/ast_to_instrs.rs
@@ -354,7 +354,8 @@ impl<'a> Compiler<'a> {
                 let mut stack_size = self.c_expr(lhs)?;
                 stack_size = max(stack_size, 1 + self.c_expr(rhs)?);
                 let send_off = self.send_off((self.lexer.lexeme_str(&op).to_string(), 1));
-                self.instrs.push(Instr::Send(send_off, UnsafeCell::new(None)));
+                self.instrs
+                    .push(Instr::Send(send_off, UnsafeCell::new(None)));
                 debug_assert!(stack_size > 0);
                 Ok(stack_size)
             }
@@ -416,7 +417,8 @@ impl<'a> Compiler<'a> {
                     max_stack = max(max_stack, 1 + i + expr_stack);
                 }
                 let send_off = self.send_off((mn, msglist.len()));
-                self.instrs.push(Instr::Send(send_off, UnsafeCell::new(None)));
+                self.instrs
+                    .push(Instr::Send(send_off, UnsafeCell::new(None)));
                 debug_assert!(max_stack > 0);
                 Ok(max_stack)
             }
@@ -424,7 +426,8 @@ impl<'a> Compiler<'a> {
                 let max_stack = self.c_expr(receiver)?;
                 for id in ids {
                     let send_off = self.send_off((self.lexer.lexeme_str(&id).to_string(), 0));
-                    self.instrs.push(Instr::Send(send_off, UnsafeCell::new(None)));
+                    self.instrs
+                        .push(Instr::Send(send_off, UnsafeCell::new(None)));
                 }
                 debug_assert!(max_stack > 0);
                 Ok(max_stack)

--- a/src/lib/compiler/ast_to_instrs.rs
+++ b/src/lib/compiler/ast_to_instrs.rs
@@ -8,6 +8,7 @@
 // terms.
 
 use std::{
+    cell::UnsafeCell,
     cmp::max,
     collections::hash_map::{self, HashMap},
     path::Path,
@@ -353,7 +354,7 @@ impl<'a> Compiler<'a> {
                 let mut stack_size = self.c_expr(lhs)?;
                 stack_size = max(stack_size, 1 + self.c_expr(rhs)?);
                 let send_off = self.send_off((self.lexer.lexeme_str(&op).to_string(), 1));
-                self.instrs.push(Instr::Send(send_off));
+                self.instrs.push(Instr::Send(send_off, UnsafeCell::new(None)));
                 debug_assert!(stack_size > 0);
                 Ok(stack_size)
             }
@@ -415,7 +416,7 @@ impl<'a> Compiler<'a> {
                     max_stack = max(max_stack, 1 + i + expr_stack);
                 }
                 let send_off = self.send_off((mn, msglist.len()));
-                self.instrs.push(Instr::Send(send_off));
+                self.instrs.push(Instr::Send(send_off, UnsafeCell::new(None)));
                 debug_assert!(max_stack > 0);
                 Ok(max_stack)
             }
@@ -423,7 +424,7 @@ impl<'a> Compiler<'a> {
                 let max_stack = self.c_expr(receiver)?;
                 for id in ids {
                     let send_off = self.send_off((self.lexer.lexeme_str(&id).to_string(), 0));
-                    self.instrs.push(Instr::Send(send_off));
+                    self.instrs.push(Instr::Send(send_off, UnsafeCell::new(None)));
                 }
                 debug_assert!(max_stack > 0);
                 Ok(max_stack)

--- a/src/lib/compiler/instrs.rs
+++ b/src/lib/compiler/instrs.rs
@@ -11,10 +11,7 @@ use std::cell::UnsafeCell;
 
 use abgc::Gc;
 
-use crate::vm::{
-    objects::Method,
-    val::Val
-};
+use crate::vm::{objects::Method, val::Val};
 
 #[derive(Debug)]
 pub enum Instr {

--- a/src/lib/compiler/instrs.rs
+++ b/src/lib/compiler/instrs.rs
@@ -7,7 +7,16 @@
 // at your option. This file may not be copied, modified, or distributed except according to those
 // terms.
 
-#[derive(Clone, Copy, Debug)]
+use std::cell::UnsafeCell;
+
+use abgc::Gc;
+
+use crate::vm::{
+    objects::Method,
+    val::Val
+};
+
+#[derive(Debug)]
 pub enum Instr {
     Block(usize),
     Builtin(Builtin),
@@ -18,7 +27,7 @@ pub enum Instr {
     Int(isize),
     Pop,
     Return,
-    Send(usize),
+    Send(usize, UnsafeCell<Option<(Val, (Val, Gc<Method>))>>),
     String(usize),
     VarLookup(usize, usize),
     VarSet(usize, usize),

--- a/src/lib/vm/val.rs
+++ b/src/lib/vm/val.rs
@@ -242,6 +242,13 @@ impl Val {
             }
         }
     }
+
+    /// Is this `Val` bit equal to `other`? This is a very strong property, generally used as a
+    /// fast proxy for "if both `Val`s are `GCBox`s then do they point to the same thing?" since,
+    /// in such cases, at least one of the sides has been pre-guaranteed to be a `GCBox`.
+    pub fn bit_eq(&self, other: &Val) -> bool {
+        self.val == other.val
+    }
 }
 
 // Implement each function from the `Obj` type so that we can efficiently deal with tagged values.


### PR DESCRIPTION
This PR adds simple support for inline caches during method lookup. The main commit is https://github.com/softdevteam/yksom/commit/0950f3de11a4f8dd75476e166df84a1a1e46cece and it's probably worth starting with that commit's message and then going backwards to the two preceding commits (which are really just warm-ups for that main commit). This is an important optimisation: on our simple while loop, it improves performance by over 20%.