### PR TITLE
Use a custom implementation for the SOM stack.

### DIFF
--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -17,7 +17,9 @@
 #![feature(unsize)]
 #![allow(clippy::cognitive_complexity)]
 #![allow(clippy::float_cmp)]
+#![allow(clippy::missing_safety_doc)]
 #![allow(clippy::never_loop)]
+#![allow(clippy::new_without_default)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::type_complexity)]
 

--- a/src/lib/vm/mod.rs
+++ b/src/lib/vm/mod.rs
@@ -10,6 +10,7 @@
 
 pub mod core;
 pub mod objects;
+pub mod somstack;
 pub mod val;
 
 pub use crate::vm::core::{VMError, VM};

--- a/src/lib/vm/somstack.rs
+++ b/src/lib/vm/somstack.rs
@@ -1,0 +1,111 @@
+use std::{
+    alloc::{alloc, dealloc, Layout},
+    cell::UnsafeCell,
+    mem::forget,
+    ptr,
+};
+
+use crate::vm::val::Val;
+
+pub const SOM_STACK_LEN: usize = 4096;
+
+/// A fixed size stack of SOM values. This stack does minimal or no checking on important
+/// operations and users must ensure that they obey the constraints on each function herein, or
+/// undefined behaviour will occur.
+pub struct SOMStack {
+    storage: *mut Val,
+    /// How many items are used? Note that the stack has an implicit capacity of [`SOM_STACK_LEN`].
+    len: UnsafeCell<usize>,
+}
+
+impl SOMStack {
+    pub fn new() -> SOMStack {
+        #![allow(clippy::cast_ptr_alignment)]
+        let storage = unsafe { alloc(Layout::array::<Val>(SOM_STACK_LEN).unwrap()) as *mut Val };
+        SOMStack {
+            storage,
+            len: UnsafeCell::new(0),
+        }
+    }
+
+    /// Returns `true` if the stack contains no elements.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns the number of elements in the stack.
+    pub fn len(&self) -> usize {
+        *unsafe { &*self.len.get() }
+    }
+
+    /// Returns the number of elements the stack can store before running out of room.
+    pub fn remaining_capacity(&self) -> usize {
+        SOM_STACK_LEN - self.len()
+    }
+
+    /// Returns the top-most value of the stack without removing it. If the stack is empty, calling
+    /// this function will lead to undefined behaviour.
+    pub fn peek(&self) -> Val {
+        debug_assert!(!self.is_empty());
+        let v = unsafe { ptr::read(self.storage.add(self.len() - 1)) };
+        let v2 = v.clone();
+        forget(v);
+        v2
+    }
+
+    /// Pops the top-most value of the stack and returns it. If the stack is empty, calling
+    /// this function will lead to undefined behaviour.
+    pub fn pop(&self) -> Val {
+        debug_assert!(!self.is_empty());
+        let len = unsafe { &mut *self.len.get() };
+        let i = *len - 1;
+        let v = unsafe { ptr::read(self.storage.add(i)) };
+        *len = i;
+        v
+    }
+
+    /// Pops the top-most value of the stack and returns it. If the stack is empty, calling
+    /// this function will lead to undefined behaviour.
+    pub fn pop_n(&self, n: usize) -> Val {
+        debug_assert!(n < self.len());
+        let len = unsafe { &mut *self.len.get() };
+        *len -= 1;
+        let i = *len - n;
+        let v = unsafe { ptr::read(self.storage.add(i)) };
+        unsafe { ptr::copy(self.storage.add(i + 1), self.storage.add(i), n) };
+        v
+    }
+
+    /// Push `v` onto the end of the stack. You must previously have checked (using
+    /// [`remaining_capacity`]) that there is room for this value: if there is not, undefined
+    /// behaviour will occur.
+    pub fn push(&self, v: Val) {
+        debug_assert!(self.remaining_capacity() > 0);
+        let len = unsafe { &mut *self.len.get() };
+        unsafe { ptr::write(self.storage.add(*len), v) };
+        *len += 1;
+    }
+
+    /// Shortens the stack, keeping the first len elements and dropping the rest.
+    pub fn truncate(&self, len: usize) {
+        debug_assert!(len <= self.len());
+        let lenref = unsafe { &mut *self.len.get() };
+        for i in len..*lenref {
+            unsafe {
+                ptr::read(self.storage.add(i));
+            }
+        }
+        *lenref = len;
+    }
+}
+
+impl Drop for SOMStack {
+    fn drop(&mut self) {
+        unsafe {
+            dealloc(
+                self.storage as *mut _,
+                Layout::array::<Val>(SOM_STACK_LEN).unwrap(),
+            )
+        };
+    }
+}


### PR DESCRIPTION
This moves from using ArrayVec to a custom fixed-size array `SOMStack` which,
currently, is simply an array of `Val`s. This is mostly intended to make future
work easier but, to my surprise, this also gives a 3% or so speed increase on
our simple while benchmark.