### PR TITLE
Backtraces

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ num-integer = "0.1"
 num_enum = "0.3"
 num-traits = "0.2"
 ryu = "1.0"
+termion = "1.5"
 
 # The main reason for customising the profile.* sections is to force unwind=abort.
 [profile.release]

--- a/lang_tests/arbint_double_div_err.som
+++ b/lang_tests/arbint_double_div_err.som
@@ -1,7 +1,9 @@
 "
 VM:
   status: error
-  stderr: NotANumber { got: String_ }
+  stderr:
+    ...
+    Expected a numeric type but got type 'String_'.
 "
 
 arbint_double_div_err = (

--- a/lang_tests/arbint_double_div_zero_err.som
+++ b/lang_tests/arbint_double_div_zero_err.som
@@ -1,7 +1,9 @@
 "
 VM:
   status: error
-  stderr: DivisionByZero
+  stderr:
+    ...
+    Division by zero.
 "
 
 arbint_double_div_zero_err = (

--- a/lang_tests/arbint_modulus_err.som
+++ b/lang_tests/arbint_modulus_err.som
@@ -1,7 +1,9 @@
 "
 VM:
   status: error
-  stderr: NotANumber { got: String_ }
+  stderr:
+    ...
+    Expected a numeric type but got type 'String_'.
 "
 
 arbint_modulus_err = (

--- a/lang_tests/double11.som
+++ b/lang_tests/double11.som
@@ -1,7 +1,9 @@
 "
 VM:
   status: error
-  stderr: TypeError { expected: Int, got: Double }
+  stderr:
+    ...
+    Expected object of type 'Int' but got type 'Double'.
 "
 
 double11 = (

--- a/lang_tests/double13.som
+++ b/lang_tests/double13.som
@@ -1,7 +1,9 @@
 "
 VM:
   status: error
-  stderr: TypeError { expected: Int, got: Double }
+  stderr:
+    ...
+    Expected object of type 'Int' but got type 'Double'.
 "
 
 double13 = (

--- a/lang_tests/double3.som
+++ b/lang_tests/double3.som
@@ -1,7 +1,9 @@
 "
 VM:
   status: error
-  stderr: CantRepresentAsDouble
+  stderr:
+    ...
+    Can't represent as double.
 "
 
 double3 = (

--- a/lang_tests/double5.som
+++ b/lang_tests/double5.som
@@ -1,7 +1,9 @@
 "
 VM:
   status: error
-  stderr: CantRepresentAsDouble
+  stderr:
+    ...
+    Can't represent as double.
 "
 
 double5 = (

--- a/lang_tests/double6.som
+++ b/lang_tests/double6.som
@@ -1,7 +1,9 @@
 "
 VM:
   status: error
-  stderr: CantRepresentAsDouble
+  stderr:
+    ...
+    Can't represent as double.
 "
 
 double6 = (

--- a/lang_tests/double7.som
+++ b/lang_tests/double7.som
@@ -1,7 +1,9 @@
 "
 VM:
   status: error
-  stderr: CantRepresentAsDouble
+  stderr:
+    ...
+    Can't represent as double.
 "
 
 double6 = (

--- a/lang_tests/double8.som
+++ b/lang_tests/double8.som
@@ -1,7 +1,9 @@
 "
 VM:
   status: error
-  stderr: CantRepresentAsDouble
+  stderr:
+    ...
+    Can't represent as double.
 "
 
 double6 = (

--- a/lang_tests/double9.som
+++ b/lang_tests/double9.som
@@ -1,7 +1,9 @@
 "
 VM:
   status: error
-  stderr: DivisionByZero
+  stderr:
+    ...
+    Division by zero.
 "
 
 double9 = (

--- a/lang_tests/double_double_div_err.som
+++ b/lang_tests/double_double_div_err.som
@@ -1,7 +1,9 @@
 "
 VM:
   status: error
-  stderr: NotANumber { got: String_ }
+  stderr:
+    ...
+    Expected a numeric type but got type 'String_'.
 "
 
 double_double_div_err = (

--- a/lang_tests/double_double_div_zero_err1.som
+++ b/lang_tests/double_double_div_zero_err1.som
@@ -1,7 +1,9 @@
 "
 VM:
   status: error
-  stderr: DivisionByZero
+  stderr:
+    ...
+    Division by zero.
 "
 
 double_double_div_zero_err1 = (

--- a/lang_tests/double_double_div_zero_err2.som
+++ b/lang_tests/double_double_div_zero_err2.som
@@ -1,7 +1,9 @@
 "
 VM:
   status: error
-  stderr: DivisionByZero
+  stderr:
+    ...
+    Division by zero.
 "
 
 double_double_div_zero_err2 = (

--- a/lang_tests/double_double_div_zero_err3.som
+++ b/lang_tests/double_double_div_zero_err3.som
@@ -1,7 +1,9 @@
 "
 VM:
   status: error
-  stderr: DivisionByZero
+  stderr:
+    ...
+    Division by zero.
 "
 
 double_double_div_zero_err3 = (

--- a/lang_tests/double_double_div_zero_err4.som
+++ b/lang_tests/double_double_div_zero_err4.som
@@ -1,7 +1,9 @@
 "
 VM:
   status: error
-  stderr: DivisionByZero
+  stderr:
+    ...
+    Division by zero.
 "
 
 double_double_div_zero_err4 = (

--- a/lang_tests/double_modulus_err.som
+++ b/lang_tests/double_modulus_err.som
@@ -1,7 +1,9 @@
 "
 VM:
   status: error
-  stderr: NotANumber { got: String_ }
+  stderr:
+    ...
+    Expected a numeric type but got type 'String_'.
 "
 
 double_modulus_err = (

--- a/lang_tests/instance_vars2.som
+++ b/lang_tests/instance_vars2.som
@@ -2,7 +2,8 @@
 VM:
   status: error
   stderr:
-   InvalidSymbol 
+    ...
+    Invalid symbol.
 "
 
 instance_vars2 = (

--- a/lang_tests/int10.som
+++ b/lang_tests/int10.som
@@ -1,7 +1,9 @@
 "
 VM:
   status: error
-  stderr: NotANumber { got: String_ }
+  stderr:
+    ...
+    Expected a numeric type but got type 'String_'.
 "
 
 int10 = (

--- a/lang_tests/int11.som
+++ b/lang_tests/int11.som
@@ -1,7 +1,9 @@
 "
 VM:
   status: error
-  stderr: NotANumber { got: String_ }
+  stderr:
+    ...
+    Expected a numeric type but got type 'String_'.
 "
 
 int11 = (

--- a/lang_tests/int12.som
+++ b/lang_tests/int12.som
@@ -1,7 +1,9 @@
 "
 VM:
   status: error
-  stderr: NotANumber { got: String_ }
+  stderr:
+    ...
+    Expected a numeric type but got type 'String_'.
 "
 
 int12 = (

--- a/lang_tests/int13.som
+++ b/lang_tests/int13.som
@@ -1,7 +1,9 @@
 "
 VM:
   status: error
-  stderr: NotANumber { got: String_ }
+  stderr:
+    ...
+    Expected a numeric type but got type 'String_'.
 "
 
 int13 = (

--- a/lang_tests/int14.som
+++ b/lang_tests/int14.som
@@ -1,7 +1,9 @@
 "
 VM:
   status: error
-  stderr: NotANumber { got: String_ }
+  stderr:
+    ...
+    Expected a numeric type but got type 'String_'.
 "
 
 int14 = (

--- a/lang_tests/int15.som
+++ b/lang_tests/int15.som
@@ -1,7 +1,9 @@
 "
 VM:
   status: error
-  stderr: NotANumber { got: String_ }
+  stderr:
+    ...
+    Expected a numeric type but got type 'String_'.
 "
 
 int15 = (

--- a/lang_tests/int16.som
+++ b/lang_tests/int16.som
@@ -1,7 +1,9 @@
 "
 VM:
   status: error
-  stderr: NotANumber { got: String_ }
+  stderr:
+    ...
+    Expected a numeric type but got type 'String_'.
 "
 
 int16 = (

--- a/lang_tests/int17.som
+++ b/lang_tests/int17.som
@@ -1,7 +1,9 @@
 "
 VM:
   status: error
-  stderr: NotANumber { got: String_ }
+  stderr:
+    ...
+    Expected a numeric type but got type 'String_'.
 "
 
 int17 = (

--- a/lang_tests/int20.som
+++ b/lang_tests/int20.som
@@ -1,7 +1,9 @@
 "
 VM:
   status: error
-  stderr: ShiftTooBig
+  stderr:
+    ...
+    Shift too big.
 "
 
 int20 = (

--- a/lang_tests/int21.som
+++ b/lang_tests/int21.som
@@ -1,7 +1,9 @@
 "
 VM:
   status: error
-  stderr: NegativeShift
+  stderr:
+    ...
+    Negative shift.
 "
 
 int21 = (

--- a/lang_tests/int22.som
+++ b/lang_tests/int22.som
@@ -1,7 +1,9 @@
 "
 VM:
   status: error
-  stderr: ShiftTooBig
+  stderr:
+    ...
+    Shift too big.
 "
 
 int22 = (

--- a/lang_tests/int23.som
+++ b/lang_tests/int23.som
@@ -1,7 +1,9 @@
 "
 VM:
   status: error
-  stderr: DivisionByZero
+  stderr:
+    ...
+    Division by zero.
 "
 
 int9 = (

--- a/lang_tests/int25.som
+++ b/lang_tests/int25.som
@@ -1,7 +1,9 @@
 "
 VM:
   status: error
-  stderr: TypeError { expected: Int, got: String_ }
+  stderr:
+    ...
+    Expected object of type 'Int' but got type 'String_'.
 "
 
 int25 = (

--- a/lang_tests/int27.som
+++ b/lang_tests/int27.som
@@ -1,7 +1,9 @@
 "
 VM:
   status: error
-  stderr: DomainError
+  stderr:
+    ...
+    Domain error.
 "
 
 int27 = (

--- a/lang_tests/int28.som
+++ b/lang_tests/int28.som
@@ -1,7 +1,9 @@
 "
 VM:
   status: error
-  stderr: DomainError
+  stderr:
+    ...
+    Domain error.
 "
 
 int28 = (

--- a/lang_tests/int31.som
+++ b/lang_tests/int31.som
@@ -1,7 +1,9 @@
 "
 VM:
   status: error
-  stderr: TypeError { expected: Int, got: String_ }
+  stderr:
+    ...
+    Expected object of type 'Int' but got type 'String_'.
 "
 
 int31 = (

--- a/lang_tests/int5.som
+++ b/lang_tests/int5.som
@@ -1,7 +1,9 @@
 "
 VM:
   status: error
-  stderr: DivisionByZero
+  stderr:
+    ...
+    Division by zero.
 "
 
 int5 = (

--- a/lang_tests/int8.som
+++ b/lang_tests/int8.som
@@ -1,7 +1,9 @@
 "
 VM:
   status: error
-  stderr: DivisionByZero
+  stderr:
+    ...
+    Division by zero.
 "
 
 int8 = (

--- a/lang_tests/int9.som
+++ b/lang_tests/int9.som
@@ -1,7 +1,9 @@
 "
 VM:
   status: error
-  stderr: DivisionByZero
+  stderr:
+    ...
+    Division by zero.
 "
 
 int9 = (

--- a/lang_tests/int_double_div_err.som
+++ b/lang_tests/int_double_div_err.som
@@ -1,7 +1,9 @@
 "
 VM:
   status: error
-  stderr: NotANumber { got: String_ }
+  stderr:
+    ...
+    Expected a numeric type but got type 'String_'.
 "
 
 int_double_div_err = (

--- a/lang_tests/int_double_div_zero_err.som
+++ b/lang_tests/int_double_div_zero_err.som
@@ -1,7 +1,9 @@
 "
 VM:
   status: error
-  stderr: DivisionByZero
+  stderr:
+    ...
+    Division by zero.
 "
 
 int_double_div_zero_err = (

--- a/lang_tests/int_modulus_err.som
+++ b/lang_tests/int_modulus_err.som
@@ -1,7 +1,9 @@
 "
 VM:
   status: error
-  stderr: NotANumber { got: String_ }
+  stderr:
+    ...
+    Expected a numeric type but got type 'String_'.
 "
 
 int_modulus_err = (

--- a/lang_tests/nested_backtrace1.som
+++ b/lang_tests/nested_backtrace1.som
@@ -1,0 +1,20 @@
+"
+VM:
+  status: error
+  stderr:
+    Traceback (most recent call at bottom):
+      ...nested_backtrace1.som, line 19, column 12:
+          run = ( self m )
+      ...nested_backtrace1.som, line 16, column 18:
+                ifTrue: 1 / 0
+    Division by zero.
+"
+
+nested_backtrace1 = (
+    m = (
+        1 == 0
+          ifTrue: 1 / 0
+          ifFalse: 2 / 0.
+    )
+    run = ( self m )
+)

--- a/lang_tests/nested_backtrace2.som
+++ b/lang_tests/nested_backtrace2.som
@@ -1,0 +1,30 @@
+"
+VM:
+  status: error
+  stderr:
+    Traceback (most recent call at bottom):
+      ...nested_backtrace2.som, line 29, column 12:
+          run = ( self m )
+      ...nested_backtrace2.som, line 25, column 8:
+              1 == 0
+                ifTrue: [ 1 / 0 ]
+                ifFalse: [ 2 / 0 ].
+      ...Boolean.som...
+              self ifFalse: [ ^falseBlock value ].
+      ...False.som...
+          ifFalse: block = ( ^block value )
+      ...Boolean.som...
+              self ifFalse: [ ^falseBlock value ].
+      ...nested_backtrace2.som, line 27, column 21:
+                ifFalse: [ 2 / 0 ].
+    Division by zero.
+"
+
+nested_backtrace2 = (
+    m = (
+        1 == 0
+          ifTrue: [ 1 / 0 ]
+          ifFalse: [ 2 / 0 ].
+    )
+    run = ( self m )
+)

--- a/lang_tests/system2.som
+++ b/lang_tests/system2.som
@@ -1,7 +1,9 @@
 "
 VM:
   status: error
-  stderr: TypeError { expected: String_, got: Inst }
+  stderr:
+    ...
+    Expected object of type 'String_' but got type 'Inst'.
 "
 
 system2 = (

--- a/lang_tests/system_global_invalid_symbol_err.som
+++ b/lang_tests/system_global_invalid_symbol_err.som
@@ -1,7 +1,9 @@
 "
 VM:
   status: error
-  stderr: InvalidSymbol
+  stderr:
+    ...
+    Invalid symbol.
 "
 
 system_global_invalid_symbol_err = (

--- a/src/lib/compiler/ast.rs
+++ b/src/lib/compiler/ast.rs
@@ -10,6 +10,7 @@ pub struct Class {
 
 #[derive(Debug)]
 pub struct Method {
+    pub span: Span,
     pub name: MethodName,
     pub body: MethodBody,
 }
@@ -30,37 +31,65 @@ pub enum MethodBody {
 #[derive(Debug)]
 pub enum Expr {
     Assign {
+        span: Span,
         id: Span,
         expr: Box<Expr>,
     },
     BinaryMsg {
+        span: Span,
         lhs: Box<Expr>,
         op: Span,
         rhs: Box<Expr>,
     },
     Block {
+        span: Span,
         params: Vec<Span>,
         vars: Vec<Span>,
         exprs: Vec<Expr>,
     },
     Double {
+        span: Span,
         is_negative: bool,
         val: Span,
     },
     Int {
+        span: Span,
         is_negative: bool,
         val: Span,
     },
     KeywordMsg {
+        span: Span,
         receiver: Box<Expr>,
         msglist: Vec<(Span, Expr)>,
     },
     UnaryMsg {
+        span: Span,
         receiver: Box<Expr>,
         ids: Vec<Span>,
     },
-    Return(Box<Expr>),
+    Return {
+        span: Span,
+        expr: Box<Expr>,
+    },
     String(Span),
     Symbol(Span),
     VarLookup(Span),
+}
+
+impl Expr {
+    pub fn span(&self) -> Span {
+        match self {
+            Expr::Assign { span, .. } => *span,
+            Expr::BinaryMsg { span, .. } => *span,
+            Expr::Block { span, .. } => *span,
+            Expr::Double { span, .. } => *span,
+            Expr::Int { span, .. } => *span,
+            Expr::KeywordMsg { span, .. } => *span,
+            Expr::UnaryMsg { span, .. } => *span,
+            Expr::Return { span, .. } => *span,
+            Expr::String(span) => *span,
+            Expr::Symbol(span) => *span,
+            Expr::VarLookup(span) => *span,
+        }
+    }
 }

--- a/src/lib/compiler/mod.rs
+++ b/src/lib/compiler/mod.rs
@@ -8,7 +8,7 @@ use std::{fs, path::Path, process};
 use lrlex::lrlex_mod;
 use lrpar::lrpar_mod;
 
-use crate::vm::{objects::Class, VM};
+use crate::vm::{val::Val, VM};
 
 mod ast;
 mod ast_to_instrs;
@@ -20,7 +20,7 @@ lrpar_mod!("lib/compiler/som.y");
 type StorageT = u32;
 
 /// Compile a class. Should only be called by the `VM`.
-pub fn compile(vm: &VM, path: &Path) -> Class {
+pub fn compile(vm: &VM, path: &Path) -> Val {
     let bytes = fs::read(path).unwrap_or_else(|_| panic!("Can't read {}.", path.to_str().unwrap()));
     let txt = String::from_utf8_lossy(&bytes);
 

--- a/src/lib/vm/core.rs
+++ b/src/lib/vm/core.rs
@@ -25,7 +25,18 @@ use crate::{
 pub const SOM_EXTENSION: &str = "som";
 
 #[derive(Debug, PartialEq)]
-pub enum VMError {
+pub struct VMError {
+    pub kind: VMErrorKind,
+}
+
+impl VMError {
+    pub fn new(_: &VM, kind: VMErrorKind) -> Box<Self> {
+        Box::new(VMError { kind })
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub enum VMErrorKind {
     /// A value which can't be represented in an `isize`.
     CantRepresentAsBigInt,
     /// A value which can't be represented in an `f64`.
@@ -355,7 +366,7 @@ impl VM {
                     if let Some(global) = unsafe { &mut *self.globals.get() }.get(&symbol_off) {
                         unsafe { &mut *self.stack.get() }.push(global.clone());
                     } else {
-                        return SendReturn::Err(Box::new(VMError::InvalidSymbol));
+                        return SendReturn::Err(VMError::new(self, VMErrorKind::InvalidSymbol));
                     }
                     pc += 1;
                 }
@@ -522,7 +533,7 @@ impl VM {
                         return SendReturn::Val;
                     }
                 }
-                SendReturn::Err(Box::new(VMError::InvalidSymbol))
+                SendReturn::Err(VMError::new(self, VMErrorKind::InvalidSymbol))
             }
             Primitive::GlobalPut => {
                 let value = unsafe { &mut *self.stack.get() }.pop();

--- a/src/lib/vm/error.rs
+++ b/src/lib/vm/error.rs
@@ -1,0 +1,138 @@
+use std::fs::read_to_string;
+
+use abgc::Gc;
+use lrpar::Span;
+
+use crate::vm::{
+    core::VM,
+    objects::{Class, Method, ObjType},
+};
+
+#[derive(Debug)]
+pub struct VMError {
+    pub kind: VMErrorKind,
+    /// The callstack (in reverse order) of (Class, Span) pairs.
+    pub backtrace: Vec<(Gc<Method>, Span)>,
+}
+
+impl VMError {
+    pub fn new(vm: &VM, kind: VMErrorKind) -> Box<Self> {
+        let backtrace = Vec::with_capacity(vm.frames_len());
+        Box::new(VMError { kind, backtrace })
+    }
+
+    pub fn console_print(&self, vm: &VM) {
+        eprintln!("Traceback (most recent call at bottom):");
+        for (method, span) in self.backtrace.iter().rev() {
+            let cls_val = method.class();
+            let cls: &Class = cls_val.downcast(vm).unwrap();
+            let cls_path = cls.path.to_str().unwrap_or("<non-UTF8 filename>");
+
+            if let Ok(d) = read_to_string(&cls.path) {
+                let newlines = self.newlines(&d);
+                let (start_line, start_col) = self.line_col(&newlines, span.start());
+                let (end_line, _) = self.line_col(&newlines, span.end());
+                eprintln!(
+                    "  File {}, line {}, column {}:",
+                    cls_path, start_line, start_col
+                );
+                for i in start_line - 1..=end_line - 1 {
+                    let line = if i == newlines.len() {
+                        &d[newlines[i - 1]..]
+                    } else {
+                        &d[newlines[i - 1]..newlines[i]]
+                    };
+                    eprintln!("  {}", line.trim_end());
+                }
+            } else {
+                eprintln!("File {}:", cls_path);
+            }
+        }
+        eprintln!("{}.", self.kind.to_string());
+    }
+
+    fn newlines(&self, d: &str) -> Vec<usize> {
+        d.char_indices()
+            .filter(|(_, c)| *c == '\n')
+            .map(|(i, _)| i + 1)
+            .collect()
+    }
+
+    fn line_col(&self, newlines: &Vec<usize>, i: usize) -> (usize, usize) {
+        if newlines.is_empty() || i < newlines[0] {
+            return (1, i);
+        }
+
+        for j in 0..newlines.len() - 1 {
+            if newlines[j + 1] > i {
+                return (j + 2, i - newlines[j]);
+            }
+        }
+        (newlines.len() + 1, i - newlines[newlines.len() - 1])
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub enum VMErrorKind {
+    /// A value which can't be represented in an `f64`.
+    CantRepresentAsDouble,
+    /// A value which can't be represented in an `isize`.
+    CantRepresentAsIsize,
+    /// A value which can't be represented in an `usize`.
+    CantRepresentAsUsize,
+    DivisionByZero,
+    /// A value which is mathematically undefined.
+    DomainError,
+    /// The VM is trying to exit.
+    Exit,
+    /// Tried to access a global before it being initialised.
+    InvalidSymbol,
+    /// Tried to do a shl or shr with a value below zero.
+    NegativeShift,
+    /// A specialised version of TypeError, because SOM has more than one number type (and casts
+    /// between them as necessary) so the `expected` field of `TypeError` doesn't quite work.
+    NotANumber {
+        got: ObjType,
+    },
+    /// Something went wrong when trying to execute a primitive.
+    PrimitiveError,
+    /// Tried to do a shl that would overflow memory and/or not fit in the required integer size.
+    ShiftTooBig,
+    /// A dynamic type error.
+    TypeError {
+        expected: ObjType,
+        got: ObjType,
+    },
+    /// An unknown method.
+    UnknownMethod(String),
+}
+
+impl VMErrorKind {
+    fn to_string(&self) -> String {
+        match self {
+            VMErrorKind::CantRepresentAsDouble => "Can't represent as double".to_owned(),
+            VMErrorKind::CantRepresentAsIsize => {
+                "Can't represent as signed machine integer".to_owned()
+            }
+            VMErrorKind::CantRepresentAsUsize => {
+                "Can't represent as unsigned machine integer".to_owned()
+            }
+            VMErrorKind::DivisionByZero => "Division by zero".to_owned(),
+            VMErrorKind::DomainError => "Domain error".to_owned(),
+            VMErrorKind::Exit => "Exit".to_owned(),
+            VMErrorKind::InvalidSymbol => "Invalid symbol".to_owned(),
+            VMErrorKind::NegativeShift => "Negative shift".to_owned(),
+            VMErrorKind::NotANumber { got } => {
+                format!("Expected a numeric type but got type '{}'", got.as_str())
+            }
+            VMErrorKind::PrimitiveError => "Primitive Error".to_owned(),
+            VMErrorKind::ShiftTooBig => "Shift too big".to_owned(),
+            VMErrorKind::TypeError { expected, got } => format!(
+                "Expected object of type '{}' but got type '{}'",
+                expected.as_str(),
+                got.as_str()
+            ),
+            VMErrorKind::UnknownMethod(name) => format!("Unknown method '{}'", name),
+        }
+    }
+}

--- a/src/lib/vm/mod.rs
+++ b/src/lib/vm/mod.rs
@@ -9,8 +9,12 @@
 //! [`Val::try_downcast`](vm::val::Val::try_downcast)) it to a concrete implementation of `Obj`.
 
 pub mod core;
+pub mod error;
 pub mod objects;
 pub mod somstack;
 pub mod val;
 
-pub use crate::vm::core::{VMError, VMErrorKind, VM};
+pub use crate::vm::{
+    core::VM,
+    error::{VMError, VMErrorKind},
+};

--- a/src/lib/vm/mod.rs
+++ b/src/lib/vm/mod.rs
@@ -13,4 +13,4 @@ pub mod objects;
 pub mod somstack;
 pub mod val;
 
-pub use crate::vm::core::{VMError, VM};
+pub use crate::vm::core::{VMError, VMErrorKind, VM};

--- a/src/lib/vm/objects/block.rs
+++ b/src/lib/vm/objects/block.rs
@@ -5,7 +5,7 @@ use abgc_derive::GcLayout;
 
 use crate::vm::{
     core::{Closure, VM},
-    objects::{Obj, ObjType, StaticObjType},
+    objects::{Method, Obj, ObjType, StaticObjType},
     val::{NotUnboxable, Val},
 };
 
@@ -21,6 +21,7 @@ pub struct BlockInfo {
 
 #[derive(Debug, GcLayout)]
 pub struct Block {
+    pub method: Gc<Method>,
     /// This `Block`'s `self` val. XXX This should probably be part of the corresponding closure's
     /// variables.
     pub inst: Val,
@@ -51,6 +52,7 @@ impl StaticObjType for Block {
 impl Block {
     pub fn new(
         vm: &VM,
+        method: Gc<Method>,
         inst: Val,
         blockinfo_off: usize,
         parent_closure: Gc<Closure>,
@@ -65,6 +67,7 @@ impl Block {
         Val::from_obj(
             vm,
             Block {
+                method,
                 inst,
                 blockn_cls,
                 blockinfo_off,

--- a/src/lib/vm/objects/class.rs
+++ b/src/lib/vm/objects/class.rs
@@ -6,7 +6,8 @@ use abgc::Gc;
 use abgc_derive::GcLayout;
 
 use crate::vm::{
-    core::{VMError, VMErrorKind, VM},
+    core::VM,
+    error::{VMError, VMErrorKind},
     objects::{Method, Obj, ObjType, StaticObjType},
     val::{NotUnboxable, Val},
 };

--- a/src/lib/vm/objects/class.rs
+++ b/src/lib/vm/objects/class.rs
@@ -15,6 +15,8 @@ use crate::vm::{
 pub struct Class {
     pub name: Val,
     pub path: PathBuf,
+    /// Offset to this class's instructions in VM::instrs.
+    pub instrs_off: usize,
     pub supercls: Option<Val>,
     pub num_inst_vars: usize,
     pub methods: HashMap<String, Gc<Method>>,

--- a/src/lib/vm/objects/class.rs
+++ b/src/lib/vm/objects/class.rs
@@ -6,7 +6,7 @@ use abgc::Gc;
 use abgc_derive::GcLayout;
 
 use crate::vm::{
-    core::{VMError, VM},
+    core::{VMError, VMErrorKind, VM},
     objects::{Method, Obj, ObjType, StaticObjType},
     val::{NotUnboxable, Val},
 };
@@ -51,7 +51,7 @@ impl Class {
             .map(|x| Ok(Gc::clone(x)))
             .unwrap_or_else(|| match &self.supercls {
                 Some(scls) => scls.downcast::<Class>(vm)?.get_method(vm, msg),
-                None => Err(Box::new(VMError::UnknownMethod(msg.to_owned()))),
+                None => Err(VMError::new(vm, VMErrorKind::UnknownMethod(msg.to_owned()))),
             })
     }
 

--- a/src/lib/vm/objects/double.rs
+++ b/src/lib/vm/objects/double.rs
@@ -4,7 +4,7 @@ use abgc_derive::GcLayout;
 use num_traits::{ToPrimitive, Zero};
 
 use crate::vm::{
-    core::{VMError, VM},
+    core::{VMError, VMErrorKind, VM},
     objects::{ArbInt, Obj, ObjType, StaticObjType, String_},
     val::{NotUnboxable, Val},
 };
@@ -39,41 +39,47 @@ impl Obj for Double {
         } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
             match rhs.bigint().to_f64() {
                 Some(i) => Ok(Double::new(vm, self.val + i)),
-                None => Err(Box::new(VMError::CantRepresentAsDouble)),
+                None => Err(VMError::new(vm, VMErrorKind::CantRepresentAsDouble)),
             }
         } else {
-            Err(Box::new(VMError::NotANumber {
-                got: other.dyn_objtype(vm),
-            }))
+            Err(VMError::new(
+                vm,
+                VMErrorKind::NotANumber {
+                    got: other.dyn_objtype(vm),
+                },
+            ))
         }
     }
 
     fn double_div(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
         if let Some(rhs) = other.as_isize(vm) {
             if rhs == 0 {
-                Err(Box::new(VMError::DivisionByZero))
+                Err(VMError::new(vm, VMErrorKind::DivisionByZero))
             } else {
                 Ok(Double::new(vm, self.val / (rhs as f64)))
             }
         } else if let Some(rhs) = other.try_downcast::<Double>(vm) {
             if rhs.val == 0f64 {
-                Err(Box::new(VMError::DivisionByZero))
+                Err(VMError::new(vm, VMErrorKind::DivisionByZero))
             } else {
                 Ok(Double::new(vm, self.val / rhs.val))
             }
         } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
             if Zero::is_zero(rhs.bigint()) {
-                Err(Box::new(VMError::DivisionByZero))
+                Err(VMError::new(vm, VMErrorKind::DivisionByZero))
             } else {
                 match rhs.bigint().to_f64() {
                     Some(i) => Ok(Double::new(vm, self.val / i)),
-                    None => Err(Box::new(VMError::CantRepresentAsDouble)),
+                    None => Err(VMError::new(vm, VMErrorKind::CantRepresentAsDouble)),
                 }
             }
         } else {
-            Err(Box::new(VMError::NotANumber {
-                got: other.dyn_objtype(vm),
-            }))
+            Err(VMError::new(
+                vm,
+                VMErrorKind::NotANumber {
+                    got: other.dyn_objtype(vm),
+                },
+            ))
         }
     }
 
@@ -85,12 +91,15 @@ impl Obj for Double {
         } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
             match rhs.bigint().to_f64() {
                 Some(i) => Ok(Double::new(vm, self.val % i)),
-                None => Err(Box::new(VMError::CantRepresentAsDouble)),
+                None => Err(VMError::new(vm, VMErrorKind::CantRepresentAsDouble)),
             }
         } else {
-            Err(Box::new(VMError::NotANumber {
-                got: other.dyn_objtype(vm),
-            }))
+            Err(VMError::new(
+                vm,
+                VMErrorKind::NotANumber {
+                    got: other.dyn_objtype(vm),
+                },
+            ))
         }
     }
 
@@ -102,12 +111,15 @@ impl Obj for Double {
         } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
             match rhs.bigint().to_f64() {
                 Some(i) => Ok(Double::new(vm, self.val * i)),
-                None => Err(Box::new(VMError::CantRepresentAsDouble)),
+                None => Err(VMError::new(vm, VMErrorKind::CantRepresentAsDouble)),
             }
         } else {
-            Err(Box::new(VMError::NotANumber {
-                got: other.dyn_objtype(vm),
-            }))
+            Err(VMError::new(
+                vm,
+                VMErrorKind::NotANumber {
+                    got: other.dyn_objtype(vm),
+                },
+            ))
         }
     }
 
@@ -123,12 +135,15 @@ impl Obj for Double {
         } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
             match rhs.bigint().to_f64() {
                 Some(i) => Ok(Double::new(vm, self.val - i)),
-                None => Err(Box::new(VMError::CantRepresentAsDouble)),
+                None => Err(VMError::new(vm, VMErrorKind::CantRepresentAsDouble)),
             }
         } else {
-            Err(Box::new(VMError::NotANumber {
-                got: other.dyn_objtype(vm),
-            }))
+            Err(VMError::new(
+                vm,
+                VMErrorKind::NotANumber {
+                    got: other.dyn_objtype(vm),
+                },
+            ))
         }
     }
 
@@ -169,9 +184,12 @@ impl Obj for Double {
                 None => false,
             }
         } else {
-            return Err(Box::new(VMError::NotANumber {
-                got: other.dyn_objtype(vm),
-            }));
+            return Err(VMError::new(
+                vm,
+                VMErrorKind::NotANumber {
+                    got: other.dyn_objtype(vm),
+                },
+            ));
         };
 
         Ok(Val::from_bool(vm, b))

--- a/src/lib/vm/objects/double.rs
+++ b/src/lib/vm/objects/double.rs
@@ -4,7 +4,8 @@ use abgc_derive::GcLayout;
 use num_traits::{ToPrimitive, Zero};
 
 use crate::vm::{
-    core::{VMError, VMErrorKind, VM},
+    core::VM,
+    error::{VMError, VMErrorKind},
     objects::{ArbInt, Obj, ObjType, StaticObjType, String_},
     val::{NotUnboxable, Val},
 };

--- a/src/lib/vm/objects/integers.rs
+++ b/src/lib/vm/objects/integers.rs
@@ -18,7 +18,8 @@ use num_bigint::BigInt;
 use num_traits::{FromPrimitive, ToPrimitive, Zero};
 
 use crate::vm::{
-    core::{VMError, VMErrorKind, VM},
+    core::VM,
+    error::{VMError, VMErrorKind},
     objects::{Double, Obj, ObjType, StaticObjType, String_},
     val::{NotUnboxable, Val},
 };

--- a/src/lib/vm/objects/method.rs
+++ b/src/lib/vm/objects/method.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::new_ret_no_self)]
 
+use std::cell::UnsafeCell;
+
 use abgc_derive::GcLayout;
 
 use crate::{
@@ -15,6 +17,7 @@ use crate::{
 pub struct Method {
     pub name: String,
     pub body: MethodBody,
+    class: UnsafeCell<Val>,
 }
 
 #[derive(Debug)]
@@ -46,5 +49,23 @@ impl NotUnboxable for Method {}
 impl StaticObjType for Method {
     fn static_objtype() -> ObjType {
         ObjType::Method
+    }
+}
+
+impl Method {
+    pub fn new(vm: &VM, name: String, body: MethodBody) -> Method {
+        Method {
+            name,
+            body,
+            class: UnsafeCell::new(vm.nil.clone()),
+        }
+    }
+
+    pub fn class(&self) -> Val {
+        unsafe { &*self.class.get() }.clone()
+    }
+
+    pub fn set_class(&self, _: &VM, class: Val) {
+        *unsafe { &mut *self.class.get() } = class;
     }
 }

--- a/src/lib/vm/objects/mod.rs
+++ b/src/lib/vm/objects/mod.rs
@@ -39,10 +39,7 @@ pub use string_::String_;
 use abgc::{self, Gc};
 use natrob::narrowable_abgc;
 
-use crate::vm::{
-    core::{VMError, VM},
-    val::Val,
-};
+use crate::vm::{core::VM, error::VMError, val::Val};
 
 /// The SOM type of objects.
 #[derive(Debug, PartialEq)]
@@ -55,6 +52,21 @@ pub enum ObjType {
     Inst,
     Int,
     String_,
+}
+
+impl ObjType {
+    pub fn as_str(&self) -> &'static str {
+        match *self {
+            ObjType::ArbInt => "ArbInt",
+            ObjType::Block => "Block",
+            ObjType::Class => "Class",
+            ObjType::Double => "Double",
+            ObjType::Method => "Method",
+            ObjType::Inst => "Inst",
+            ObjType::Int => "Int",
+            ObjType::String_ => "String_",
+        }
+    }
 }
 
 /// The main SOM Object trait. Notice that code should almost never call these functions directly:

--- a/src/lib/vm/objects/string_.rs
+++ b/src/lib/vm/objects/string_.rs
@@ -5,7 +5,8 @@ use std::str;
 use abgc_derive::GcLayout;
 
 use crate::vm::{
-    core::{VMError, VM},
+    core::VM,
+    error::VMError,
     objects::{Obj, ObjType, StaticObjType},
     val::{NotUnboxable, Val},
 };

--- a/src/lib/vm/val.rs
+++ b/src/lib/vm/val.rs
@@ -15,7 +15,7 @@ use num_enum::{IntoPrimitive, UnsafeFromPrimitive};
 use num_traits::{FromPrimitive, ToPrimitive, Zero};
 
 use super::{
-    core::{VMError, VM},
+    core::{VMError, VMErrorKind, VM},
     objects::{ArbInt, Double, Int, Obj, ObjType, StaticObjType, String_, ThinObj},
 };
 
@@ -129,20 +129,26 @@ impl Val {
     /// be boxed) or return a `VMError` if the cast is invalid.
     pub fn downcast<T: Obj + StaticObjType + NotUnboxable>(
         &self,
-        _: &VM,
+        vm: &VM,
     ) -> Result<&T, Box<VMError>> {
         match self.valkind() {
-            ValKind::INT => Err(Box::new(VMError::TypeError {
-                expected: T::static_objtype(),
-                got: Int::static_objtype(),
-            })),
+            ValKind::INT => Err(VMError::new(
+                vm,
+                VMErrorKind::TypeError {
+                    expected: T::static_objtype(),
+                    got: Int::static_objtype(),
+                },
+            )),
             ValKind::GCBOX => {
                 let tobj = unsafe { self.val_to_tobj() };
                 tobj.downcast().ok_or_else(|| {
-                    Box::new(VMError::TypeError {
-                        expected: T::static_objtype(),
-                        got: tobj.deref().dyn_objtype(),
-                    })
+                    VMError::new(
+                        vm,
+                        VMErrorKind::TypeError {
+                            expected: T::static_objtype(),
+                            got: tobj.deref().dyn_objtype(),
+                        },
+                    )
                 })
             }
             ValKind::ILLEGAL => unreachable!(),
@@ -314,10 +320,13 @@ impl Val {
             } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
                 return ArbInt::new(vm, BigInt::from_isize(lhs).unwrap() & rhs.bigint());
             }
-            return Err(Box::new(VMError::TypeError {
-                expected: self.dyn_objtype(vm),
-                got: other.dyn_objtype(vm),
-            }));
+            return Err(VMError::new(
+                vm,
+                VMErrorKind::TypeError {
+                    expected: self.dyn_objtype(vm),
+                    got: other.dyn_objtype(vm),
+                },
+            ));
         }
         self.tobj(vm).unwrap().and(vm, other)
     }
@@ -331,7 +340,7 @@ impl Val {
                     val: (self.val / other.val) * (1 << TAG_BITSIZE),
                 });
             } else {
-                return Err(Box::new(VMError::DivisionByZero));
+                return Err(VMError::new(vm, VMErrorKind::DivisionByZero));
             }
         }
         self.tobj(vm).unwrap().div(vm, other)
@@ -342,28 +351,31 @@ impl Val {
         if let Some(lhs) = self.as_isize(vm) {
             if let Some(rhs) = other.as_isize(vm) {
                 if rhs == 0 {
-                    return Err(Box::new(VMError::DivisionByZero));
+                    return Err(VMError::new(vm, VMErrorKind::DivisionByZero));
                 } else {
                     return Ok(Double::new(vm, (lhs as f64) / (rhs as f64)));
                 }
             } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
                 if Zero::is_zero(rhs.bigint()) {
-                    return Err(Box::new(VMError::DivisionByZero));
+                    return Err(VMError::new(vm, VMErrorKind::DivisionByZero));
                 } else if let Some(i) = rhs.bigint().to_f64() {
                     return Ok(Double::new(vm, (lhs as f64) / i));
                 } else {
-                    return Err(Box::new(VMError::CantRepresentAsDouble));
+                    return Err(VMError::new(vm, VMErrorKind::CantRepresentAsDouble));
                 }
             } else if let Some(rhs) = other.try_downcast::<Double>(vm) {
                 if rhs.double() == 0f64 {
-                    return Err(Box::new(VMError::DivisionByZero));
+                    return Err(VMError::new(vm, VMErrorKind::DivisionByZero));
                 } else {
                     return Ok(Double::new(vm, (lhs as f64) / rhs.double()));
                 }
             }
-            return Err(Box::new(VMError::NotANumber {
-                got: other.dyn_objtype(vm),
-            }));
+            return Err(VMError::new(
+                vm,
+                VMErrorKind::NotANumber {
+                    got: other.dyn_objtype(vm),
+                },
+            ));
         }
         self.tobj(vm).unwrap().double_div(vm, other)
     }
@@ -378,9 +390,12 @@ impl Val {
             } else if let Some(rhs) = other.try_downcast::<Double>(vm) {
                 return Ok(Double::new(vm, (lhs as f64) % rhs.double()));
             }
-            return Err(Box::new(VMError::NotANumber {
-                got: other.dyn_objtype(vm),
-            }));
+            return Err(VMError::new(
+                vm,
+                VMErrorKind::NotANumber {
+                    got: other.dyn_objtype(vm),
+                },
+            ));
         }
         self.tobj(vm).unwrap().modulus(vm, other)
     }
@@ -401,9 +416,10 @@ impl Val {
         if let Some(lhs) = self.as_isize(vm) {
             if let Some(rhs) = other.as_isize(vm) {
                 if rhs < 0 {
-                    return Err(Box::new(VMError::NegativeShift));
+                    return Err(VMError::new(vm, VMErrorKind::NegativeShift));
                 } else {
-                    let rhs_i = u32::try_from(rhs).map_err(|_| Box::new(VMError::ShiftTooBig))?;
+                    let rhs_i = u32::try_from(rhs)
+                        .map_err(|_| VMError::new(vm, VMErrorKind::ShiftTooBig))?;
                     if let Some(i) = lhs.checked_shl(rhs_i) {
                         // We have to be careful as shifting bits in an isize can lead to positive
                         // numbers becoming negative in two's complement. For example, on a 64-bit
@@ -422,11 +438,14 @@ impl Val {
                 }
             }
             if other.try_downcast::<ArbInt>(vm).is_some() {
-                return Err(Box::new(VMError::ShiftTooBig));
+                return Err(VMError::new(vm, VMErrorKind::ShiftTooBig));
             }
-            return Err(Box::new(VMError::NotANumber {
-                got: other.dyn_objtype(vm),
-            }));
+            return Err(VMError::new(
+                vm,
+                VMErrorKind::NotANumber {
+                    got: other.dyn_objtype(vm),
+                },
+            ));
         }
         self.tobj(vm).unwrap().shl(vm, other)
     }
@@ -435,7 +454,7 @@ impl Val {
     pub fn sqrt(&self, vm: &VM) -> Result<Val, Box<VMError>> {
         if let Some(lhs) = self.as_isize(vm) {
             if lhs < 0 {
-                return Err(Box::new(VMError::DomainError));
+                return Err(VMError::new(vm, VMErrorKind::DomainError));
             } else {
                 let result = (lhs as f64).sqrt();
                 if result.round() == result {
@@ -467,10 +486,13 @@ impl Val {
             } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
                 return ArbInt::new(vm, BigInt::from_isize(lhs).unwrap() ^ rhs.bigint());
             }
-            return Err(Box::new(VMError::TypeError {
-                expected: self.dyn_objtype(vm),
-                got: other.dyn_objtype(vm),
-            }));
+            return Err(VMError::new(
+                vm,
+                VMErrorKind::TypeError {
+                    expected: self.dyn_objtype(vm),
+                    got: other.dyn_objtype(vm),
+                },
+            ));
         }
         self.tobj(vm).unwrap().xor(vm, other)
     }
@@ -518,7 +540,7 @@ macro_rules! binop_typeerror {
                         Ok(Val::from_bool(vm,
                             &BigInt::from_isize(lhs).unwrap() $op rhs.bigint()))
                     } else {
-                        Err(Box::new(VMError::NotANumber {
+                        Err(VMError::new(vm, VMErrorKind::NotANumber {
                           got: other.dyn_objtype(vm),
                         }))
                     }
@@ -576,7 +598,7 @@ impl Drop for Val {
 mod tests {
     use super::*;
     use crate::vm::{
-        core::{VMError, VM},
+        core::VM,
         objects::{Class, ObjType, String_},
     };
 
@@ -674,8 +696,8 @@ mod tests {
         let v = String_::new(&vm, "s".to_owned(), true);
         assert!(v.downcast::<String_>(&vm).is_ok());
         assert_eq!(
-            *v.downcast::<Class>(&vm).unwrap_err(),
-            VMError::TypeError {
+            v.downcast::<Class>(&vm).unwrap_err().kind,
+            VMErrorKind::TypeError {
                 expected: ObjType::Class,
                 got: ObjType::String_
             }

--- a/src/lib/vm/val.rs
+++ b/src/lib/vm/val.rs
@@ -15,7 +15,8 @@ use num_enum::{IntoPrimitive, UnsafeFromPrimitive};
 use num_traits::{FromPrimitive, ToPrimitive, Zero};
 
 use super::{
-    core::{VMError, VMErrorKind, VM},
+    core::VM,
+    error::{VMError, VMErrorKind},
     objects::{ArbInt, Double, Int, Obj, ObjType, StaticObjType, String_, ThinObj},
 };
 
@@ -61,7 +62,7 @@ pub trait NotUnboxable {}
 pub struct Val {
     // We use this usize for pointer tagging. Needless to say, this is highly dangerous, and needs
     // several parts of the code to cooperate in order to be correct.
-    val: usize,
+    pub val: usize,
 }
 
 impl Val {

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use std::{
 
 use getopts::Options;
 
-use yksom::vm::{objects::Inst, VMError, VM};
+use yksom::vm::{objects::Inst, VMError, VMErrorKind, VM};
 
 fn usage(prog: &str) -> ! {
     let path = Path::new(prog);
@@ -37,9 +37,13 @@ fn main() {
     let cls = vm.compile(&Path::new(&matches.free[0]).canonicalize().unwrap(), true);
     let app = Inst::new(&vm, cls);
     match vm.send(app, "run", vec![]) {
-        Ok(_) | Err(box VMError::Exit) => (),
+        Ok(_)
+        | Err(box VMError {
+            kind: VMErrorKind::Exit,
+            ..
+        }) => (),
         Err(e) => {
-            eprintln!("{:?}", e);
+            eprintln!("{:?}", e.kind);
             process::exit(1);
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,7 +43,7 @@ fn main() {
             ..
         }) => (),
         Err(e) => {
-            eprintln!("{:?}", e.kind);
+            e.console_print(&vm);
             process::exit(1);
         }
     }


### PR DESCRIPTION
Although SOM has the `halt` instruction to get a backtrace, I find it more useful to have a backtrace automatically printed when an error occurs. Thus yksom has had internal support from day one for percolating errors up the call stack.

This PR extends that such that we can print out detailed backtraces such as the following (for [this program](https://github.com/ltratt/yksom/blob/f76bff84c8abdb3890c365c9822ef63e24835996/lang_tests/nested_backtrace2.som)):

![image](https://user-images.githubusercontent.com/20318/75908736-a0644600-5e42-11ea-9689-662bb6eec4b2.png)

Note that this is not just printing out the call-stack, but it is highlighting the portion of line(s) which pertain to the error.

This PR is a bit scary, but there's a *lot* of boiler plate because we have to adjust lots of lang_tests. It's split into four bits:

 1) We track the `Span` that each instruction relates to https://github.com/softdevteam/yksom/commit/e222959159c91b7b34947bca4e37f7008da371ac
 2) We need to be able to track the call-stack with an error, so `VMError` needs to become a `struct` (the simple part of this in https://github.com/softdevteam/yksom/commit/f21e04090dd1471ea284e20fdcae76a3f6e36c86)
 3) Print out backtraces without highlighting (which requires changing lang_tests too) https://github.com/softdevteam/yksom/commit/4bcb29665486d00838fd0223290d5bb324412ed0
 4) Do the fancy terminal highlighting stuff https://github.com/softdevteam/yksom/commit/f76bff84c8abdb3890c365c9822ef63e24835996

Out of those it's really #3 that's the most imposing, and that's because of the lang_test adjustments which you can go over very quickly.