### PR TITLE
Add support for globals.

### DIFF
--- a/lang_tests/instance_vars2.som
+++ b/lang_tests/instance_vars2.som
@@ -2,11 +2,11 @@
 VM:
   status: error
   stderr:
-    ...line 11, column 11:
-      ...
-    Unknown variable 'x'
+   InvalidSymbol 
 "
 
 instance_vars2 = (
-    x = (^x)
+  run = (
+    x = 1
+  )
 )

--- a/lang_tests/system_global.som
+++ b/lang_tests/system_global.som
@@ -1,0 +1,36 @@
+"
+VM:
+  status: success
+  stdout:
+    true
+    true
+    42
+    42
+    String
+    21
+    21
+    nil
+    true
+    false
+"
+
+system_global = (
+    run = (
+        ((system global: #Integer) == Integer) println.
+        system global: #Integer put: 42.
+        ((system global: #Integer) == Integer) println.
+        Integer println.
+        (system global: #Integer) println.
+        system global: #Integer put: 'a'.
+        Integer class println.
+        system global: #ab put: 21.
+        (system global: #ab) println.
+        ab println.
+        system global: #nil put: 'a'.
+        system global: #true put: 'b'.
+        system global: #false put: 'c'.
+        nil println.
+        true println.
+        false println.
+    )
+)

--- a/lang_tests/system_global_invalid_symbol_err.som
+++ b/lang_tests/system_global_invalid_symbol_err.som
@@ -1,0 +1,11 @@
+"
+VM:
+  status: error
+  stderr: InvalidSymbol
+"
+
+system_global_invalid_symbol_err = (
+    run = (
+        system global: #ab.
+    )
+)

--- a/lib/SOM/System.som
+++ b/lib/SOM/System.som
@@ -1,4 +1,6 @@
 System = (
-    printString: string = primitive
-    printNewline        = primitive
+    global: name            = primitive
+    global: name put: value = primitive
+    printString: string     = primitive
+    printNewline            = primitive
 )

--- a/src/lib/compiler/ast_to_instrs.rs
+++ b/src/lib/compiler/ast_to_instrs.rs
@@ -238,6 +238,8 @@ impl<'a> Compiler<'a> {
                 "asSymbol" => Ok(MethodBody::Primitive(Primitive::AsSymbol)),
                 "class" => Ok(MethodBody::Primitive(Primitive::Class)),
                 "concatenate:" => Ok(MethodBody::Primitive(Primitive::Concatenate)),
+                "global:" => Ok(MethodBody::Primitive(Primitive::Global)),
+                "global:put:" => Ok(MethodBody::Primitive(Primitive::GlobalPut)),
                 "halt" => Ok(MethodBody::Primitive(Primitive::Halt)),
                 "hashcode" => Ok(MethodBody::Primitive(Primitive::Hashcode)),
                 "inspect" => Ok(MethodBody::Primitive(Primitive::Inspect)),
@@ -485,13 +487,20 @@ impl<'a> Compiler<'a> {
                             vm.instrs_push(Instr::VarLookup(depth, var_num));
                         }
                     }
-                    Err(e) => match self.lexer.lexeme_str(&lexeme) {
-                        "nil" => vm.instrs_push(Instr::Builtin(Builtin::Nil)),
-                        "false" => vm.instrs_push(Instr::Builtin(Builtin::False)),
-                        "system" => vm.instrs_push(Instr::Builtin(Builtin::System)),
-                        "true" => vm.instrs_push(Instr::Builtin(Builtin::True)),
-                        _ => return Err(e),
-                    },
+                    Err(_) => {
+                        let lex_string = self.lexer.lexeme_str(&lexeme);
+
+                        match lex_string {
+                            "nil" => vm.instrs_push(Instr::Builtin(Builtin::Nil)),
+                            "false" => vm.instrs_push(Instr::Builtin(Builtin::False)),
+                            "true" => vm.instrs_push(Instr::Builtin(Builtin::True)),
+                            _ => {
+                                vm.instrs_push(Instr::Global(
+                                    vm.add_symbol(lex_string.to_string()),
+                                ));
+                            }
+                        }
+                    }
                 }
                 Ok(1)
             }

--- a/src/lib/compiler/instrs.rs
+++ b/src/lib/compiler/instrs.rs
@@ -2,6 +2,7 @@
 pub enum Instr {
     Block(usize),
     Builtin(Builtin),
+    Global(usize),
     ClosureReturn(usize),
     Double(f64),
     InstVarLookup(usize),
@@ -36,6 +37,8 @@ pub enum Primitive {
     Div,
     DoubleDiv,
     Equals,
+    Global,
+    GlobalPut,
     GreaterThan,
     GreaterThanEquals,
     Halt,


### PR DESCRIPTION
Add a hashmap which maps symbols to their corresponding object and retrieve an object from this hashmap when its symbol is referenced during runtime.