### PR TITLE
Various suggestions from Clippy.

### DIFF
--- a/src/lib/compiler/ast_to_instrs.rs
+++ b/src/lib/compiler/ast_to_instrs.rs
@@ -428,7 +428,7 @@ impl<'a> Compiler<'a> {
             ast::Expr::KeywordMsg { receiver, msglist } => {
                 let mut max_stack = self.c_expr(receiver)?;
                 let mut mn = String::new();
-                for (i, (kw, expr)) in msglist.into_iter().enumerate() {
+                for (i, (kw, expr)) in msglist.iter().enumerate() {
                     mn.push_str(self.lexer.lexeme_str(&kw));
                     let expr_stack = self.c_expr(expr)?;
                     max_stack = max(max_stack, 1 + i + expr_stack);

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -23,6 +23,8 @@
 #![feature(specialization)]
 #![feature(unsize)]
 #![allow(clippy::cognitive_complexity)]
+#![allow(clippy::float_cmp)]
+#![allow(clippy::never_loop)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::type_complexity)]
 


### PR DESCRIPTION
Note that Clippy has a pronounced dislike of comparing floats: in our case, such comparisons are entirely sensible. Turning this warning off is the only way to maintain our sanity.