### PR TITLE
Reduce the quantity of explicitly unsafe code

### DIFF
--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -12,6 +12,7 @@
 
 #![feature(alloc_layout_extra)]
 #![feature(allocator_api)]
+#![feature(cell_update)]
 #![feature(coerce_unsized)]
 #![feature(specialization)]
 #![feature(unsize)]

--- a/src/lib/vm/somstack.rs
+++ b/src/lib/vm/somstack.rs
@@ -1,5 +1,6 @@
 use std::{
     alloc::{alloc, dealloc, Layout},
+    cell::Cell,
     mem::forget,
     ptr,
 };
@@ -14,14 +15,17 @@ pub const SOM_STACK_LEN: usize = 4096;
 pub struct SOMStack {
     storage: *mut Val,
     /// How many items are used? Note that the stack has an implicit capacity of [`SOM_STACK_LEN`].
-    len: usize,
+    len: Cell<usize>,
 }
 
 impl SOMStack {
     pub fn new() -> SOMStack {
         #![allow(clippy::cast_ptr_alignment)]
         let storage = unsafe { alloc(Layout::array::<Val>(SOM_STACK_LEN).unwrap()) as *mut Val };
-        SOMStack { storage, len: 0 }
+        SOMStack {
+            storage,
+            len: Cell::new(0),
+        }
     }
 
     /// Returns `true` if the stack contains no elements.
@@ -31,7 +35,7 @@ impl SOMStack {
 
     /// Returns the number of elements in the stack.
     pub fn len(&self) -> usize {
-        self.len
+        self.len.get()
     }
 
     /// Returns the number of elements the stack can store before running out of room.
@@ -43,7 +47,7 @@ impl SOMStack {
     /// this function will lead to undefined behaviour.
     pub fn peek(&self) -> Val {
         debug_assert!(!self.is_empty());
-        let v = unsafe { ptr::read(self.storage.add(self.len - 1)) };
+        let v = unsafe { ptr::read(self.storage.add(self.len.get() - 1)) };
         let v2 = v.clone();
         forget(v);
         v2
@@ -51,18 +55,18 @@ impl SOMStack {
 
     /// Pops the top-most value of the stack and returns it. If the stack is empty, calling
     /// this function will lead to undefined behaviour.
-    pub fn pop(&mut self) -> Val {
+    pub fn pop(&self) -> Val {
         debug_assert!(!self.is_empty());
-        self.len -= 1;
-        unsafe { ptr::read(self.storage.add(self.len)) }
+        self.len.update(|x| x - 1);
+        unsafe { ptr::read(self.storage.add(self.len.get())) }
     }
 
     /// Pops the top-most value of the stack and returns it. If the stack is empty, calling
     /// this function will lead to undefined behaviour.
-    pub fn pop_n(&mut self, n: usize) -> Val {
+    pub fn pop_n(&self, n: usize) -> Val {
         debug_assert!(n < self.len());
-        self.len -= 1;
-        let i = self.len - n;
+        self.len.update(|x| x - 1);
+        let i = self.len.get() - n;
         let v = unsafe { ptr::read(self.storage.add(i)) };
         unsafe { ptr::copy(self.storage.add(i + 1), self.storage.add(i), n) };
         v
@@ -71,21 +75,21 @@ impl SOMStack {
     /// Push `v` onto the end of the stack. You must previously have checked (using
     /// [`SOMStack::remaining_capacity`]) that there is room for this value: if there is not,
     /// undefined behaviour will occur.
-    pub fn push(&mut self, v: Val) {
+    pub fn push(&self, v: Val) {
         debug_assert!(self.remaining_capacity() > 0);
-        unsafe { ptr::write(self.storage.add(self.len), v) };
-        self.len += 1;
+        unsafe { ptr::write(self.storage.add(self.len.get()), v) };
+        self.len.update(|x| x + 1);
     }
 
     /// Shortens the stack, keeping the first len elements and dropping the rest.
-    pub fn truncate(&mut self, len: usize) {
+    pub fn truncate(&self, len: usize) {
         debug_assert!(len <= self.len());
-        for i in len..self.len {
+        for i in len..self.len.get() {
             unsafe {
                 ptr::read(self.storage.add(i));
             }
         }
-        self.len = len;
+        self.len.set(len);
     }
 }
 


### PR DESCRIPTION
This PR is in two stages: first of all it gives `SOMStack` (the SOM stack of values) an immutable API (https://github.com/softdevteam/yksom/commit/d8cb3ce47c2495e590833efced89228f7bf55000) and then uses that to reduce the `unsafe` code in the main interpreter (https://github.com/softdevteam/yksom/commit/af582fe8138fc074c043e897ff8ff5fb944ac23e). This should make it harder to reintroduce the incorrect code we addressed in #102.

[Note that `SOMStack` is not thread-safe, but that's OK a) because the use of `Cell` means that it is not `Sync` b) SOM is single-threaded.]