### PR TITLE
Reorder functions in structs

### DIFF
--- a/src/lib/vm/core.rs
+++ b/src/lib/vm/core.rs
@@ -424,7 +424,7 @@ impl VM {
                 SendReturn::Val
             }
             Primitive::BitXor => {
-                self.stack_push(stry!(rcv.bit_xor(self, self.stack_pop())));
+                self.stack_push(stry!(rcv.xor(self, self.stack_pop())));
                 SendReturn::Val
             }
             Primitive::Class => {

--- a/src/lib/vm/objects/double.rs
+++ b/src/lib/vm/objects/double.rs
@@ -57,23 +57,6 @@ impl Obj for Double {
         }
     }
 
-    fn sub(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
-        if let Some(rhs) = other.as_isize(vm) {
-            Ok(Double::new(vm, self.val - (rhs as f64)))
-        } else if let Some(rhs) = other.try_downcast::<Double>(vm) {
-            Ok(Double::new(vm, self.val - rhs.val))
-        } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
-            match rhs.bigint().to_f64() {
-                Some(i) => Ok(Double::new(vm, self.val - i)),
-                None => Err(Box::new(VMError::CantRepresentAsDouble)),
-            }
-        } else {
-            Err(Box::new(VMError::NotANumber {
-                got: other.dyn_objtype(vm),
-            }))
-        }
-    }
-
     fn mul(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
         if let Some(rhs) = other.as_isize(vm) {
             Ok(Double::new(vm, self.val * (rhs as f64)))
@@ -93,6 +76,23 @@ impl Obj for Double {
 
     fn sqrt(&self, vm: &VM) -> Result<Val, Box<VMError>> {
         Ok(Double::new(vm, self.val.sqrt()))
+    }
+
+    fn sub(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
+        if let Some(rhs) = other.as_isize(vm) {
+            Ok(Double::new(vm, self.val - (rhs as f64)))
+        } else if let Some(rhs) = other.try_downcast::<Double>(vm) {
+            Ok(Double::new(vm, self.val - rhs.val))
+        } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
+            match rhs.bigint().to_f64() {
+                Some(i) => Ok(Double::new(vm, self.val - i)),
+                None => Err(Box::new(VMError::CantRepresentAsDouble)),
+            }
+        } else {
+            Err(Box::new(VMError::NotANumber {
+                got: other.dyn_objtype(vm),
+            }))
+        }
     }
 
     fn ref_equals(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {

--- a/src/lib/vm/objects/integers.rs
+++ b/src/lib/vm/objects/integers.rs
@@ -83,53 +83,6 @@ impl Obj for ArbInt {
         }
     }
 
-    fn xor(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
-        if let Some(rhs) = other.as_isize(vm) {
-            ArbInt::new(vm, &self.val ^ BigInt::from_isize(rhs).unwrap())
-        } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
-            ArbInt::new(vm, &self.val ^ &rhs.val)
-        } else {
-            Err(Box::new(VMError::TypeError {
-                expected: self.dyn_objtype(),
-                got: other.dyn_objtype(vm),
-            }))
-        }
-    }
-
-    fn sub(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
-        if let Some(rhs) = other.as_isize(vm) {
-            ArbInt::new(vm, &self.val - rhs)
-        } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
-            ArbInt::new(vm, &self.val - &rhs.val)
-        } else if let Some(rhs) = other.try_downcast::<Double>(vm) {
-            match self.val.to_f64() {
-                Some(i) => Ok(Double::new(vm, i - rhs.double())),
-                None => Err(Box::new(VMError::CantRepresentAsDouble)),
-            }
-        } else {
-            Err(Box::new(VMError::NotANumber {
-                got: other.dyn_objtype(vm),
-            }))
-        }
-    }
-
-    fn mul(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
-        if let Some(rhs) = other.as_isize(vm) {
-            ArbInt::new(vm, &self.val * rhs)
-        } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
-            ArbInt::new(vm, &self.val * &rhs.val)
-        } else if let Some(rhs) = other.try_downcast::<Double>(vm) {
-            match self.val.to_f64() {
-                Some(i) => Ok(Double::new(vm, i * rhs.double())),
-                None => Err(Box::new(VMError::CantRepresentAsDouble)),
-            }
-        } else {
-            Err(Box::new(VMError::NotANumber {
-                got: other.dyn_objtype(vm),
-            }))
-        }
-    }
-
     fn div(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
         if let Some(rhs) = other.as_isize(vm) {
             if rhs == 0 {
@@ -150,6 +103,23 @@ impl Obj for ArbInt {
                     Some(i) => ArbInt::new(vm, BigInt::from_f64(i / rhs.double()).unwrap()),
                     None => Err(Box::new(VMError::CantRepresentAsDouble)),
                 }
+            }
+        } else {
+            Err(Box::new(VMError::NotANumber {
+                got: other.dyn_objtype(vm),
+            }))
+        }
+    }
+
+    fn mul(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
+        if let Some(rhs) = other.as_isize(vm) {
+            ArbInt::new(vm, &self.val * rhs)
+        } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
+            ArbInt::new(vm, &self.val * &rhs.val)
+        } else if let Some(rhs) = other.try_downcast::<Double>(vm) {
+            match self.val.to_f64() {
+                Some(i) => Ok(Double::new(vm, i * rhs.double())),
+                None => Err(Box::new(VMError::CantRepresentAsDouble)),
             }
         } else {
             Err(Box::new(VMError::NotANumber {
@@ -185,6 +155,36 @@ impl Obj for ArbInt {
             } else {
                 ArbInt::new(vm, result)
             }
+        }
+    }
+
+    fn sub(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
+        if let Some(rhs) = other.as_isize(vm) {
+            ArbInt::new(vm, &self.val - rhs)
+        } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
+            ArbInt::new(vm, &self.val - &rhs.val)
+        } else if let Some(rhs) = other.try_downcast::<Double>(vm) {
+            match self.val.to_f64() {
+                Some(i) => Ok(Double::new(vm, i - rhs.double())),
+                None => Err(Box::new(VMError::CantRepresentAsDouble)),
+            }
+        } else {
+            Err(Box::new(VMError::NotANumber {
+                got: other.dyn_objtype(vm),
+            }))
+        }
+    }
+
+    fn xor(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
+        if let Some(rhs) = other.as_isize(vm) {
+            ArbInt::new(vm, &self.val ^ BigInt::from_isize(rhs).unwrap())
+        } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
+            ArbInt::new(vm, &self.val ^ &rhs.val)
+        } else {
+            Err(Box::new(VMError::TypeError {
+                expected: self.dyn_objtype(),
+                got: other.dyn_objtype(vm),
+            }))
         }
     }
 
@@ -341,18 +341,29 @@ impl Obj for Int {
         }
     }
 
-    fn sub(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn div(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
         if let Some(rhs) = other.as_isize(vm) {
-            match self.val.checked_sub(rhs) {
-                Some(i) => Val::from_isize(vm, i),
-                None => ArbInt::new(vm, BigInt::from_isize(self.val).unwrap() - rhs),
+            if rhs == 0 {
+                Err(Box::new(VMError::DivisionByZero))
+            } else {
+                Val::from_isize(vm, self.val / rhs)
             }
         } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
-            ArbInt::new(vm, &self.val - &rhs.val)
+            match BigInt::from_isize(self.val).unwrap().checked_div(&rhs.val) {
+                Some(i) => ArbInt::new(vm, i),
+                None => Err(Box::new(VMError::DivisionByZero)),
+            }
         } else if let Some(rhs) = other.try_downcast::<Double>(vm) {
-            match self.val.to_f64() {
-                Some(i) => Ok(Double::new(vm, i - rhs.double())),
-                None => Err(Box::new(VMError::CantRepresentAsDouble)),
+            if rhs.double() == 0f64 {
+                Err(Box::new(VMError::DivisionByZero))
+            } else {
+                // Note that converting an f64 to an isize in Rust can lead to undefined behaviour
+                // https://github.com/rust-lang/rust/issues/10184 -- it's not obvious that we can
+                // do anything about this other than wait for it to be fixed in LLVM and Rust.
+                match self.val.to_f64() {
+                    Some(i) => Val::from_isize(vm, (i / rhs.double()) as isize),
+                    None => Err(Box::new(VMError::CantRepresentAsDouble)),
+                }
             }
         } else {
             Err(Box::new(VMError::NotANumber {
@@ -381,29 +392,18 @@ impl Obj for Int {
         }
     }
 
-    fn div(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn sub(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
         if let Some(rhs) = other.as_isize(vm) {
-            if rhs == 0 {
-                Err(Box::new(VMError::DivisionByZero))
-            } else {
-                Val::from_isize(vm, self.val / rhs)
+            match self.val.checked_sub(rhs) {
+                Some(i) => Val::from_isize(vm, i),
+                None => ArbInt::new(vm, BigInt::from_isize(self.val).unwrap() - rhs),
             }
         } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
-            match BigInt::from_isize(self.val).unwrap().checked_div(&rhs.val) {
-                Some(i) => ArbInt::new(vm, i),
-                None => Err(Box::new(VMError::DivisionByZero)),
-            }
+            ArbInt::new(vm, &self.val - &rhs.val)
         } else if let Some(rhs) = other.try_downcast::<Double>(vm) {
-            if rhs.double() == 0f64 {
-                Err(Box::new(VMError::DivisionByZero))
-            } else {
-                // Note that converting an f64 to an isize in Rust can lead to undefined behaviour
-                // https://github.com/rust-lang/rust/issues/10184 -- it's not obvious that we can
-                // do anything about this other than wait for it to be fixed in LLVM and Rust.
-                match self.val.to_f64() {
-                    Some(i) => Val::from_isize(vm, (i / rhs.double()) as isize),
-                    None => Err(Box::new(VMError::CantRepresentAsDouble)),
-                }
+            match self.val.to_f64() {
+                Some(i) => Ok(Double::new(vm, i - rhs.double())),
+                None => Err(Box::new(VMError::CantRepresentAsDouble)),
             }
         } else {
             Err(Box::new(VMError::NotANumber {

--- a/src/lib/vm/objects/integers.rs
+++ b/src/lib/vm/objects/integers.rs
@@ -83,7 +83,7 @@ impl Obj for ArbInt {
         }
     }
 
-    fn bit_xor(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn xor(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
         if let Some(rhs) = other.as_isize(vm) {
             ArbInt::new(vm, &self.val ^ BigInt::from_isize(rhs).unwrap())
         } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {

--- a/src/lib/vm/objects/mod.rs
+++ b/src/lib/vm/objects/mod.rs
@@ -81,7 +81,7 @@ pub trait Obj: std::fmt::Debug + abgc::GcLayout {
     }
 
     /// Produce a new `Val` which performs a bitwise xor with `other` and this
-    fn bit_xor(&self, _: &VM, _: Val) -> Result<Val, Box<VMError>> {
+    fn xor(&self, _: &VM, _: Val) -> Result<Val, Box<VMError>> {
         unimplemented!();
     }
 
@@ -95,18 +95,13 @@ pub trait Obj: std::fmt::Debug + abgc::GcLayout {
         unimplemented!();
     }
 
-    /// Produce a new `Val` which subtracts `other` from this.
-    fn sub(&self, _: &VM, _: Val) -> Result<Val, Box<VMError>> {
+    /// Produce a new `Val` which divides `other` from this.
+    fn div(&self, _: &VM, _: Val) -> Result<Val, Box<VMError>> {
         unimplemented!();
     }
 
     /// Produce a new `Val` which multiplies `other` to this.
     fn mul(&self, _: &VM, _: Val) -> Result<Val, Box<VMError>> {
-        unimplemented!();
-    }
-
-    /// Produce a new `Val` which divides `other` from this.
-    fn div(&self, _: &VM, _: Val) -> Result<Val, Box<VMError>> {
         unimplemented!();
     }
 
@@ -117,6 +112,11 @@ pub trait Obj: std::fmt::Debug + abgc::GcLayout {
 
     /// Produces a new `Val` which is the square root of this.
     fn sqrt(&self, _: &VM) -> Result<Val, Box<VMError>> {
+        unimplemented!();
+    }
+
+    /// Produce a new `Val` which subtracts `other` from this.
+    fn sub(&self, _: &VM, _: Val) -> Result<Val, Box<VMError>> {
         unimplemented!();
     }
 

--- a/src/lib/vm/objects/mod.rs
+++ b/src/lib/vm/objects/mod.rs
@@ -80,11 +80,6 @@ pub trait Obj: std::fmt::Debug + abgc::GcLayout {
         unimplemented!();
     }
 
-    /// Produce a new `Val` which performs a bitwise xor with `other` and this
-    fn xor(&self, _: &VM, _: Val) -> Result<Val, Box<VMError>> {
-        unimplemented!();
-    }
-
     /// Produce a new `Val` which adds `other` to this.
     fn add(&self, _: &VM, _: Val) -> Result<Val, Box<VMError>> {
         unimplemented!();
@@ -117,6 +112,11 @@ pub trait Obj: std::fmt::Debug + abgc::GcLayout {
 
     /// Produce a new `Val` which subtracts `other` from this.
     fn sub(&self, _: &VM, _: Val) -> Result<Val, Box<VMError>> {
+        unimplemented!();
+    }
+
+    /// Produce a new `Val` which performs a bitwise xor with `other` and this
+    fn xor(&self, _: &VM, _: Val) -> Result<Val, Box<VMError>> {
         unimplemented!();
     }
 

--- a/src/lib/vm/val.rs
+++ b/src/lib/vm/val.rs
@@ -308,7 +308,7 @@ impl Val {
     }
 
     /// Produce a new `Val` which performs a bitwise xor operation with `other` and this.
-    pub fn bit_xor(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
+    pub fn xor(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
         if let Some(lhs) = self.as_isize(vm) {
             if let Some(rhs) = other.as_isize(vm) {
                 return Val::from_isize(vm, lhs ^ rhs);
@@ -320,7 +320,7 @@ impl Val {
                 got: other.dyn_objtype(vm),
             }));
         }
-        self.tobj(vm).unwrap().bit_xor(vm, other)
+        self.tobj(vm).unwrap().xor(vm, other)
     }
 
     /// Produce a new `Val` which subtracts `other` from this.

--- a/src/lib/vm/val.rs
+++ b/src/lib/vm/val.rs
@@ -280,6 +280,14 @@ impl Val {
         }
     }
 
+    pub fn to_strval(&self, vm: &VM) -> Result<Val, Box<VMError>> {
+        debug_assert!(!self.is_illegal());
+        match self.valkind() {
+            ValKind::INT => Ok(String_::new(vm, self.as_isize(vm).unwrap().to_string())),
+            ValKind::GCBOX => self.tobj(vm).unwrap().to_strval(vm),
+        }
+    }
+
     /// Produce a new `Val` which adds `other` to this.
     pub fn add(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
         debug_assert_eq!(ValKind::INT as usize, 0);
@@ -307,44 +315,6 @@ impl Val {
         self.tobj(vm).unwrap().and(vm, other)
     }
 
-    /// Produce a new `Val` which performs a bitwise xor operation with `other` and this.
-    pub fn xor(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
-        if let Some(lhs) = self.as_isize(vm) {
-            if let Some(rhs) = other.as_isize(vm) {
-                return Val::from_isize(vm, lhs ^ rhs);
-            } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
-                return ArbInt::new(vm, BigInt::from_isize(lhs).unwrap() ^ rhs.bigint());
-            }
-            return Err(Box::new(VMError::TypeError {
-                expected: self.dyn_objtype(vm),
-                got: other.dyn_objtype(vm),
-            }));
-        }
-        self.tobj(vm).unwrap().xor(vm, other)
-    }
-
-    /// Produce a new `Val` which subtracts `other` from this.
-    pub fn sub(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
-        debug_assert_eq!(ValKind::INT as usize, 0);
-        if self.valkind() == ValKind::INT && other.valkind() == ValKind::INT {
-            if let Some(val) = self.val.checked_sub(other.val) {
-                return Ok(Val { val });
-            }
-        }
-        self.tobj(vm).unwrap().sub(vm, other)
-    }
-
-    /// Produce a new `Val` which multiplies `other` to this.
-    pub fn mul(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
-        debug_assert_eq!(ValKind::INT as usize, 0);
-        if self.valkind() == ValKind::INT && other.valkind() == ValKind::INT {
-            if let Some(val) = self.val.checked_mul(other.val / (1 << TAG_BITSIZE)) {
-                return Ok(Val { val });
-            }
-        }
-        self.tobj(vm).unwrap().mul(vm, other)
-    }
-
     /// Produce a new `Val` which divides `other` from this.
     pub fn div(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
         debug_assert_eq!(ValKind::INT as usize, 0);
@@ -358,6 +328,17 @@ impl Val {
             }
         }
         self.tobj(vm).unwrap().div(vm, other)
+    }
+
+    /// Produce a new `Val` which multiplies `other` to this.
+    pub fn mul(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
+        debug_assert_eq!(ValKind::INT as usize, 0);
+        if self.valkind() == ValKind::INT && other.valkind() == ValKind::INT {
+            if let Some(val) = self.val.checked_mul(other.val / (1 << TAG_BITSIZE)) {
+                return Ok(Val { val });
+            }
+        }
+        self.tobj(vm).unwrap().mul(vm, other)
     }
 
     /// Produce a new `Val` which shifts `self` `other` bits to the left.
@@ -412,12 +393,31 @@ impl Val {
         self.tobj(vm).unwrap().sqrt(vm)
     }
 
-    pub fn to_strval(&self, vm: &VM) -> Result<Val, Box<VMError>> {
-        debug_assert!(!self.is_illegal());
-        match self.valkind() {
-            ValKind::INT => Ok(String_::new(vm, self.as_isize(vm).unwrap().to_string())),
-            ValKind::GCBOX => self.tobj(vm).unwrap().to_strval(vm),
+    /// Produce a new `Val` which subtracts `other` from this.
+    pub fn sub(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
+        debug_assert_eq!(ValKind::INT as usize, 0);
+        if self.valkind() == ValKind::INT && other.valkind() == ValKind::INT {
+            if let Some(val) = self.val.checked_sub(other.val) {
+                return Ok(Val { val });
+            }
         }
+        self.tobj(vm).unwrap().sub(vm, other)
+    }
+
+    /// Produce a new `Val` which performs a bitwise xor operation with `other` and this.
+    pub fn xor(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
+        if let Some(lhs) = self.as_isize(vm) {
+            if let Some(rhs) = other.as_isize(vm) {
+                return Val::from_isize(vm, lhs ^ rhs);
+            } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
+                return ArbInt::new(vm, BigInt::from_isize(lhs).unwrap() ^ rhs.bigint());
+            }
+            return Err(Box::new(VMError::TypeError {
+                expected: self.dyn_objtype(vm),
+                got: other.dyn_objtype(vm),
+            }));
+        }
+        self.tobj(vm).unwrap().xor(vm, other)
     }
 
     /// Is this `Val` reference equal to `other`? Notice that for integers (but not Doubles)


### PR DESCRIPTION
After renaming `bit_xor` to `xor`, this PR simply sorts out the order that functions are written in so that we're more consistent across structs -- this PR has no functional change. @ummarikar This one is for you to review.

bors delegate=ummarikar