### PR TITLE
Add support for Integer class primitives.

### DIFF
--- a/lang_tests/int_class.som
+++ b/lang_tests/int_class.som
@@ -1,0 +1,12 @@
+"
+VM:
+  status: success
+  stdout:
+    Integer
+"
+
+int_class = (
+    run = (
+        (Integer class) println.
+    )
+)

--- a/src/lib/compiler/ast_to_instrs.rs
+++ b/src/lib/compiler/ast_to_instrs.rs
@@ -491,6 +491,7 @@ impl<'a> Compiler<'a> {
                         "false" => vm.instrs_push(Instr::Builtin(Builtin::False)),
                         "system" => vm.instrs_push(Instr::Builtin(Builtin::System)),
                         "true" => vm.instrs_push(Instr::Builtin(Builtin::True)),
+                        "Integer" => vm.instrs_push(Instr::Builtin(Builtin::Integer)),
                         _ => return Err(e),
                     },
                 }

--- a/src/lib/compiler/instrs.rs
+++ b/src/lib/compiler/instrs.rs
@@ -27,6 +27,7 @@ pub enum Instr {
 #[derive(Clone, Copy, Debug)]
 pub enum Builtin {
     False,
+    Integer,
     Nil,
     System,
     True,

--- a/src/lib/vm/core.rs
+++ b/src/lib/vm/core.rs
@@ -113,6 +113,7 @@ pub struct VM {
     pub system_cls: Val,
     pub true_cls: Val,
     pub false_: Val,
+    pub int_: Val,
     pub nil: Val,
     pub system: Val,
     pub true_: Val,
@@ -155,6 +156,7 @@ impl VM {
             system_cls: Val::illegal(),
             true_cls: Val::illegal(),
             false_: Val::illegal(),
+            int_: Val::illegal(),
             nil: Val::illegal(),
             system: Val::illegal(),
             true_: Val::illegal(),
@@ -192,6 +194,7 @@ impl VM {
         vm.system_cls = vm.init_builtin_class("System", false);
         vm.true_cls = vm.init_builtin_class("True", false);
         vm.false_ = Inst::new(&vm, vm.false_cls.clone());
+        vm.int_ = Inst::new(&vm, vm.int_cls.clone());
         vm.system = Inst::new(&vm, vm.system_cls.clone());
         vm.true_ = Inst::new(&vm, vm.true_cls.clone());
 
@@ -299,6 +302,7 @@ impl VM {
                         Builtin::False => self.false_.clone(),
                         Builtin::System => self.system.clone(),
                         Builtin::True => self.true_.clone(),
+                        Builtin::Integer => self.int_.clone(),
                     });
                     pc += 1;
                 }
@@ -841,6 +845,7 @@ impl VM {
             system_cls: Val::illegal(),
             true_cls: Val::illegal(),
             false_: Val::illegal(),
+            int_: Val::illegal(),
             nil: Val::illegal(),
             system: Val::illegal(),
             true_: Val::illegal(),


### PR DESCRIPTION
Add Integer as a Builtin and include a test to ensure `(Integer class) println.` prints `Integer`.