### PR TITLE
Sqrt should return an Int where possible.

### DIFF
--- a/src/lib/vm/objects/integers.rs
+++ b/src/lib/vm/objects/integers.rs
@@ -159,7 +159,12 @@ impl Obj for ArbInt {
         if self.val < Zero::zero() {
             Err(Box::new(VMError::DomainError))
         } else {
-            ArbInt::new(vm, self.val.sqrt())
+            let result = self.val.sqrt();
+            if let Some(i) = result.to_isize() {
+                Val::from_isize(vm, i)
+            } else {
+                ArbInt::new(vm, result)
+            }
         }
     }
 


### PR DESCRIPTION
Sqrt should return an Int if the sqrt of a BigInt can be represented as an isize.