### PR TITLE
Build even when rustfmt can't be installed.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -10,8 +10,16 @@ sh rustup.sh --default-host x86_64-unknown-linux-gnu --default-toolchain nightly
 
 export PATH=`pwd`/.cargo/bin/:$PATH
 
-rustup component add --toolchain nightly rustfmt-preview || cargo +nightly install --force rustfmt-nightly
+# Sometimes rustfmt is so broken that there is no way to install it at all.
+# Rather than refusing to merge, we just can't rust rustfmt at such a point.
+rustup component add --toolchain nightly rustfmt-preview \
+    || cargo +nightly install --force rustfmt-nightly \
+    || true
+rustfmt=0
+cargo fmt 2>&1 | grep "not installed for the toolchain" > /dev/null || rustfmt=1
+if [ $rustfmt -eq 1 ]; then
+    cargo +nightly fmt --all -- --check
+fi
 
-cargo +nightly fmt --all -- --check
 cargo test
 cargo test --release


### PR DESCRIPTION
Sometimes rust nightly and/or rustfmt are so broken that the latter won't install under any method we try. Rather than borking completely, it's better to allow the PR to be merged even without the fmt check. This is less than ideal, but I can't see a better way of doing things.