### PR TITLE
Make illegal values an explicitly tagged value.

### DIFF
--- a/src/lib/compiler/ast_to_instrs.rs
+++ b/src/lib/compiler/ast_to_instrs.rs
@@ -25,6 +25,7 @@ use crate::{
     },
     vm::{
         objects::{BlockInfo, Class, Method, MethodBody, String_},
+        val::ValKind,
         VM,
     },
 };
@@ -70,7 +71,10 @@ impl<'a> Compiler<'a> {
             }
             // Whatever superclass has been chosen, it must have been initialised already or else
             // bad things will happen.
-            debug_assert!(!supercls.as_ref().unwrap().is_illegal());
+            debug_assert_ne!(
+                supercls.as_ref().map(|x| x.valkind()),
+                Some(ValKind::ILLEGAL)
+            );
         } else {
             supercls = None;
         }


### PR DESCRIPTION
Previously we used (sort of) null `GCBOX`'s as an illegal value. The problem with this is that we were haphazard in checking whether such values were ever used for anything *and* we only did so in debug mode. Any mistakes in their use were likely to end badly. This commit tentatively adds illegal values as an explicitly tagged entity: that means that we can't use them incorrectly, even in release mode. This probably slightly slows things down, but not enough that I can measure.