### PR TITLE
block values need to execute with their self set to the outer object

### DIFF
--- a/lang_tests/instance_var_in_block.som
+++ b/lang_tests/instance_var_in_block.som
@@ -1,0 +1,15 @@
+"
+VM:
+  status: success
+  stdout:
+    1
+"
+
+instance_var_in_block = (
+    |y|
+    run = (
+        y := 0.
+        [ y := y + 1 ] value.
+        y println.
+    )
+)

--- a/src/lib/compiler/ast_to_instrs.rs
+++ b/src/lib/compiler/ast_to_instrs.rs
@@ -95,7 +95,12 @@ impl<'a> Compiler<'a> {
                 .iter()
                 .map(|(lexeme, msg)| {
                     let ((line_off, col), _) = compiler.lexer.line_col(lexeme.span());
-                    let line = compiler.lexer.span_lines_str(lexeme.span()).split("\n").nth(0).unwrap();
+                    let line = compiler
+                        .lexer
+                        .span_lines_str(lexeme.span())
+                        .split("\n")
+                        .nth(0)
+                        .unwrap();
                     format!(
                         "File '{}', line {}, column {}:\n  {}\n{}",
                         compiler.path.to_str().unwrap(),
@@ -131,9 +136,10 @@ impl<'a> Compiler<'a> {
                 };
                 ((op, self.lexer.span_str(op.span()).to_string()), arg_v)
             }
-            ast::MethodName::Id(lexeme) => {
-                ((lexeme, self.lexer.span_str(lexeme.span()).to_string()), vec![])
-            }
+            ast::MethodName::Id(lexeme) => (
+                (lexeme, self.lexer.span_str(lexeme.span()).to_string()),
+                vec![],
+            ),
             ast::MethodName::Keywords(ref pairs) => {
                 let name = pairs
                     .iter()

--- a/src/lib/vm/core.rs
+++ b/src/lib/vm/core.rs
@@ -301,6 +301,7 @@ impl VM {
                     };
                     unsafe { &mut *self.stack.get() }.push(Block::new(
                         self,
+                        rcv.clone(),
                         blkinfo_off,
                         Gc::clone(&self.current_frame().closure),
                         num_params,
@@ -643,7 +644,7 @@ impl VM {
                     nargs as usize,
                 );
                 unsafe { &mut *self.frames.get() }.push(frame);
-                let r = self.exec_user(rcv.clone(), bytecode_off);
+                let r = self.exec_user(rcv_blk.inst.clone(), bytecode_off);
                 self.frame_pop();
                 r
             }

--- a/src/lib/vm/objects/block.rs
+++ b/src/lib/vm/objects/block.rs
@@ -21,7 +21,10 @@ pub struct BlockInfo {
 
 #[derive(Debug, GcLayout)]
 pub struct Block {
-    // Does this Block represent Block, Block2, or Block3?
+    /// This `Block`'s `self` val. XXX This should probably be part of the corresponding closure's
+    /// variables.
+    pub inst: Val,
+    /// Does this Block represent Block, Block2, or Block3?
     pub blockn_cls: Val,
     pub blockinfo_off: usize,
     pub parent_closure: Gc<Closure>,
@@ -48,6 +51,7 @@ impl StaticObjType for Block {
 impl Block {
     pub fn new(
         vm: &VM,
+        inst: Val,
         blockinfo_off: usize,
         parent_closure: Gc<Closure>,
         num_params: usize,
@@ -61,6 +65,7 @@ impl Block {
         Val::from_obj(
             vm,
             Block {
+                inst,
                 blockn_cls,
                 blockinfo_off,
                 parent_closure,


### PR DESCRIPTION
The `value` primitive is rather special, and before this commit we didn't implement it quite correctly. The new test instance_var_in_block.som caused this error:

```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value:
TypeError { expected: Inst, got: Block }', src/lib/vm/core.rs:353:39
```

The problem is that when executing a block via `value` we always set `rcv` to `Block`. This commit calls exec_primitive with an extra argument that allows it to set `rcv` to the "outer" `rcv`, fixing the problem.
