### PR TITLE
Add `metaclass` to yksom.

### DIFF
--- a/lang_tests/class_and_metaclass.som
+++ b/lang_tests/class_and_metaclass.som
@@ -7,6 +7,9 @@ VM:
     Metaclass
     Metaclass class
     Metaclass
+    Integer class
+    Metaclass
+    true
 "
 
 class_and_metaclass = (
@@ -16,5 +19,8 @@ class_and_metaclass = (
         Integer class class println.
         Integer class class class println.
         Integer class class class class println.
+        1 class class println.
+        1 class class class println.
+        (1 class <> (1 class class)) println.
     )
 ) 

--- a/lang_tests/class_and_metaclass.som
+++ b/lang_tests/class_and_metaclass.som
@@ -1,0 +1,20 @@
+"
+VM:
+  status: success
+  stdout:
+    Integer
+    Integer class
+    Metaclass
+    Metaclass class
+    Metaclass
+"
+
+class_and_metaclass = (
+    run = (
+        Integer println.
+        Integer class println.
+        Integer class class println.
+        Integer class class class println.
+        Integer class class class class println.
+    )
+) 

--- a/lang_tests/class_superclass.som
+++ b/lang_tests/class_superclass.som
@@ -8,6 +8,7 @@ VM:
     nil
     Class
     Class
+    Class
 "
 
 class_superclass = (
@@ -18,5 +19,6 @@ class_superclass = (
         Class superclass superclass println.
         Metaclass superclass println.
         Integer class class superclass println.
+        1 class class class superclass println.
     )
 )

--- a/lang_tests/class_superclass.som
+++ b/lang_tests/class_superclass.som
@@ -6,6 +6,8 @@ VM:
     nil
     String
     nil
+    Class
+    Class
 "
 
 class_superclass = (
@@ -14,5 +16,7 @@ class_superclass = (
         Object superclass println.
         Symbol superclass println.
         Class superclass superclass println.
+        Metaclass superclass println.
+        Integer class class superclass println.
     )
 )

--- a/lang_tests/class_superclass.som
+++ b/lang_tests/class_superclass.som
@@ -9,6 +9,7 @@ VM:
     Class
     Class
     Class
+    Class
 "
 
 class_superclass = (
@@ -20,5 +21,6 @@ class_superclass = (
         Metaclass superclass println.
         Integer class class superclass println.
         1 class class class superclass println.
+        Object class superclass println.
     )
 )

--- a/lang_tests/int32.som
+++ b/lang_tests/int32.som
@@ -1,0 +1,12 @@
+"
+VM:
+  status: success
+  stdout:
+    1
+"
+
+int32 = (
+    run = (
+        (Integer fromString: '1') println.
+    )
+)

--- a/lang_tests/int_from_string.som
+++ b/lang_tests/int_from_string.som
@@ -3,10 +3,12 @@ VM:
   status: success
   stdout:
     1
+    Integer
 "
 
-int32 = (
+int_from_string = (
     run = (
         (Integer fromString: '1') println.
+        (Integer fromString: '1') class println.
     )
 )

--- a/lang_tests/int_from_string_err.som
+++ b/lang_tests/int_from_string_err.som
@@ -1,0 +1,11 @@
+"
+VM:
+  status: error
+  stderr: ParseError
+"
+
+int_from_string_err = (
+    run = (
+        Integer fromString: 'a'.
+    )
+)

--- a/lib/SOM/Integer.som
+++ b/lib/SOM/Integer.som
@@ -26,4 +26,7 @@ Integer = (
         i := self.
         [ i <= limit ] whileTrue: [ block value: i. i := i + step ]
     )
+
+    -----
+    fromString: aString = primitive
 )

--- a/lib/SOM/Metaclass.som
+++ b/lib/SOM/Metaclass.som
@@ -1,0 +1,1 @@
+Metaclass = Class ()

--- a/src/lib/compiler/ast.rs
+++ b/src/lib/compiler/ast.rs
@@ -8,6 +8,7 @@ pub struct Class {
     pub supername: Option<Lexeme<StorageT>>,
     pub inst_vars: Vec<Lexeme<StorageT>>,
     pub methods: Vec<Method>,
+    pub class_methods: (Vec<Lexeme<StorageT>>, Vec<Method>)
 }
 
 #[derive(Debug)]

--- a/src/lib/compiler/ast.rs
+++ b/src/lib/compiler/ast.rs
@@ -8,7 +8,7 @@ pub struct Class {
     pub supername: Option<Lexeme<StorageT>>,
     pub inst_vars: Vec<Lexeme<StorageT>>,
     pub methods: Vec<Method>,
-    pub class_methods: (Vec<Lexeme<StorageT>>, Vec<Method>)
+    pub class_methods: (Vec<Lexeme<StorageT>>, Vec<Method>),
 }
 
 #[derive(Debug)]

--- a/src/lib/compiler/ast_to_instrs.rs
+++ b/src/lib/compiler/ast_to_instrs.rs
@@ -141,14 +141,17 @@ impl<'a> Compiler<'a> {
         }
 
         Ok(Class {
-            class: Some(Val::from_obj(vm, Class {
-                class: None,
-                name: String_::new(vm, name.to_string() + " class", true),
-                path: compiler.path.to_path_buf(),
-                supercls: supercls_cls,
-                num_inst_vars: astcls.class_methods.0.len(),
-                methods: class_methods,
-            })),
+            class: Some(Val::from_obj(
+                vm,
+                Class {
+                    class: None,
+                    name: String_::new(vm, name.to_string() + " class", true),
+                    path: compiler.path.to_path_buf(),
+                    supercls: supercls_cls,
+                    num_inst_vars: astcls.class_methods.0.len(),
+                    methods: class_methods,
+                },
+            )),
             name: String_::new(vm, name, true),
             path: compiler.path.to_path_buf(),
             supercls,

--- a/src/lib/compiler/instrs.rs
+++ b/src/lib/compiler/instrs.rs
@@ -37,6 +37,7 @@ pub enum Primitive {
     Div,
     DoubleDiv,
     Equals,
+    FromString,
     Global,
     GlobalPut,
     GreaterThan,

--- a/src/lib/compiler/som.y
+++ b/src/lib/compiler/som.y
@@ -3,7 +3,7 @@
 %%
 ClassDef -> Result<Class, ()>:
       "ID" "=" SuperClass "(" NameDefs MethodsOpt ClassMethods ")"
-      { Ok(Class{ name: map_err($1)?, supername: $3?, inst_vars: $5?, methods: $6? }) }
+      { Ok(Class{ name: map_err($1)?, supername: $3?, inst_vars: $5?, methods: $6?, class_methods: $7? }) }
     ;
 SuperClass -> Result<Option<Lexeme<StorageT>>, ()>:
       "ID" { Ok(Some(map_err($1)?)) }
@@ -17,9 +17,9 @@ Methods -> Result<Vec<Method>, ()>:
       Method { Ok(vec![$1?]) }
     | Methods Method { flattenr($1, $2) }
     ;
-ClassMethods -> Result<(), ()>:
-          "SEPARATOR" NameDefs MethodsOpt { unimplemented!() }
-    | { Ok(()) }
+ClassMethods -> Result<(Vec<Lexeme<StorageT>>, Vec<Method>), ()>:
+          "SEPARATOR" NameDefs MethodsOpt { Ok(($2?, $3?)) }
+    | { Ok((vec![], vec![])) }
     ;
 Method -> Result<Method, ()>:
       MethodName "=" MethodBody

--- a/src/lib/vm/core.rs
+++ b/src/lib/vm/core.rs
@@ -102,6 +102,7 @@ pub struct VM {
     pub double_cls: Val,
     pub false_cls: Val,
     pub int_cls: Val,
+    pub meta_cls: Val,
     pub nil_cls: Val,
     pub obj_cls: Val,
     pub str_cls: Val,
@@ -148,6 +149,7 @@ impl VM {
             double_cls: Val::illegal(),
             false_cls: Val::illegal(),
             int_cls: Val::illegal(),
+            meta_cls: Val::illegal(),
             nil_cls: Val::illegal(),
             obj_cls: Val::illegal(),
             str_cls: Val::illegal(),
@@ -177,6 +179,7 @@ impl VM {
         // than it in the phase.
         vm.obj_cls = vm.init_builtin_class("Object", false);
         vm.cls_cls = vm.init_builtin_class("Class", false);
+        vm.meta_cls = vm.init_builtin_class("Metaclass", false);
         vm.nil_cls = vm.init_builtin_class("Nil", true);
         vm.nil = Inst::new(&vm, vm.nil_cls.clone());
 
@@ -896,6 +899,7 @@ impl VM {
             false_cls: Val::illegal(),
             int_cls: Val::illegal(),
             obj_cls: Val::illegal(),
+            meta_cls: Val::illegal(),
             nil_cls: Val::illegal(),
             str_cls: Val::illegal(),
             sym_cls: Val::illegal(),

--- a/src/lib/vm/core.rs
+++ b/src/lib/vm/core.rs
@@ -15,7 +15,7 @@ use crate::{
         instrs::{Builtin, Instr, Primitive},
     },
     vm::{
-        objects::{Block, BlockInfo, Class, Double, Inst, Method, MethodBody, ObjType, String_},
+        objects::{Block, BlockInfo, Class, Double, Inst, Method, MethodBody, ObjType, String_, Int},
         somstack::SOMStack,
         val::Val,
     },
@@ -57,6 +57,8 @@ pub enum VMError {
     PrimitiveError,
     /// Tried to do a shl that would overflow memory and/or not fit in the required integer size.
     ShiftTooBig,
+    /// The given string cannot be parsed to produce a number.
+    ParseError,
     /// A dynamic type error.
     TypeError {
         expected: ObjType,
@@ -501,6 +503,12 @@ impl VM {
             Primitive::Equals => {
                 unsafe { &mut *self.stack.get() }.push(stry!(
                     rcv.equals(self, unsafe { &mut *self.stack.get() }.pop())
+                ));
+                SendReturn::Val
+            }
+            Primitive::FromString => {
+                unsafe { &mut *self.stack.get() }.push(stry!(
+                    Int::from_str(self, unsafe { &mut *self.stack.get() }.pop())
                 ));
                 SendReturn::Val
             }

--- a/src/lib/vm/core.rs
+++ b/src/lib/vm/core.rs
@@ -15,7 +15,9 @@ use crate::{
         instrs::{Builtin, Instr, Primitive},
     },
     vm::{
-        objects::{Block, BlockInfo, Class, Double, Inst, Method, MethodBody, ObjType, String_, Int},
+        objects::{
+            Block, BlockInfo, Class, Double, Inst, Int, Method, MethodBody, ObjType, String_,
+        },
         somstack::SOMStack,
         val::Val,
     },
@@ -507,9 +509,10 @@ impl VM {
                 SendReturn::Val
             }
             Primitive::FromString => {
-                unsafe { &mut *self.stack.get() }.push(stry!(
-                    Int::from_str(self, unsafe { &mut *self.stack.get() }.pop())
-                ));
+                unsafe { &mut *self.stack.get() }.push(stry!(Int::from_str(
+                    self,
+                    unsafe { &mut *self.stack.get() }.pop()
+                )));
                 SendReturn::Val
             }
             Primitive::Global => {

--- a/src/lib/vm/objects/class.rs
+++ b/src/lib/vm/objects/class.rs
@@ -7,7 +7,7 @@ use abgc_derive::GcLayout;
 
 use crate::vm::{
     core::{VMError, VM},
-    objects::{Method, Obj, ObjType, StaticObjType, String_},
+    objects::{Method, Obj, ObjType, StaticObjType},
     val::{NotUnboxable, Val},
 };
 

--- a/src/lib/vm/objects/class.rs
+++ b/src/lib/vm/objects/class.rs
@@ -30,6 +30,11 @@ impl Obj for Class {
         let name: &String_ = self.name.downcast(vm).unwrap();
         let s = name.as_str();
 
+        let mut methods_clone = HashMap::with_capacity(self.methods.len());
+        for (k, v) in self.methods.iter() {
+            methods_clone.insert(k.clone(), Gc::clone(v));
+        }
+
         if !self.metaclass {
             return Val::from_obj(
                 vm,
@@ -39,7 +44,7 @@ impl Obj for Class {
                     path: self.path.clone(),
                     supercls: Some(vm.cls_cls.clone()),
                     num_inst_vars: self.num_inst_vars,
-                    methods: HashMap::clone(&self.methods),
+                    methods: methods_clone,
                 },
             );
         }

--- a/src/lib/vm/objects/class.rs
+++ b/src/lib/vm/objects/class.rs
@@ -38,8 +38,8 @@ impl Obj for Class {
                     name: String_::new(vm, s.to_string() + " class", true),
                     path: self.path.clone(),
                     supercls: Some(vm.cls_cls.clone()),
-                    num_inst_vars: 0,
-                    methods: HashMap::with_capacity(0),
+                    num_inst_vars: self.num_inst_vars,
+                    methods: HashMap::clone(&self.methods),
                 },
             );
         }

--- a/src/lib/vm/objects/integers.rs
+++ b/src/lib/vm/objects/integers.rs
@@ -11,7 +11,10 @@
 
 #![allow(clippy::new_ret_no_self)]
 
-use std::convert::TryFrom;
+use std::{
+    convert::TryFrom,
+    str::FromStr,
+};
 
 use abgc_derive::GcLayout;
 use num_bigint::BigInt;
@@ -344,6 +347,15 @@ impl ArbInt {
     pub fn bigint(&self) -> &BigInt {
         &self.val
     }
+
+    pub fn from_str(vm: &VM, val: Val) -> Result<Val, Box<VMError>> {
+        let string: &String_ = val.downcast(vm).unwrap();
+
+        match BigInt::from_str(string.as_str()) {
+            Ok(b) => ArbInt::new(vm, b),
+            Err(_) => Err(Box::new(VMError::ParseError)),
+        }
+    }
 }
 
 #[derive(Debug, GcLayout)]
@@ -479,6 +491,15 @@ impl Int {
             Some(self.val as usize)
         } else {
             None
+        }
+    }
+
+    pub fn from_str(vm: &VM, val: Val) -> Result<Val, Box<VMError>> {
+        let string: &String_ = val.downcast(vm).unwrap();
+
+        match isize::from_str(string.as_str()) {
+            Ok(i) => Val::from_isize(vm, i),
+            Err(_) => ArbInt::from_str(vm, val),
         }
     }
 }

--- a/src/lib/vm/objects/integers.rs
+++ b/src/lib/vm/objects/integers.rs
@@ -11,10 +11,7 @@
 
 #![allow(clippy::new_ret_no_self)]
 
-use std::{
-    convert::TryFrom,
-    str::FromStr,
-};
+use std::{convert::TryFrom, str::FromStr};
 
 use abgc_derive::GcLayout;
 use num_bigint::BigInt;

--- a/src/lib/vm/objects/method.rs
+++ b/src/lib/vm/objects/method.rs
@@ -17,7 +17,7 @@ pub struct Method {
     pub body: MethodBody,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum MethodBody {
     /// A built-in primitive.
     Primitive(Primitive),
@@ -46,5 +46,11 @@ impl NotUnboxable for Method {}
 impl StaticObjType for Method {
     fn static_objtype() -> ObjType {
         ObjType::Method
+    }
+}
+
+impl Clone for Method {
+    fn clone(&self) -> Self {
+        Method { name: self.name.clone(), body: self.body }
     }
 }

--- a/src/lib/vm/objects/method.rs
+++ b/src/lib/vm/objects/method.rs
@@ -51,6 +51,9 @@ impl StaticObjType for Method {
 
 impl Clone for Method {
     fn clone(&self) -> Self {
-        Method { name: self.name.clone(), body: self.body }
+        Method {
+            name: self.name.clone(),
+            body: self.body,
+        }
     }
 }


### PR DESCRIPTION
I added a boolean to `Class` to differentiate between `Class` and `Metaclass`. The reason why I did this is because `vm.meta_cls` is not yet initialised before compile-time and so must be returned at runtime instead. Also, I tried putting the `Class` object, that I return in `get_class` (https://github.com/softdevteam/yksom/blob/aaf937dfe3803c8e02d438daa293f845a72c924a/src/lib/vm/objects/class.rs#L36), inside the `Class` struct but this causes the superclass test to fail. This is the only implementation that I could get to pass all the tests and make (some) sense.