### PR TITLE
Move the UnsafeCell from SOMStack to VM.

### DIFF
--- a/src/lib/vm/somstack.rs
+++ b/src/lib/vm/somstack.rs
@@ -1,6 +1,5 @@
 use std::{
     alloc::{alloc, dealloc, Layout},
-    cell::UnsafeCell,
     mem::forget,
     ptr,
 };
@@ -15,17 +14,14 @@ pub const SOM_STACK_LEN: usize = 4096;
 pub struct SOMStack {
     storage: *mut Val,
     /// How many items are used? Note that the stack has an implicit capacity of [`SOM_STACK_LEN`].
-    len: UnsafeCell<usize>,
+    len: usize,
 }
 
 impl SOMStack {
     pub fn new() -> SOMStack {
         #![allow(clippy::cast_ptr_alignment)]
         let storage = unsafe { alloc(Layout::array::<Val>(SOM_STACK_LEN).unwrap()) as *mut Val };
-        SOMStack {
-            storage,
-            len: UnsafeCell::new(0),
-        }
+        SOMStack { storage, len: 0 }
     }
 
     /// Returns `true` if the stack contains no elements.
@@ -35,7 +31,7 @@ impl SOMStack {
 
     /// Returns the number of elements in the stack.
     pub fn len(&self) -> usize {
-        *unsafe { &*self.len.get() }
+        self.len
     }
 
     /// Returns the number of elements the stack can store before running out of room.
@@ -47,7 +43,7 @@ impl SOMStack {
     /// this function will lead to undefined behaviour.
     pub fn peek(&self) -> Val {
         debug_assert!(!self.is_empty());
-        let v = unsafe { ptr::read(self.storage.add(self.len() - 1)) };
+        let v = unsafe { ptr::read(self.storage.add(self.len - 1)) };
         let v2 = v.clone();
         forget(v);
         v2
@@ -55,47 +51,41 @@ impl SOMStack {
 
     /// Pops the top-most value of the stack and returns it. If the stack is empty, calling
     /// this function will lead to undefined behaviour.
-    pub fn pop(&self) -> Val {
+    pub fn pop(&mut self) -> Val {
         debug_assert!(!self.is_empty());
-        let len = unsafe { &mut *self.len.get() };
-        let i = *len - 1;
-        let v = unsafe { ptr::read(self.storage.add(i)) };
-        *len = i;
-        v
+        self.len -= 1;
+        unsafe { ptr::read(self.storage.add(self.len)) }
     }
 
     /// Pops the top-most value of the stack and returns it. If the stack is empty, calling
     /// this function will lead to undefined behaviour.
-    pub fn pop_n(&self, n: usize) -> Val {
+    pub fn pop_n(&mut self, n: usize) -> Val {
         debug_assert!(n < self.len());
-        let len = unsafe { &mut *self.len.get() };
-        *len -= 1;
-        let i = *len - n;
+        self.len -= 1;
+        let i = self.len - n;
         let v = unsafe { ptr::read(self.storage.add(i)) };
         unsafe { ptr::copy(self.storage.add(i + 1), self.storage.add(i), n) };
         v
     }
 
     /// Push `v` onto the end of the stack. You must previously have checked (using
-    /// [`remaining_capacity`]) that there is room for this value: if there is not, undefined
-    /// behaviour will occur.
-    pub fn push(&self, v: Val) {
+    /// [`SOMStack::remaining_capacity`]) that there is room for this value: if there is not,
+    /// undefined behaviour will occur.
+    pub fn push(&mut self, v: Val) {
         debug_assert!(self.remaining_capacity() > 0);
-        let len = unsafe { &mut *self.len.get() };
-        unsafe { ptr::write(self.storage.add(*len), v) };
-        *len += 1;
+        unsafe { ptr::write(self.storage.add(self.len), v) };
+        self.len += 1;
     }
 
     /// Shortens the stack, keeping the first len elements and dropping the rest.
-    pub fn truncate(&self, len: usize) {
+    pub fn truncate(&mut self, len: usize) {
         debug_assert!(len <= self.len());
-        let lenref = unsafe { &mut *self.len.get() };
-        for i in len..*lenref {
+        for i in len..self.len {
             unsafe {
                 ptr::read(self.storage.add(i));
             }
         }
-        *lenref = len;
+        self.len = len;
     }
 }
 


### PR DESCRIPTION
This is how I should have done things in the first place, but I'd forgotten one
of my guiding principles, which is that `VM` should (roughly) model what a
multi-threaded interpreter should look like. In that model, some sort of lock
would be need to held before `SOMStack` can be accessed, but after that
`SOMStack` should be fairly normal.

This commit thus makes VM store `SOMStack` in an `UnsafeCell`, which means we
can then remove the inner `UnsafeCell` from `SOMStack` itself.