### PR TITLE
Add Symbol class.

### DIFF
--- a/lang_tests/symbol.som
+++ b/lang_tests/symbol.som
@@ -1,0 +1,22 @@
+"
+VM:
+  status: success
+  stdout:
+    #ab
+    true
+    false
+    true
+    String
+    String
+"
+
+symbol = (
+    run = (
+        #ab println.
+        (#ab == #ab) println.
+        ((#a + #b) == #ab) println.
+        (('a' + 'b') asSymbol == #ab) println.
+        (('a' + #ab) class) println.
+        ((#ab + 'a') class) println.
+    )
+)

--- a/lib/SOM/String.som
+++ b/lib/SOM/String.som
@@ -2,5 +2,6 @@ String = (
     concatenate: argument = primitive
     + argument = ( ^self concatenate: argument asString )
     asString = (^self)
+    asSymbol = primitive
     print = ( system printString: self )
 )

--- a/lib/SOM/Symbol.som
+++ b/lib/SOM/Symbol.som
@@ -1,4 +1,6 @@
 Symbol = String (
     asString = primitive
     asSymbol = ( ^self )
+    "FIXME implement super keyword instead"
+    print    = ( '#' print. (self asString) print )
 )

--- a/lib/SOM/Symbol.som
+++ b/lib/SOM/Symbol.som
@@ -1,0 +1,4 @@
+Symbol = String (
+    asString = primitive
+    asSymbol = ( ^self )
+)

--- a/src/lib/compiler/ast.rs
+++ b/src/lib/compiler/ast.rs
@@ -66,5 +66,6 @@ pub enum Expr {
     },
     Return(Box<Expr>),
     String(Lexeme<StorageT>),
+    Symbol(Lexeme<StorageT>),
     VarLookup(Lexeme<StorageT>),
 }

--- a/src/lib/compiler/ast_to_instrs.rs
+++ b/src/lib/compiler/ast_to_instrs.rs
@@ -55,6 +55,7 @@ impl<'a> Compiler<'a> {
                     "Block" => Some(vm.block_cls.clone()),
                     "Boolean" => Some(vm.bool_cls.clone()),
                     "nil" => None,
+                    "String" => Some(vm.str_cls.clone()),
                     _ => unimplemented!(),
                 };
             } else {
@@ -109,7 +110,7 @@ impl<'a> Compiler<'a> {
         }
 
         Ok(Class {
-            name: String_::new(vm, name),
+            name: String_::new(vm, name, true),
             path: compiler.path.to_path_buf(),
             supercls,
             num_inst_vars: astcls.inst_vars.len(),

--- a/src/lib/compiler/ast_to_instrs.rs
+++ b/src/lib/compiler/ast_to_instrs.rs
@@ -235,6 +235,7 @@ impl<'a> Compiler<'a> {
                 }
                 "sqrt" => Ok(MethodBody::Primitive(Primitive::Sqrt)),
                 "asString" => Ok(MethodBody::Primitive(Primitive::AsString)),
+                "asSymbol" => Ok(MethodBody::Primitive(Primitive::AsSymbol)),
                 "class" => Ok(MethodBody::Primitive(Primitive::Class)),
                 "concatenate:" => Ok(MethodBody::Primitive(Primitive::Concatenate)),
                 "halt" => Ok(MethodBody::Primitive(Primitive::Halt)),
@@ -467,6 +468,12 @@ impl<'a> Compiler<'a> {
                 // Strip off the beginning/end quotes.
                 let s = s_orig[1..s_orig.len() - 1].to_owned();
                 vm.instrs_push(Instr::String(vm.add_string(s)));
+                Ok(1)
+            }
+            ast::Expr::Symbol(lexeme) => {
+                // XXX are there string escaping rules we need to take account of?
+                let s = self.lexer.lexeme_str(&lexeme);
+                vm.instrs_push(Instr::Symbol(vm.add_symbol(s.to_owned())));
                 Ok(1)
             }
             ast::Expr::VarLookup(lexeme) => {

--- a/src/lib/compiler/instrs.rs
+++ b/src/lib/compiler/instrs.rs
@@ -11,6 +11,7 @@ pub enum Instr {
     Return,
     Send(usize, usize),
     String(usize),
+    Symbol(usize),
     VarLookup(usize, usize),
     VarSet(usize, usize),
 }
@@ -28,6 +29,7 @@ pub enum Primitive {
     Add,
     And,
     AsString,
+    AsSymbol,
     BitXor,
     Class,
     Concatenate,

--- a/src/lib/compiler/som.y
+++ b/src/lib/compiler/som.y
@@ -140,7 +140,7 @@ Literal -> Result<Expr, ()>:
     | "-" "INT" { Ok(Expr::Int{ is_negative: true, val: map_err($2)? }) }
     | "DOUBLE" { Ok(Expr::Double{ is_negative: false, val: map_err($1)? }) }
     | "-" "DOUBLE" { Ok(Expr::Double{ is_negative: true, val: map_err($2)? }) }
-    | StringConst { unimplemented!() }
+    | StringConst { $1 }
     | ArrayConst { unimplemented!() }
     ;
 Block -> Result<Expr, ()>:
@@ -157,9 +157,9 @@ Argument -> Result<Option<Lexeme<StorageT>>, ()>:
       "ID" { Ok(Some(map_err($1)?)) }
     | { unimplemented!() }
     ;
-StringConst -> Result<(), ()>:
+StringConst -> Result<Expr, ()>:
       "#" "STRING" { unimplemented!() }
-    | "#" "ID" { unimplemented!() }
+    | "#" "ID" { Ok(Expr::Symbol(map_err($2)?)) }
     | "#" "KEYWORD" { unimplemented!() }
     | "#" BinOp { unimplemented!() }
     ;

--- a/src/lib/vm/core.rs
+++ b/src/lib/vm/core.rs
@@ -103,6 +103,7 @@ pub struct VM {
     pub nil_cls: Val,
     pub obj_cls: Val,
     pub str_cls: Val,
+    pub sym_cls: Val,
     pub system_cls: Val,
     pub true_cls: Val,
     pub false_: Val,
@@ -145,6 +146,7 @@ impl VM {
             nil_cls: Val::illegal(),
             obj_cls: Val::illegal(),
             str_cls: Val::illegal(),
+            sym_cls: Val::illegal(),
             system_cls: Val::illegal(),
             true_cls: Val::illegal(),
             false_: Val::illegal(),
@@ -182,6 +184,7 @@ impl VM {
         vm.false_cls = vm.init_builtin_class("False", false);
         vm.int_cls = vm.init_builtin_class("Integer", false);
         vm.str_cls = vm.init_builtin_class("String", false);
+        vm.sym_cls = vm.init_builtin_class("Symbol", false);
         vm.system_cls = vm.init_builtin_class("System", false);
         vm.true_cls = vm.init_builtin_class("True", false);
         vm.false_ = Inst::new(&vm, vm.false_cls.clone());
@@ -677,7 +680,7 @@ impl VM {
             let strings = unsafe { &mut *self.strings.get() };
             let len = strings.len();
             reverse_strings.insert(s.clone(), len);
-            strings.push(String_::new(self, s));
+            strings.push(String_::new(self, s, true));
             len
         }
     }
@@ -810,6 +813,7 @@ impl VM {
             obj_cls: Val::illegal(),
             nil_cls: Val::illegal(),
             str_cls: Val::illegal(),
+            sym_cls: Val::illegal(),
             system_cls: Val::illegal(),
             true_cls: Val::illegal(),
             false_: Val::illegal(),

--- a/src/lib/vm/objects/double.rs
+++ b/src/lib/vm/objects/double.rs
@@ -28,7 +28,7 @@ impl Obj for Double {
 
     fn to_strval(&self, vm: &VM) -> Result<Val, Box<VMError>> {
         let mut buf = ryu::Buffer::new();
-        Ok(String_::new(vm, buf.format(self.val).to_owned()))
+        Ok(String_::new(vm, buf.format(self.val).to_owned(), true))
     }
 
     fn add(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {

--- a/src/lib/vm/objects/integers.rs
+++ b/src/lib/vm/objects/integers.rs
@@ -41,7 +41,7 @@ impl Obj for ArbInt {
     }
 
     fn to_strval(&self, vm: &VM) -> Result<Val, Box<VMError>> {
-        Ok(String_::new(vm, self.val.to_string()))
+        Ok(String_::new(vm, self.val.to_string(), true))
     }
 
     fn add(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
@@ -362,7 +362,7 @@ impl Obj for Int {
     }
 
     fn to_strval(&self, vm: &VM) -> Result<Val, Box<VMError>> {
-        Ok(String_::new(vm, self.val.to_string()))
+        Ok(String_::new(vm, self.val.to_string(), true))
     }
 
     fn add(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {

--- a/src/lib/vm/objects/string_.rs
+++ b/src/lib/vm/objects/string_.rs
@@ -13,6 +13,7 @@ use crate::vm::{
 #[derive(Debug, GcLayout)]
 pub struct String_ {
     s: String,
+    is_str: bool,
 }
 
 impl Obj for String_ {
@@ -21,7 +22,12 @@ impl Obj for String_ {
     }
 
     fn get_class(&self, vm: &VM) -> Val {
-        vm.str_cls.clone()
+        // FIXME This is a temporary hack until we sort out bootstrapping of the String_ class
+        if self.is_str {
+            vm.str_cls.clone()
+        } else {
+            vm.sym_cls.clone()
+        }
     }
 }
 
@@ -34,8 +40,8 @@ impl StaticObjType for String_ {
 }
 
 impl String_ {
-    pub fn new(vm: &VM, s: String) -> Val {
-        Val::from_obj(vm, String_ { s })
+    pub fn new(vm: &VM, s: String, is_str: bool) -> Val {
+        Val::from_obj(vm, String_ { s, is_str })
     }
 
     pub fn as_str(&self) -> &str {
@@ -57,6 +63,6 @@ impl String_ {
         let mut new = String::with_capacity(self.s.len() + other_str.s.len());
         new.push_str(&self.s);
         new.push_str(&other_str.s);
-        Ok(String_::new(vm, new))
+        Ok(String_::new(vm, new, true))
     }
 }

--- a/src/lib/vm/objects/string_.rs
+++ b/src/lib/vm/objects/string_.rs
@@ -29,6 +29,19 @@ impl Obj for String_ {
             vm.sym_cls.clone()
         }
     }
+
+    fn to_strval(&self, vm: &VM) -> Result<Val, Box<VMError>> {
+        Ok(String_::new(vm, self.s.to_string(), true))
+    }
+
+    fn ref_equals(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
+        let other_str: &String_ = other.downcast(vm)?;
+
+        Ok(Val::from_bool(
+            vm,
+            (self.is_str == other_str.is_str) && (self.s == other_str.s),
+        ))
+    }
 }
 
 impl NotUnboxable for String_ {}
@@ -64,5 +77,9 @@ impl String_ {
         new.push_str(&self.s);
         new.push_str(&other_str.s);
         Ok(String_::new(vm, new, true))
+    }
+
+    pub fn to_symbol(&self, vm: &VM) -> Result<Val, Box<VMError>> {
+        Ok(String_::new(vm, self.s.to_string(), false))
     }
 }

--- a/src/lib/vm/val.rs
+++ b/src/lib/vm/val.rs
@@ -285,7 +285,11 @@ impl Val {
 
     pub fn to_strval(&self, vm: &VM) -> Result<Val, Box<VMError>> {
         match self.valkind() {
-            ValKind::INT => Ok(String_::new(vm, self.as_isize(vm).unwrap().to_string(), true)),
+            ValKind::INT => Ok(String_::new(
+                vm,
+                self.as_isize(vm).unwrap().to_string(),
+                true,
+            )),
             ValKind::GCBOX => self.tobj(vm).unwrap().to_strval(vm),
             ValKind::ILLEGAL => unreachable!(),
         }

--- a/src/lib/vm/val.rs
+++ b/src/lib/vm/val.rs
@@ -285,7 +285,7 @@ impl Val {
 
     pub fn to_strval(&self, vm: &VM) -> Result<Val, Box<VMError>> {
         match self.valkind() {
-            ValKind::INT => Ok(String_::new(vm, self.as_isize(vm).unwrap().to_string())),
+            ValKind::INT => Ok(String_::new(vm, self.as_isize(vm).unwrap().to_string(), true)),
             ValKind::GCBOX => self.tobj(vm).unwrap().to_strval(vm),
             ValKind::ILLEGAL => unreachable!(),
         }
@@ -652,7 +652,7 @@ mod tests {
         let vm = VM::new_no_bootstrap();
 
         let v = {
-            let v = String_::new(&vm, "s".to_owned());
+            let v = String_::new(&vm, "s".to_owned(), true);
             let v_tobj = v.tobj(&vm).unwrap();
             let v_int: &dyn Obj = v_tobj.deref().deref();
             let v_recovered = Val::recover(v_int);
@@ -667,7 +667,7 @@ mod tests {
     #[test]
     fn test_cast() {
         let vm = VM::new_no_bootstrap();
-        let v = String_::new(&vm, "s".to_owned());
+        let v = String_::new(&vm, "s".to_owned(), true);
         assert!(v.downcast::<String_>(&vm).is_ok());
         assert_eq!(
             *v.downcast::<Class>(&vm).unwrap_err(),
@@ -681,7 +681,7 @@ mod tests {
     #[test]
     fn test_downcast() {
         let vm = VM::new_no_bootstrap();
-        let v = String_::new(&vm, "s".to_owned());
+        let v = String_::new(&vm, "s".to_owned(), true);
         assert!(v.downcast::<String_>(&vm).is_ok());
         assert!(v.downcast::<Class>(&vm).is_err());
         assert!(v.try_downcast::<String_>(&vm).is_some());


### PR DESCRIPTION
Add support for the som class - `Symbol`, a subclass of `String`. In the future, this should be used to implement classes as globals so we can support class primitives.