### PR TITLE
Remove as many UnsafeCells as possible

### DIFF
--- a/src/lib/compiler/mod.rs
+++ b/src/lib/compiler/mod.rs
@@ -20,7 +20,7 @@ lrpar_mod!("lib/compiler/som.y");
 type StorageT = u32;
 
 /// Compile a class. Should only be called by the `VM`.
-pub fn compile(vm: &VM, path: &Path) -> Val {
+pub fn compile(vm: &mut VM, path: &Path) -> Val {
     let bytes = fs::read(path).unwrap_or_else(|_| panic!("Can't read {}.", path.to_str().unwrap()));
     let txt = String::from_utf8_lossy(&bytes);
 
@@ -32,7 +32,7 @@ pub fn compile(vm: &VM, path: &Path) -> Val {
     }
     match astopt {
         Some(Ok(astcls)) => {
-            let cls = ast_to_instrs::Compiler::compile(&vm, &lexer, &path, &astcls).unwrap_or_else(
+            let cls = ast_to_instrs::Compiler::compile(vm, &lexer, &path, &astcls).unwrap_or_else(
                 |msg| {
                     eprintln!("{}", msg);
                     process::exit(1);

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -12,7 +12,6 @@
 
 #![feature(alloc_layout_extra)]
 #![feature(allocator_api)]
-#![feature(cell_update)]
 #![feature(coerce_unsized)]
 #![feature(specialization)]
 #![feature(unsize)]

--- a/src/lib/vm/core.rs
+++ b/src/lib/vm/core.rs
@@ -481,12 +481,14 @@ impl VM {
 
         match prim {
             Primitive::Add => {
-                let v = stry!(rcv.add(self, self.stack.pop()));
+                let v = self.stack.pop();
+                let v = stry!(rcv.add(self, v));
                 self.stack.push(v);
                 SendReturn::Val
             }
             Primitive::And => {
-                let v = stry!(rcv.and(self, self.stack.pop()));
+                let v = self.stack.pop();
+                let v = stry!(rcv.and(self, v));
                 self.stack.push(v);
                 SendReturn::Val
             }
@@ -501,7 +503,8 @@ impl VM {
                 SendReturn::Val
             }
             Primitive::BitXor => {
-                let v = stry!(rcv.xor(self, self.stack.pop()));
+                let v = self.stack.pop();
+                let v = stry!(rcv.xor(self, v));
                 self.stack.push(v);
                 SendReturn::Val
             }
@@ -517,17 +520,20 @@ impl VM {
                 SendReturn::Val
             }
             Primitive::Div => {
-                let v = stry!(rcv.div(self, self.stack.pop()));
+                let v = self.stack.pop();
+                let v = stry!(rcv.div(self, v));
                 self.stack.push(v);
                 SendReturn::Val
             }
             Primitive::DoubleDiv => {
-                let v = stry!(rcv.double_div(self, self.stack.pop()));
+                let v = self.stack.pop();
+                let v = stry!(rcv.double_div(self, v));
                 self.stack.push(v);
                 SendReturn::Val
             }
             Primitive::Equals => {
-                let v = stry!(rcv.equals(self, self.stack.pop()));
+                let v = self.stack.pop();
+                let v = stry!(rcv.equals(self, v));
                 self.stack.push(v);
                 SendReturn::Val
             }
@@ -570,12 +576,14 @@ impl VM {
                 SendReturn::Val
             }
             Primitive::GreaterThan => {
-                let v = stry!(rcv.greater_than(self, self.stack.pop()));
+                let v = self.stack.pop();
+                let v = stry!(rcv.greater_than(self, v));
                 self.stack.push(v);
                 SendReturn::Val
             }
             Primitive::GreaterThanEquals => {
-                let v = stry!(rcv.greater_than_equals(self, self.stack.pop()));
+                let v = self.stack.pop();
+                let v = stry!(rcv.greater_than_equals(self, v));
                 self.stack.push(v);
                 SendReturn::Val
             }
@@ -586,12 +594,14 @@ impl VM {
             Primitive::InstVarAtPut => unimplemented!(),
             Primitive::InstVarNamed => unimplemented!(),
             Primitive::LessThan => {
-                let v = stry!(rcv.less_than(self, self.stack.pop()));
+                let v = self.stack.pop();
+                let v = stry!(rcv.less_than(self, v));
                 self.stack.push(v);
                 SendReturn::Val
             }
             Primitive::LessThanEquals => {
-                let v = stry!(rcv.less_than_equals(self, self.stack.pop()));
+                let v = self.stack.pop();
+                let v = stry!(rcv.less_than_equals(self, v));
                 self.stack.push(v);
                 SendReturn::Val
             }
@@ -612,12 +622,14 @@ impl VM {
                 SendReturn::Val
             }
             Primitive::Mod => {
-                let v = stry!(rcv.modulus(self, self.stack.pop()));
+                let v = self.stack.pop();
+                let v = stry!(rcv.modulus(self, v));
                 self.stack.push(v);
                 SendReturn::Val
             }
             Primitive::Mul => {
-                let v = stry!(rcv.mul(self, self.stack.pop()));
+                let v = self.stack.pop();
+                let v = stry!(rcv.mul(self, v));
                 self.stack.push(v);
                 SendReturn::Val
             }
@@ -632,7 +644,8 @@ impl VM {
                 SendReturn::Val
             }
             Primitive::NotEquals => {
-                let v = stry!(rcv.not_equals(self, self.stack.pop()));
+                let v = self.stack.pop();
+                let v = stry!(rcv.not_equals(self, v));
                 self.stack.push(v);
                 SendReturn::Val
             }
@@ -642,7 +655,8 @@ impl VM {
             Primitive::PerformWithArguments => unimplemented!(),
             Primitive::PerformWithArgumentsInSuperClass => unimplemented!(),
             Primitive::RefEquals => {
-                let v = stry!(rcv.ref_equals(self, self.stack.pop()));
+                let v = self.stack.pop();
+                let v = stry!(rcv.ref_equals(self, v));
                 self.stack.push(v);
                 SendReturn::Val
             }
@@ -662,7 +676,8 @@ impl VM {
                 SendReturn::Val
             }
             Primitive::Shl => {
-                let v = stry!(rcv.shl(self, self.stack.pop()));
+                let v = self.stack.pop();
+                let v = stry!(rcv.shl(self, v));
                 self.stack.push(v);
                 SendReturn::Val
             }
@@ -672,7 +687,8 @@ impl VM {
                 SendReturn::Val
             }
             Primitive::Sub => {
-                let v = stry!(rcv.sub(self, self.stack.pop()));
+                let v = self.stack.pop();
+                let v = stry!(rcv.sub(self, v));
                 self.stack.push(v);
                 SendReturn::Val
             }

--- a/src/lib/vm/core.rs
+++ b/src/lib/vm/core.rs
@@ -85,7 +85,7 @@ pub struct VM {
     /// `usize` where the latter represents the index of the string in `strings`.
     reverse_strings: HashMap<String, usize>,
     symbols: Vec<Val>,
-    reverse_symbols: UnsafeCell<HashMap<String, usize>>,
+    reverse_symbols: HashMap<String, usize>,
     frames: UnsafeCell<Vec<Frame>>,
 }
 
@@ -130,7 +130,7 @@ impl VM {
             strings: Vec::new(),
             reverse_strings: HashMap::new(),
             symbols: Vec::new(),
-            reverse_symbols: UnsafeCell::new(HashMap::new()),
+            reverse_symbols: HashMap::new(),
             frames: UnsafeCell::new(Vec::new()),
         };
         // The very delicate phase.
@@ -839,14 +839,13 @@ impl VM {
     /// Add the symbol `s` to the VM, returning its index. Note that symbols are reused, so indexes
     /// are also reused.
     pub fn add_symbol(&mut self, s: String) -> usize {
-        let reverse_symbols = unsafe { &mut *self.reverse_symbols.get() };
         // We want to avoid `clone`ing `s` in the (hopefully common) case of a cache hit, hence
         // this slightly laborious dance and double-lookup.
-        if let Some(i) = reverse_symbols.get(&s) {
+        if let Some(i) = self.reverse_symbols.get(&s) {
             *i
         } else {
             let len = self.symbols.len();
-            reverse_symbols.insert(s.clone(), len);
+            self.reverse_symbols.insert(s.clone(), len);
             let v = String_::new(self, s, false);
             self.symbols.push(v);
             len
@@ -1063,7 +1062,7 @@ impl VM {
             strings: Vec::new(),
             reverse_strings: HashMap::new(),
             symbols: Vec::new(),
-            reverse_symbols: UnsafeCell::new(HashMap::new()),
+            reverse_symbols: HashMap::new(),
             frames: UnsafeCell::new(Vec::new()),
         }
     }

--- a/src/lib/vm/core.rs
+++ b/src/lib/vm/core.rs
@@ -84,7 +84,7 @@ pub struct VM {
     /// reverse_strings is an optimisation allowing us to reuse strings: it maps a `String to a
     /// `usize` where the latter represents the index of the string in `strings`.
     reverse_strings: HashMap<String, usize>,
-    symbols: UnsafeCell<Vec<Val>>,
+    symbols: Vec<Val>,
     reverse_symbols: UnsafeCell<HashMap<String, usize>>,
     frames: UnsafeCell<Vec<Frame>>,
 }
@@ -129,7 +129,7 @@ impl VM {
             stack: SOMStack::new(),
             strings: Vec::new(),
             reverse_strings: HashMap::new(),
-            symbols: UnsafeCell::new(Vec::new()),
+            symbols: Vec::new(),
             reverse_symbols: UnsafeCell::new(HashMap::new()),
             frames: UnsafeCell::new(Vec::new()),
         };
@@ -455,8 +455,8 @@ impl VM {
                     pc += 1;
                 }
                 Instr::Symbol(symbol_off) => {
-                    debug_assert!(unsafe { &*self.symbols.get() }.len() > symbol_off);
-                    let s = unsafe { (&*self.symbols.get()).get_unchecked(symbol_off) }.clone();
+                    debug_assert!(self.symbols.len() > symbol_off);
+                    let s = unsafe { self.symbols.get_unchecked(symbol_off) }.clone();
                     self.stack.push(s);
                     pc += 1;
                 }
@@ -845,10 +845,10 @@ impl VM {
         if let Some(i) = reverse_symbols.get(&s) {
             *i
         } else {
-            let symbols = unsafe { &mut *self.symbols.get() };
-            let len = symbols.len();
+            let len = self.symbols.len();
             reverse_symbols.insert(s.clone(), len);
-            symbols.push(String_::new(self, s, false));
+            let v = String_::new(self, s, false);
+            self.symbols.push(v);
             len
         }
     }
@@ -1062,7 +1062,7 @@ impl VM {
             stack: SOMStack::new(),
             strings: Vec::new(),
             reverse_strings: HashMap::new(),
-            symbols: UnsafeCell::new(Vec::new()),
+            symbols: Vec::new(),
             reverse_symbols: UnsafeCell::new(HashMap::new()),
             frames: UnsafeCell::new(Vec::new()),
         }

--- a/src/lib/vm/core.rs
+++ b/src/lib/vm/core.rs
@@ -40,10 +40,7 @@ enum SendReturn {
     Val,
 }
 
-/// The core VM struct. Although SOM is single-threaded, we roughly model what a multi-threaded VM
-/// would need to look like. That is, since this struct would need to be shared between threads and
-/// called without a single lock, thread-safety would need to be handled internally. We model that
-/// with [`UnsafeCell`].
+/// The core VM struct.
 pub struct VM {
     classpath: Vec<String>,
     pub block_cls: Val,
@@ -765,10 +762,6 @@ impl VM {
     }
 
     /// Lookup the method `name` in the class `rcv_cls`, utilising the inline cache at index `idx`.
-    ///
-    /// # Guarantees for UnsafeCell
-    ///
-    /// This method guarantees not to mutate `self.sends`.
     pub fn inline_cache_lookup(
         &mut self,
         idx: usize,

--- a/src/lib/vm/core.rs
+++ b/src/lib/vm/core.rs
@@ -187,8 +187,8 @@ impl VM {
         cls_val
     }
 
-    fn find_class(&mut self, name: &str) -> Result<PathBuf, ()> {
-        for dn in &mut self.classpath {
+    fn find_class(&self, name: &str) -> Result<PathBuf, ()> {
+        for dn in &self.classpath {
             let mut pb = PathBuf::new();
             pb.push(dn);
             pb.push(name);
@@ -213,7 +213,7 @@ impl VM {
     }
 
     /// Inform the user of the error string `error` and then exit.
-    pub fn error(&mut self, error: &str) -> ! {
+    pub fn error(&self, error: &str) -> ! {
         eprintln!("{}", error);
         process::exit(1);
     }
@@ -731,7 +731,7 @@ impl VM {
         }
     }
 
-    fn current_frame(&mut self) -> &Frame {
+    fn current_frame(&self) -> &Frame {
         debug_assert!(!self.frames.is_empty());
         let frames_len = self.frames.len();
         unsafe { self.frames.get_unchecked(frames_len - 1) }
@@ -741,7 +741,7 @@ impl VM {
         self.frames.pop();
     }
 
-    pub fn frames_len(&mut self) -> usize {
+    pub fn frames_len(&self) -> usize {
         self.frames.len()
     }
 
@@ -790,7 +790,7 @@ impl VM {
     }
 
     /// How many instructions are currently present in the VM?
-    pub fn instrs_len(&mut self) -> usize {
+    pub fn instrs_len(&self) -> usize {
         self.instrs.len()
     }
 
@@ -866,9 +866,8 @@ impl VM {
     }
 
     /// Lookup the global `name`: if it has not been added, or has been added but not set, then
-    /// `self.nil` will be returned. Notice that this does not change the stored value for this
-    /// global.
-    pub fn get_global_or_nil(&mut self, name: &str) -> Val {
+    /// `self.nil` will be returned.
+    pub fn get_global_or_nil(&self, name: &str) -> Val {
         if let Some(i) = self.reverse_globals.get(name).cloned() {
             let v = &self.globals[i];
             if v.valkind() != ValKind::ILLEGAL {
@@ -880,7 +879,7 @@ impl VM {
 
     /// Get the global at position `i`: if it has not been set (i.e. is `ValKind::ILLEGAL`) this
     /// will return `Err(...)`.
-    pub fn get_legal_global(&mut self, i: usize) -> Result<Val, Box<VMError>> {
+    pub fn get_legal_global(&self, i: usize) -> Result<Val, Box<VMError>> {
         let v = &self.globals[i];
         if v.valkind() != ValKind::ILLEGAL {
             return Ok(v.clone());

--- a/src/lib/vm/core.rs
+++ b/src/lib/vm/core.rs
@@ -64,7 +64,7 @@ pub struct VM {
     pub system: Val,
     pub true_: Val,
     blockinfos: Vec<BlockInfo>,
-    classes: UnsafeCell<Vec<Val>>,
+    classes: Vec<Val>,
     /// The current known set of globals including those not yet assigned to: in other words, it is
     /// expected that some entries of this `Vec` are illegal (i.e. created by `Val::illegal`).
     globals: UnsafeCell<Vec<Val>>,
@@ -117,7 +117,7 @@ impl VM {
             system: Val::illegal(),
             true_: Val::illegal(),
             blockinfos: Vec::new(),
-            classes: UnsafeCell::new(Vec::new()),
+            classes: Vec::new(),
             globals: UnsafeCell::new(Vec::new()),
             reverse_globals: UnsafeCell::new(HashMap::new()),
             inline_caches: UnsafeCell::new(Vec::new()),
@@ -182,7 +182,7 @@ impl VM {
         if !inst_vars_allowed && cls.num_inst_vars > 0 {
             panic!("No instance vars allowed in {}", path.to_str().unwrap());
         }
-        unsafe { &mut *self.classes.get() }.push(cls_val.clone());
+        self.classes.push(cls_val.clone());
         cls_val
     }
 
@@ -1060,7 +1060,7 @@ impl VM {
             system: Val::illegal(),
             true_: Val::illegal(),
             blockinfos: Vec::new(),
-            classes: UnsafeCell::new(Vec::new()),
+            classes: Vec::new(),
             globals: UnsafeCell::new(Vec::new()),
             reverse_globals: UnsafeCell::new(HashMap::new()),
             inline_caches: UnsafeCell::new(Vec::new()),

--- a/src/lib/vm/core.rs
+++ b/src/lib/vm/core.rs
@@ -728,10 +728,10 @@ impl VM {
         }
     }
 
-    fn current_frame(&self) -> &Frame {
+    fn current_frame(&mut self) -> &mut Frame {
         debug_assert!(!self.frames.is_empty());
         let frames_len = self.frames.len();
-        unsafe { self.frames.get_unchecked(frames_len - 1) }
+        unsafe { self.frames.get_unchecked_mut(frames_len - 1) }
     }
 
     fn frame_pop(&mut self) {
@@ -909,7 +909,7 @@ impl VM {
 pub struct Frame {
     /// Stack pointer. Note that this is updated lazily (i.e. it might not be accurate at all
     /// points, but it is guaranteed to be correct over function calls).
-    sp: UnsafeCell<usize>,
+    sp: usize,
     closure: Gc<Closure>,
 }
 
@@ -943,7 +943,7 @@ impl Frame {
         }
 
         Frame {
-            sp: UnsafeCell::new(0),
+            sp: 0,
             closure: Gc::new(Closure::new(parent_closure, vars)),
         }
     }
@@ -952,7 +952,7 @@ impl Frame {
         self.closure(depth).get_var(var)
     }
 
-    fn var_set(&self, depth: usize, var: usize, val: Val) {
+    fn var_set(&mut self, depth: usize, var: usize, val: Val) {
         self.closure(depth).set_var(var, val);
     }
 
@@ -969,12 +969,12 @@ impl Frame {
 
     /// Return this frame's stack pointer.
     fn sp(&self) -> usize {
-        *unsafe { &*self.sp.get() }
+        self.sp
     }
 
     /// Set this frame's stack pointer to `sp`.
-    fn set_sp(&self, sp: usize) {
-        *unsafe { &mut *self.sp.get() } = sp;
+    fn set_sp(&mut self, sp: usize) {
+        self.sp = sp;
     }
 }
 

--- a/src/lib/vm/core.rs
+++ b/src/lib/vm/core.rs
@@ -83,7 +83,7 @@ pub struct VM {
     strings: UnsafeCell<Vec<Val>>,
     /// reverse_strings is an optimisation allowing us to reuse strings: it maps a `String to a
     /// `usize` where the latter represents the index of the string in `strings`.
-    reverse_strings: UnsafeCell<HashMap<String, usize>>,
+    reverse_strings: HashMap<String, usize>,
     symbols: UnsafeCell<Vec<Val>>,
     reverse_symbols: UnsafeCell<HashMap<String, usize>>,
     frames: UnsafeCell<Vec<Frame>>,
@@ -128,7 +128,7 @@ impl VM {
             reverse_sends: HashMap::new(),
             stack: SOMStack::new(),
             strings: UnsafeCell::new(Vec::new()),
-            reverse_strings: UnsafeCell::new(HashMap::new()),
+            reverse_strings: HashMap::new(),
             symbols: UnsafeCell::new(Vec::new()),
             reverse_symbols: UnsafeCell::new(HashMap::new()),
             frames: UnsafeCell::new(Vec::new()),
@@ -823,15 +823,14 @@ impl VM {
     /// Add the string `s` to the VM, returning its index. Note that strings are reused, so indexes
     /// are also reused.
     pub fn add_string(&mut self, s: String) -> usize {
-        let reverse_strings = unsafe { &mut *self.reverse_strings.get() };
         // We want to avoid `clone`ing `s` in the (hopefully common) case of a cache hit, hence
         // this slightly laborious dance and double-lookup.
-        if let Some(i) = reverse_strings.get(&s) {
+        if let Some(i) = self.reverse_strings.get(&s) {
             *i
         } else {
             let strings = unsafe { &mut *self.strings.get() };
             let len = strings.len();
-            reverse_strings.insert(s.clone(), len);
+            self.reverse_strings.insert(s.clone(), len);
             strings.push(String_::new(self, s, true));
             len
         }
@@ -1062,7 +1061,7 @@ impl VM {
             reverse_sends: HashMap::new(),
             stack: SOMStack::new(),
             strings: UnsafeCell::new(Vec::new()),
-            reverse_strings: UnsafeCell::new(HashMap::new()),
+            reverse_strings: HashMap::new(),
             symbols: UnsafeCell::new(Vec::new()),
             reverse_symbols: UnsafeCell::new(HashMap::new()),
             frames: UnsafeCell::new(Vec::new()),

--- a/src/lib/vm/error.rs
+++ b/src/lib/vm/error.rs
@@ -17,12 +17,12 @@ pub struct VMError {
 }
 
 impl VMError {
-    pub fn new(vm: &mut VM, kind: VMErrorKind) -> Box<Self> {
+    pub fn new(vm: &VM, kind: VMErrorKind) -> Box<Self> {
         let backtrace = Vec::with_capacity(vm.frames_len());
         Box::new(VMError { kind, backtrace })
     }
 
-    pub fn console_print(&self, vm: &mut VM) {
+    pub fn console_print(&self, vm: &VM) {
         eprintln!("Traceback (most recent call at bottom):");
         for (method, span) in self.backtrace.iter().rev() {
             let cls_val = method.class();
@@ -163,7 +163,7 @@ pub enum VMErrorKind {
 }
 
 impl VMErrorKind {
-    fn to_string(&self, _: &mut VM) -> String {
+    fn to_string(&self, _: &VM) -> String {
         match self {
             VMErrorKind::CantRepresentAsDouble => "Can't represent as double".to_owned(),
             VMErrorKind::CantRepresentAsIsize => {

--- a/src/lib/vm/error.rs
+++ b/src/lib/vm/error.rs
@@ -17,12 +17,12 @@ pub struct VMError {
 }
 
 impl VMError {
-    pub fn new(vm: &VM, kind: VMErrorKind) -> Box<Self> {
+    pub fn new(vm: &mut VM, kind: VMErrorKind) -> Box<Self> {
         let backtrace = Vec::with_capacity(vm.frames_len());
         Box::new(VMError { kind, backtrace })
     }
 
-    pub fn console_print(&self, vm: &VM) {
+    pub fn console_print(&self, vm: &mut VM) {
         eprintln!("Traceback (most recent call at bottom):");
         for (method, span) in self.backtrace.iter().rev() {
             let cls_val = method.class();
@@ -163,7 +163,7 @@ pub enum VMErrorKind {
 }
 
 impl VMErrorKind {
-    fn to_string(&self, _: &VM) -> String {
+    fn to_string(&self, _: &mut VM) -> String {
         match self {
             VMErrorKind::CantRepresentAsDouble => "Can't represent as double".to_owned(),
             VMErrorKind::CantRepresentAsIsize => {

--- a/src/lib/vm/objects/block.rs
+++ b/src/lib/vm/objects/block.rs
@@ -36,7 +36,7 @@ impl Obj for Block {
         ObjType::Block
     }
 
-    fn get_class(&self, _: &VM) -> Val {
+    fn get_class(&self, _: &mut VM) -> Val {
         self.blockn_cls.clone()
     }
 }
@@ -51,7 +51,7 @@ impl StaticObjType for Block {
 
 impl Block {
     pub fn new(
-        vm: &VM,
+        vm: &mut VM,
         method: Gc<Method>,
         inst: Val,
         blockinfo_off: usize,

--- a/src/lib/vm/objects/class.rs
+++ b/src/lib/vm/objects/class.rs
@@ -28,7 +28,7 @@ impl Obj for Class {
         ObjType::Class
     }
 
-    fn get_class(&self, vm: &VM) -> Val {
+    fn get_class(&self, vm: &mut VM) -> Val {
         vm.cls_cls.clone()
     }
 }
@@ -42,11 +42,11 @@ impl StaticObjType for Class {
 }
 
 impl Class {
-    pub fn name(&self, _: &VM) -> Result<Val, Box<VMError>> {
+    pub fn name(&self, _: &mut VM) -> Result<Val, Box<VMError>> {
         Ok(self.name.clone())
     }
 
-    pub fn get_method(&self, vm: &VM, msg: &str) -> Result<Gc<Method>, Box<VMError>> {
+    pub fn get_method(&self, vm: &mut VM, msg: &str) -> Result<Gc<Method>, Box<VMError>> {
         self.methods
             .get(msg)
             .map(|x| Ok(Gc::clone(x)))
@@ -56,7 +56,7 @@ impl Class {
             })
     }
 
-    pub fn superclass(&self, vm: &VM) -> Val {
+    pub fn superclass(&self, vm: &mut VM) -> Val {
         if let Some(superclass) = &self.supercls {
             return superclass.clone();
         }

--- a/src/lib/vm/objects/class.rs
+++ b/src/lib/vm/objects/class.rs
@@ -42,11 +42,11 @@ impl StaticObjType for Class {
 }
 
 impl Class {
-    pub fn name(&self, _: &mut VM) -> Result<Val, Box<VMError>> {
+    pub fn name(&self, _: &VM) -> Result<Val, Box<VMError>> {
         Ok(self.name.clone())
     }
 
-    pub fn get_method(&self, vm: &mut VM, msg: &str) -> Result<Gc<Method>, Box<VMError>> {
+    pub fn get_method(&self, vm: &VM, msg: &str) -> Result<Gc<Method>, Box<VMError>> {
         self.methods
             .get(msg)
             .map(|x| Ok(Gc::clone(x)))
@@ -56,7 +56,7 @@ impl Class {
             })
     }
 
-    pub fn superclass(&self, vm: &mut VM) -> Val {
+    pub fn superclass(&self, vm: &VM) -> Val {
         if let Some(superclass) = &self.supercls {
             return superclass.clone();
         }

--- a/src/lib/vm/objects/double.rs
+++ b/src/lib/vm/objects/double.rs
@@ -23,16 +23,16 @@ impl Obj for Double {
         ObjType::Double
     }
 
-    fn get_class(&self, vm: &VM) -> Val {
+    fn get_class(&self, vm: &mut VM) -> Val {
         vm.double_cls.clone()
     }
 
-    fn to_strval(&self, vm: &VM) -> Result<Val, Box<VMError>> {
+    fn to_strval(&self, vm: &mut VM) -> Result<Val, Box<VMError>> {
         let mut buf = ryu::Buffer::new();
         Ok(String_::new(vm, buf.format(self.val).to_owned(), true))
     }
 
-    fn add(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn add(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         if let Some(rhs) = other.as_isize(vm) {
             Ok(Double::new(vm, self.val + (rhs as f64)))
         } else if let Some(rhs) = other.try_downcast::<Double>(vm) {
@@ -43,16 +43,12 @@ impl Obj for Double {
                 None => Err(VMError::new(vm, VMErrorKind::CantRepresentAsDouble)),
             }
         } else {
-            Err(VMError::new(
-                vm,
-                VMErrorKind::NotANumber {
-                    got: other.dyn_objtype(vm),
-                },
-            ))
+            let got = other.dyn_objtype(vm);
+            Err(VMError::new(vm, VMErrorKind::NotANumber { got }))
         }
     }
 
-    fn double_div(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn double_div(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         if let Some(rhs) = other.as_isize(vm) {
             if rhs == 0 {
                 Err(VMError::new(vm, VMErrorKind::DivisionByZero))
@@ -75,16 +71,12 @@ impl Obj for Double {
                 }
             }
         } else {
-            Err(VMError::new(
-                vm,
-                VMErrorKind::NotANumber {
-                    got: other.dyn_objtype(vm),
-                },
-            ))
+            let got = other.dyn_objtype(vm);
+            Err(VMError::new(vm, VMErrorKind::NotANumber { got }))
         }
     }
 
-    fn modulus(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn modulus(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         if let Some(rhs) = other.as_isize(vm) {
             Ok(Double::new(vm, self.val % (rhs as f64)))
         } else if let Some(rhs) = other.try_downcast::<Double>(vm) {
@@ -95,16 +87,12 @@ impl Obj for Double {
                 None => Err(VMError::new(vm, VMErrorKind::CantRepresentAsDouble)),
             }
         } else {
-            Err(VMError::new(
-                vm,
-                VMErrorKind::NotANumber {
-                    got: other.dyn_objtype(vm),
-                },
-            ))
+            let got = other.dyn_objtype(vm);
+            Err(VMError::new(vm, VMErrorKind::NotANumber { got }))
         }
     }
 
-    fn mul(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn mul(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         if let Some(rhs) = other.as_isize(vm) {
             Ok(Double::new(vm, self.val * (rhs as f64)))
         } else if let Some(rhs) = other.try_downcast::<Double>(vm) {
@@ -115,20 +103,16 @@ impl Obj for Double {
                 None => Err(VMError::new(vm, VMErrorKind::CantRepresentAsDouble)),
             }
         } else {
-            Err(VMError::new(
-                vm,
-                VMErrorKind::NotANumber {
-                    got: other.dyn_objtype(vm),
-                },
-            ))
+            let got = other.dyn_objtype(vm);
+            Err(VMError::new(vm, VMErrorKind::NotANumber { got }))
         }
     }
 
-    fn sqrt(&self, vm: &VM) -> Result<Val, Box<VMError>> {
+    fn sqrt(&self, vm: &mut VM) -> Result<Val, Box<VMError>> {
         Ok(Double::new(vm, self.val.sqrt()))
     }
 
-    fn sub(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn sub(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         if let Some(rhs) = other.as_isize(vm) {
             Ok(Double::new(vm, self.val - (rhs as f64)))
         } else if let Some(rhs) = other.try_downcast::<Double>(vm) {
@@ -139,16 +123,12 @@ impl Obj for Double {
                 None => Err(VMError::new(vm, VMErrorKind::CantRepresentAsDouble)),
             }
         } else {
-            Err(VMError::new(
-                vm,
-                VMErrorKind::NotANumber {
-                    got: other.dyn_objtype(vm),
-                },
-            ))
+            let got = other.dyn_objtype(vm);
+            Err(VMError::new(vm, VMErrorKind::NotANumber { got }))
         }
     }
 
-    fn ref_equals(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn ref_equals(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         let b = if let Some(rhs) = other.try_downcast::<Double>(vm) {
             self.val == rhs.double()
         } else {
@@ -157,7 +137,7 @@ impl Obj for Double {
         Ok(Val::from_bool(vm, b))
     }
 
-    fn equals(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn equals(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         let b = if let Some(rhs) = other.as_isize(vm) {
             self.val == (rhs as f64)
         } else if let Some(rhs) = other.try_downcast::<Double>(vm) {
@@ -174,7 +154,7 @@ impl Obj for Double {
         Ok(Val::from_bool(vm, b))
     }
 
-    fn less_than(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn less_than(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         let b = if let Some(rhs) = other.as_isize(vm) {
             self.val < (rhs as f64)
         } else if let Some(rhs) = other.try_downcast::<Double>(vm) {
@@ -185,12 +165,8 @@ impl Obj for Double {
                 None => false,
             }
         } else {
-            return Err(VMError::new(
-                vm,
-                VMErrorKind::NotANumber {
-                    got: other.dyn_objtype(vm),
-                },
-            ));
+            let got = other.dyn_objtype(vm);
+            return Err(VMError::new(vm, VMErrorKind::NotANumber { got }));
         };
 
         Ok(Val::from_bool(vm, b))
@@ -204,7 +180,7 @@ impl StaticObjType for Double {
 }
 
 impl Double {
-    pub fn new(vm: &VM, val: f64) -> Val {
+    pub fn new(vm: &mut VM, val: f64) -> Val {
         Val::from_obj(vm, Double { val })
     }
 

--- a/src/lib/vm/objects/instance.rs
+++ b/src/lib/vm/objects/instance.rs
@@ -22,7 +22,7 @@ impl Obj for Inst {
         ObjType::Inst
     }
 
-    fn get_class(&self, _: &VM) -> Val {
+    fn get_class(&self, _: &mut VM) -> Val {
         self.class.clone()
     }
 }
@@ -36,7 +36,7 @@ impl StaticObjType for Inst {
 }
 
 impl Inst {
-    pub fn new(vm: &VM, class: Val) -> Val {
+    pub fn new(vm: &mut VM, class: Val) -> Val {
         let cls: &Class = class.downcast(vm).unwrap();
         let mut inst_vars = Vec::with_capacity(cls.num_inst_vars);
         inst_vars.resize(cls.num_inst_vars, Val::illegal());

--- a/src/lib/vm/objects/integers.rs
+++ b/src/lib/vm/objects/integers.rs
@@ -37,15 +37,15 @@ impl Obj for ArbInt {
         ObjType::ArbInt
     }
 
-    fn get_class(&self, vm: &VM) -> Val {
+    fn get_class(&self, vm: &mut VM) -> Val {
         vm.int_cls.clone()
     }
 
-    fn to_strval(&self, vm: &VM) -> Result<Val, Box<VMError>> {
+    fn to_strval(&self, vm: &mut VM) -> Result<Val, Box<VMError>> {
         Ok(String_::new(vm, self.val.to_string(), true))
     }
 
-    fn add(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn add(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         if let Some(rhs) = other.as_isize(vm) {
             ArbInt::new(vm, &self.val + rhs)
         } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
@@ -56,32 +56,24 @@ impl Obj for ArbInt {
                 None => Err(VMError::new(vm, VMErrorKind::CantRepresentAsDouble)),
             }
         } else {
-            Err(VMError::new(
-                vm,
-                VMErrorKind::NotANumber {
-                    got: other.dyn_objtype(vm),
-                },
-            ))
+            let got = other.dyn_objtype(vm);
+            Err(VMError::new(vm, VMErrorKind::NotANumber { got }))
         }
     }
 
-    fn and(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn and(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         if let Some(rhs) = other.as_isize(vm) {
             ArbInt::new(vm, &self.val & BigInt::from_isize(rhs).unwrap())
         } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
             ArbInt::new(vm, &self.val & &rhs.val)
         } else {
-            Err(VMError::new(
-                vm,
-                VMErrorKind::TypeError {
-                    expected: self.dyn_objtype(),
-                    got: other.dyn_objtype(vm),
-                },
-            ))
+            let expected = self.dyn_objtype();
+            let got = other.dyn_objtype(vm);
+            Err(VMError::new(vm, VMErrorKind::TypeError { expected, got }))
         }
     }
 
-    fn div(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn div(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         if let Some(rhs) = other.as_isize(vm) {
             if rhs == 0 {
                 Err(VMError::new(vm, VMErrorKind::DivisionByZero))
@@ -103,16 +95,12 @@ impl Obj for ArbInt {
                 }
             }
         } else {
-            Err(VMError::new(
-                vm,
-                VMErrorKind::NotANumber {
-                    got: other.dyn_objtype(vm),
-                },
-            ))
+            let got = other.dyn_objtype(vm);
+            Err(VMError::new(vm, VMErrorKind::NotANumber { got }))
         }
     }
 
-    fn double_div(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn double_div(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         if let Some(rhs) = other.as_isize(vm) {
             if rhs == 0 {
                 Err(VMError::new(vm, VMErrorKind::DivisionByZero))
@@ -142,16 +130,12 @@ impl Obj for ArbInt {
                 Err(VMError::new(vm, VMErrorKind::CantRepresentAsDouble))
             }
         } else {
-            Err(VMError::new(
-                vm,
-                VMErrorKind::NotANumber {
-                    got: other.dyn_objtype(vm),
-                },
-            ))
+            let got = other.dyn_objtype(vm);
+            Err(VMError::new(vm, VMErrorKind::NotANumber { got }))
         }
     }
 
-    fn modulus(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn modulus(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         if let Some(rhs) = other.as_isize(vm) {
             ArbInt::new(vm, &self.val % rhs)
         } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
@@ -162,16 +146,12 @@ impl Obj for ArbInt {
                 None => Err(VMError::new(vm, VMErrorKind::CantRepresentAsDouble)),
             }
         } else {
-            Err(VMError::new(
-                vm,
-                VMErrorKind::NotANumber {
-                    got: other.dyn_objtype(vm),
-                },
-            ))
+            let got = other.dyn_objtype(vm);
+            Err(VMError::new(vm, VMErrorKind::NotANumber { got }))
         }
     }
 
-    fn mul(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn mul(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         if let Some(rhs) = other.as_isize(vm) {
             ArbInt::new(vm, &self.val * rhs)
         } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
@@ -182,16 +162,12 @@ impl Obj for ArbInt {
                 None => Err(VMError::new(vm, VMErrorKind::CantRepresentAsDouble)),
             }
         } else {
-            Err(VMError::new(
-                vm,
-                VMErrorKind::NotANumber {
-                    got: other.dyn_objtype(vm),
-                },
-            ))
+            let got = other.dyn_objtype(vm);
+            Err(VMError::new(vm, VMErrorKind::NotANumber { got }))
         }
     }
 
-    fn shl(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn shl(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         if let Some(rhs) = other.as_isize(vm) {
             if rhs < 0 {
                 Err(VMError::new(vm, VMErrorKind::NegativeShift))
@@ -203,16 +179,12 @@ impl Obj for ArbInt {
         } else if other.try_downcast::<ArbInt>(vm).is_some() {
             Err(VMError::new(vm, VMErrorKind::ShiftTooBig))
         } else {
-            Err(VMError::new(
-                vm,
-                VMErrorKind::NotANumber {
-                    got: other.dyn_objtype(vm),
-                },
-            ))
+            let got = other.dyn_objtype(vm);
+            Err(VMError::new(vm, VMErrorKind::NotANumber { got }))
         }
     }
 
-    fn sqrt(&self, vm: &VM) -> Result<Val, Box<VMError>> {
+    fn sqrt(&self, vm: &mut VM) -> Result<Val, Box<VMError>> {
         if self.val < Zero::zero() {
             Err(VMError::new(vm, VMErrorKind::DomainError))
         } else {
@@ -225,7 +197,7 @@ impl Obj for ArbInt {
         }
     }
 
-    fn sub(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn sub(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         if let Some(rhs) = other.as_isize(vm) {
             ArbInt::new(vm, &self.val - rhs)
         } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
@@ -236,32 +208,24 @@ impl Obj for ArbInt {
                 None => Err(VMError::new(vm, VMErrorKind::CantRepresentAsDouble)),
             }
         } else {
-            Err(VMError::new(
-                vm,
-                VMErrorKind::NotANumber {
-                    got: other.dyn_objtype(vm),
-                },
-            ))
+            let got = other.dyn_objtype(vm);
+            Err(VMError::new(vm, VMErrorKind::NotANumber { got }))
         }
     }
 
-    fn xor(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn xor(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         if let Some(rhs) = other.as_isize(vm) {
             ArbInt::new(vm, &self.val ^ BigInt::from_isize(rhs).unwrap())
         } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
             ArbInt::new(vm, &self.val ^ &rhs.val)
         } else {
-            Err(VMError::new(
-                vm,
-                VMErrorKind::TypeError {
-                    expected: self.dyn_objtype(),
-                    got: other.dyn_objtype(vm),
-                },
-            ))
+            let expected = self.dyn_objtype();
+            let got = other.dyn_objtype(vm);
+            Err(VMError::new(vm, VMErrorKind::TypeError { expected, got }))
         }
     }
 
-    fn ref_equals(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn ref_equals(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         let b = if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
             self.val == rhs.val
         } else {
@@ -270,7 +234,7 @@ impl Obj for ArbInt {
         Ok(Val::from_bool(vm, b))
     }
 
-    fn equals(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn equals(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         let b = if other.dyn_objtype(vm) == ObjType::Int {
             debug_assert!(self.val != BigInt::from_isize(other.as_isize(vm).unwrap()).unwrap());
             false
@@ -282,7 +246,7 @@ impl Obj for ArbInt {
         Ok(Val::from_bool(vm, b))
     }
 
-    fn not_equals(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn not_equals(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         let b = if other.dyn_objtype(vm) == ObjType::Int {
             debug_assert!(self.val != BigInt::from_isize(other.as_isize(vm).unwrap()).unwrap());
             true
@@ -294,70 +258,54 @@ impl Obj for ArbInt {
         Ok(Val::from_bool(vm, b))
     }
 
-    fn greater_than(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn greater_than(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         let b = if other.dyn_objtype(vm) == ObjType::Int {
             debug_assert!(self.val > BigInt::from_isize(other.as_isize(vm).unwrap()).unwrap());
             true
         } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
             self.val > rhs.val
         } else {
-            return Err(VMError::new(
-                vm,
-                VMErrorKind::NotANumber {
-                    got: other.dyn_objtype(vm),
-                },
-            ));
+            let got = other.dyn_objtype(vm);
+            return Err(VMError::new(vm, VMErrorKind::NotANumber { got }));
         };
         Ok(Val::from_bool(vm, b))
     }
 
-    fn greater_than_equals(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn greater_than_equals(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         let b = if other.dyn_objtype(vm) == ObjType::Int {
             debug_assert!(self.val >= BigInt::from_isize(other.as_isize(vm).unwrap()).unwrap());
             true
         } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
             self.val >= rhs.val
         } else {
-            return Err(VMError::new(
-                vm,
-                VMErrorKind::NotANumber {
-                    got: other.dyn_objtype(vm),
-                },
-            ));
+            let got = other.dyn_objtype(vm);
+            return Err(VMError::new(vm, VMErrorKind::NotANumber { got }));
         };
         Ok(Val::from_bool(vm, b))
     }
 
-    fn less_than(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn less_than(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         let b = if other.dyn_objtype(vm) == ObjType::Int {
             debug_assert!(self.val < BigInt::from_isize(other.as_isize(vm).unwrap()).unwrap());
             false
         } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
             self.val < rhs.val
         } else {
-            return Err(VMError::new(
-                vm,
-                VMErrorKind::NotANumber {
-                    got: other.dyn_objtype(vm),
-                },
-            ));
+            let got = other.dyn_objtype(vm);
+            return Err(VMError::new(vm, VMErrorKind::NotANumber { got }));
         };
         Ok(Val::from_bool(vm, b))
     }
 
-    fn less_than_equals(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn less_than_equals(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         let b = if other.dyn_objtype(vm) == ObjType::Int {
             debug_assert!(self.val <= BigInt::from_isize(other.as_isize(vm).unwrap()).unwrap());
             false
         } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
             self.val <= rhs.val
         } else {
-            return Err(VMError::new(
-                vm,
-                VMErrorKind::NotANumber {
-                    got: other.dyn_objtype(vm),
-                },
-            ));
+            let got = other.dyn_objtype(vm);
+            return Err(VMError::new(vm, VMErrorKind::NotANumber { got }));
         };
         Ok(Val::from_bool(vm, b))
     }
@@ -374,7 +322,7 @@ impl ArbInt {
     /// efficient integer representation that can represent `val` (i.e. this might create a tagged
     /// `isize`, a boxed `isize`, or a boxed `BigInt`) -- the VM relies, in various places, on this
     /// property (e.g. an `ArbInt` with a value `1` would cause odd errors elsewhere).
-    pub fn new(vm: &VM, val: BigInt) -> Result<Val, Box<VMError>> {
+    pub fn new(vm: &mut VM, val: BigInt) -> Result<Val, Box<VMError>> {
         if let Some(i) = val.to_isize() {
             Val::from_isize(vm, i)
         } else {
@@ -398,15 +346,15 @@ impl Obj for Int {
         ObjType::Int
     }
 
-    fn get_class(&self, vm: &VM) -> Val {
+    fn get_class(&self, vm: &mut VM) -> Val {
         vm.int_cls.clone()
     }
 
-    fn to_strval(&self, vm: &VM) -> Result<Val, Box<VMError>> {
+    fn to_strval(&self, vm: &mut VM) -> Result<Val, Box<VMError>> {
         Ok(String_::new(vm, self.val.to_string(), true))
     }
 
-    fn add(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn add(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         if let Some(rhs) = other.as_isize(vm) {
             match self.val.checked_add(rhs) {
                 Some(i) => Val::from_isize(vm, i),
@@ -420,16 +368,12 @@ impl Obj for Int {
                 None => Err(VMError::new(vm, VMErrorKind::CantRepresentAsDouble)),
             }
         } else {
-            Err(VMError::new(
-                vm,
-                VMErrorKind::NotANumber {
-                    got: other.dyn_objtype(vm),
-                },
-            ))
+            let got = other.dyn_objtype(vm);
+            Err(VMError::new(vm, VMErrorKind::NotANumber { got }))
         }
     }
 
-    fn div(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn div(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         if let Some(rhs) = other.as_isize(vm) {
             if rhs == 0 {
                 Err(VMError::new(vm, VMErrorKind::DivisionByZero))
@@ -454,16 +398,12 @@ impl Obj for Int {
                 }
             }
         } else {
-            Err(VMError::new(
-                vm,
-                VMErrorKind::NotANumber {
-                    got: other.dyn_objtype(vm),
-                },
-            ))
+            let got = other.dyn_objtype(vm);
+            Err(VMError::new(vm, VMErrorKind::NotANumber { got }))
         }
     }
 
-    fn mul(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn mul(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         if let Some(rhs) = other.as_isize(vm) {
             match self.val.checked_mul(rhs) {
                 Some(i) => Val::from_isize(vm, i),
@@ -477,16 +417,12 @@ impl Obj for Int {
                 None => Err(VMError::new(vm, VMErrorKind::CantRepresentAsDouble)),
             }
         } else {
-            Err(VMError::new(
-                vm,
-                VMErrorKind::NotANumber {
-                    got: other.dyn_objtype(vm),
-                },
-            ))
+            let got = other.dyn_objtype(vm);
+            Err(VMError::new(vm, VMErrorKind::NotANumber { got }))
         }
     }
 
-    fn sub(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn sub(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         if let Some(rhs) = other.as_isize(vm) {
             match self.val.checked_sub(rhs) {
                 Some(i) => Val::from_isize(vm, i),
@@ -500,12 +436,8 @@ impl Obj for Int {
                 None => Err(VMError::new(vm, VMErrorKind::CantRepresentAsDouble)),
             }
         } else {
-            Err(VMError::new(
-                vm,
-                VMErrorKind::NotANumber {
-                    got: other.dyn_objtype(vm),
-                },
-            ))
+            let got = other.dyn_objtype(vm);
+            Err(VMError::new(vm, VMErrorKind::NotANumber { got }))
         }
     }
 }
@@ -519,7 +451,7 @@ impl StaticObjType for Int {
 impl Int {
     /// Create a `Val` representing the `usize` integer `i`. The `Val` is guaranteed to be boxed
     /// internally.
-    pub fn boxed_isize(vm: &VM, i: isize) -> Result<Val, Box<VMError>> {
+    pub fn boxed_isize(vm: &mut VM, i: isize) -> Result<Val, Box<VMError>> {
         Ok(Val::from_obj(vm, Int { val: i }))
     }
 
@@ -544,139 +476,139 @@ mod tests {
 
     #[test]
     fn test_boxed_int() {
-        let vm = VM::new_no_bootstrap();
+        let mut vm = VM::new_no_bootstrap();
 
-        assert_eq!(Val::from_isize(&vm, 12345).unwrap().valkind(), ValKind::INT);
         assert_eq!(
-            Int::boxed_isize(&vm, 12345).unwrap().valkind(),
+            Val::from_isize(&mut vm, 12345).unwrap().valkind(),
+            ValKind::INT
+        );
+        assert_eq!(
+            Int::boxed_isize(&mut vm, 12345).unwrap().valkind(),
             ValKind::GCBOX
         );
 
-        let v = Val::from_isize(&vm, 12345).unwrap();
+        let v = Val::from_isize(&mut vm, 12345).unwrap();
         assert_eq!(
-            v.tobj(&vm)
+            v.tobj(&mut vm)
                 .unwrap()
                 .downcast::<Int>()
                 .unwrap()
                 .as_usize()
                 .unwrap(),
-            v.as_usize(&vm).unwrap()
+            v.as_usize(&mut vm).unwrap()
         );
     }
 
     #[test]
     fn test_bint() {
-        let vm = VM::new_no_bootstrap();
+        let mut vm = VM::new_no_bootstrap();
 
-        assert_eq!(Val::from_isize(&vm, 0).unwrap().valkind(), ValKind::INT);
+        assert_eq!(Val::from_isize(&mut vm, 0).unwrap().valkind(), ValKind::INT);
         assert_eq!(
-            Val::from_isize(&vm, 1 << (BITSIZE - 1 - TAG_BITSIZE))
+            Val::from_isize(&mut vm, 1 << (BITSIZE - 1 - TAG_BITSIZE))
                 .unwrap()
                 .valkind(),
             ValKind::GCBOX
         );
         assert_eq!(
-            Val::from_isize(&vm, -1 - 1 << (BITSIZE - 1 - TAG_BITSIZE))
+            Val::from_isize(&mut vm, -1 - 1 << (BITSIZE - 1 - TAG_BITSIZE))
                 .unwrap()
                 .valkind(),
             ValKind::GCBOX
         );
         assert_eq!(
-            Val::from_isize(&vm, 1 << (BITSIZE - 1)).unwrap().valkind(),
+            Val::from_isize(&mut vm, 1 << (BITSIZE - 1))
+                .unwrap()
+                .valkind(),
             ValKind::GCBOX
         );
+        let v = Val::from_isize(&mut vm, isize::min_value()).unwrap();
         assert_eq!(
-            Val::from_isize(&vm, isize::min_value())
+            Val::from_isize(&mut vm, isize::min_value())
                 .unwrap()
-                .add(&vm, Val::from_isize(&vm, isize::min_value()).unwrap())
+                .add(&mut vm, v)
                 .unwrap()
-                .downcast::<ArbInt>(&vm)
+                .downcast::<ArbInt>(&mut vm)
                 .unwrap()
                 .val,
             BigInt::from_str("-18446744073709551616").unwrap()
         );
         // Check that sizes "downsize" from more expensive to cheaper types.
+        let v = Val::from_isize(&mut vm, isize::max_value()).unwrap();
         assert_eq!(
-            Val::from_isize(&vm, isize::max_value())
+            Val::from_isize(&mut vm, isize::max_value())
                 .unwrap()
-                .sub(&vm, Val::from_isize(&vm, isize::max_value()).unwrap())
+                .sub(&mut vm, v)
                 .unwrap()
                 .valkind(),
             ValKind::INT
         );
-        let bi = Val::from_isize(&vm, isize::max_value())
+        let v = Val::from_isize(&mut vm, 10).unwrap();
+        let bi = Val::from_isize(&mut vm, isize::max_value())
             .unwrap()
-            .add(&vm, Val::from_isize(&vm, 10).unwrap())
+            .add(&mut vm, v)
             .unwrap();
-        assert!(bi.downcast::<ArbInt>(&vm).is_ok());
+        assert!(bi.downcast::<ArbInt>(&mut vm).is_ok());
+        let v = Val::from_isize(&mut vm, 1 << (TAG_BITSIZE + 2)).unwrap();
         assert_eq!(
-            bi.tobj(&vm)
-                .unwrap()
-                .sub(&vm, Val::from_isize(&vm, 1 << (TAG_BITSIZE + 2)).unwrap())
-                .unwrap()
-                .valkind(),
+            bi.tobj(&mut vm).unwrap().sub(&mut vm, v).unwrap().valkind(),
             ValKind::GCBOX
         );
+        let v = Val::from_isize(&mut vm, isize::max_value()).unwrap();
         assert_eq!(
-            bi.tobj(&vm)
-                .unwrap()
-                .sub(&vm, Val::from_isize(&vm, isize::max_value()).unwrap())
-                .unwrap()
-                .valkind(),
+            bi.tobj(&mut vm).unwrap().sub(&mut vm, v).unwrap().valkind(),
             ValKind::INT
         );
         // Different LHS and RHS types
-        assert!(Val::from_isize(&vm, 1)
+        assert!(Val::from_isize(&mut vm, 1)
             .unwrap()
-            .add(&vm, bi.clone())
+            .add(&mut vm, bi.clone())
             .unwrap()
-            .downcast::<ArbInt>(&vm)
+            .downcast::<ArbInt>(&mut vm)
             .is_ok());
-        assert!(Val::from_isize(&vm, 1)
+        assert!(Val::from_isize(&mut vm, 1)
             .unwrap()
-            .sub(&vm, bi.clone())
+            .sub(&mut vm, bi.clone())
             .unwrap()
-            .downcast::<ArbInt>(&vm)
+            .downcast::<ArbInt>(&mut vm)
             .is_ok());
-        assert!(Val::from_isize(&vm, 1)
+        assert!(Val::from_isize(&mut vm, 1)
             .unwrap()
-            .mul(&vm, bi.clone())
+            .mul(&mut vm, bi.clone())
             .unwrap()
-            .downcast::<ArbInt>(&vm)
+            .downcast::<ArbInt>(&mut vm)
             .is_ok());
         assert_eq!(
-            Val::from_isize(&vm, 1)
+            Val::from_isize(&mut vm, 1)
                 .unwrap()
-                .div(&vm, bi.clone())
+                .div(&mut vm, bi.clone())
                 .unwrap()
                 .valkind(),
             ValKind::INT
         );
 
+        let v = Val::from_isize(&mut vm, 1).unwrap();
         assert!(bi
             .clone()
-            .add(&vm, Val::from_isize(&vm, 1).unwrap())
+            .add(&mut vm, v)
             .unwrap()
-            .downcast::<ArbInt>(&vm)
+            .downcast::<ArbInt>(&mut vm)
             .is_ok());
+        let v = Val::from_isize(&mut vm, 1).unwrap();
         assert!(bi
             .clone()
-            .sub(&vm, Val::from_isize(&vm, 1).unwrap())
+            .sub(&mut vm, v)
             .unwrap()
-            .downcast::<ArbInt>(&vm)
+            .downcast::<ArbInt>(&mut vm)
             .is_ok());
+        let v = Val::from_isize(&mut vm, 1).unwrap();
         assert!(bi
             .clone()
-            .mul(&vm, Val::from_isize(&vm, 1).unwrap())
+            .mul(&mut vm, v)
             .unwrap()
-            .downcast::<ArbInt>(&vm)
+            .downcast::<ArbInt>(&mut vm)
             .is_ok());
-        assert_eq!(
-            bi.clone()
-                .div(&vm, Val::from_isize(&vm, 99999999).unwrap())
-                .unwrap()
-                .valkind(),
-            ValKind::INT
-        );
+        let v = Val::from_isize(&mut vm, 99999999).unwrap();
+        assert_eq!(bi.clone().div(&mut vm, v).unwrap().valkind(), ValKind::INT);
     }
 }

--- a/src/lib/vm/objects/method.rs
+++ b/src/lib/vm/objects/method.rs
@@ -39,7 +39,7 @@ impl Obj for Method {
         ObjType::Method
     }
 
-    fn get_class(&self, _: &VM) -> Val {
+    fn get_class(&self, _: &mut VM) -> Val {
         unimplemented!();
     }
 }
@@ -53,7 +53,7 @@ impl StaticObjType for Method {
 }
 
 impl Method {
-    pub fn new(vm: &VM, name: String, body: MethodBody) -> Method {
+    pub fn new(vm: &mut VM, name: String, body: MethodBody) -> Method {
         Method {
             name,
             body,
@@ -65,7 +65,7 @@ impl Method {
         unsafe { &*self.class.get() }.clone()
     }
 
-    pub fn set_class(&self, _: &VM, class: Val) {
+    pub fn set_class(&self, _: &mut VM, class: Val) {
         *unsafe { &mut *self.class.get() } = class;
     }
 }

--- a/src/lib/vm/objects/method.rs
+++ b/src/lib/vm/objects/method.rs
@@ -53,7 +53,7 @@ impl StaticObjType for Method {
 }
 
 impl Method {
-    pub fn new(vm: &mut VM, name: String, body: MethodBody) -> Method {
+    pub fn new(vm: &VM, name: String, body: MethodBody) -> Method {
         Method {
             name,
             body,
@@ -65,7 +65,7 @@ impl Method {
         unsafe { &*self.class.get() }.clone()
     }
 
-    pub fn set_class(&self, _: &mut VM, class: Val) {
+    pub fn set_class(&self, _: &VM, class: Val) {
         *unsafe { &mut *self.class.get() } = class;
     }
 }

--- a/src/lib/vm/objects/mod.rs
+++ b/src/lib/vm/objects/mod.rs
@@ -76,65 +76,65 @@ pub trait Obj: std::fmt::Debug + abgc::GcLayout {
     /// What `ObjType` does this `Val` represent?
     fn dyn_objtype(&self) -> ObjType;
     /// What class is this object an instance of?
-    fn get_class(&self, vm: &VM) -> Val;
+    fn get_class(&self, vm: &mut VM) -> Val;
 
     /// Convert this object to a `Val` that represents a SOM string.
-    fn to_strval(&self, _: &VM) -> Result<Val, Box<VMError>> {
+    fn to_strval(&self, _: &mut VM) -> Result<Val, Box<VMError>> {
         unimplemented!();
     }
 
     /// Produce a new `Val` which adds `other` to this.
-    fn add(&self, _: &VM, _: Val) -> Result<Val, Box<VMError>> {
+    fn add(&self, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
         unimplemented!();
     }
 
     /// Produce a new `Val` which performs a bitwise and with `other` and this.
-    fn and(&self, _: &VM, _: Val) -> Result<Val, Box<VMError>> {
+    fn and(&self, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
         unimplemented!();
     }
 
     /// Produce a new `Val` which divides `other` from this.
-    fn div(&self, _: &VM, _: Val) -> Result<Val, Box<VMError>> {
+    fn div(&self, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
         unimplemented!();
     }
 
-    fn double_div(&self, _: &VM, _: Val) -> Result<Val, Box<VMError>> {
+    fn double_div(&self, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
         unimplemented!();
     }
 
     /// Produce a new `Val` which performs a mod operation on this with `other`.
-    fn modulus(&self, _: &VM, _: Val) -> Result<Val, Box<VMError>> {
+    fn modulus(&self, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
         unimplemented!();
     }
 
     /// Produce a new `Val` which multiplies `other` to this.
-    fn mul(&self, _: &VM, _: Val) -> Result<Val, Box<VMError>> {
+    fn mul(&self, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
         unimplemented!();
     }
 
     /// Produce a new `Val` which shifts `self` `other` bits to the left.
-    fn shl(&self, _: &VM, _: Val) -> Result<Val, Box<VMError>> {
+    fn shl(&self, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
         unimplemented!();
     }
 
     /// Produces a new `Val` which is the square root of this.
-    fn sqrt(&self, _: &VM) -> Result<Val, Box<VMError>> {
+    fn sqrt(&self, _: &mut VM) -> Result<Val, Box<VMError>> {
         unimplemented!();
     }
 
     /// Produce a new `Val` which subtracts `other` from this.
-    fn sub(&self, _: &VM, _: Val) -> Result<Val, Box<VMError>> {
+    fn sub(&self, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
         unimplemented!();
     }
 
     /// Produce a new `Val` which performs a bitwise xor with `other` and this
-    fn xor(&self, _: &VM, _: Val) -> Result<Val, Box<VMError>> {
+    fn xor(&self, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
         unimplemented!();
     }
 
     /// Is this `Val` reference equality equal to `other`? Only number types are likely to want to
     /// override this.
-    fn ref_equals(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn ref_equals(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         let other_tobj = other.tobj(vm)?;
         let other_data =
             unsafe { std::mem::transmute::<&dyn Obj, (*const u8, usize)>(&**other_tobj).0 };
@@ -145,32 +145,32 @@ pub trait Obj: std::fmt::Debug + abgc::GcLayout {
     }
 
     /// Does this `Val` equal `other`?
-    fn equals(&self, _: &VM, _: Val) -> Result<Val, Box<VMError>> {
+    fn equals(&self, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
         unimplemented!();
     }
 
     /// Does this `Val` not equal `other`?
-    fn not_equals(&self, _: &VM, _: Val) -> Result<Val, Box<VMError>> {
+    fn not_equals(&self, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
         unimplemented!();
     }
 
     /// Is this `Val` greater than `other`?
-    fn greater_than(&self, _: &VM, _: Val) -> Result<Val, Box<VMError>> {
+    fn greater_than(&self, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
         unimplemented!();
     }
 
     /// Is this `Val` greater than or equal to `other`?
-    fn greater_than_equals(&self, _: &VM, _: Val) -> Result<Val, Box<VMError>> {
+    fn greater_than_equals(&self, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
         unimplemented!();
     }
 
     /// Is this `Val` less than `other`?
-    fn less_than(&self, _: &VM, _: Val) -> Result<Val, Box<VMError>> {
+    fn less_than(&self, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
         unimplemented!();
     }
 
     /// Is this `Val` less than or equal to `other`?
-    fn less_than_equals(&self, _: &VM, _: Val) -> Result<Val, Box<VMError>> {
+    fn less_than_equals(&self, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
         unimplemented!();
     }
 }

--- a/src/lib/vm/objects/string_.rs
+++ b/src/lib/vm/objects/string_.rs
@@ -22,7 +22,7 @@ impl Obj for String_ {
         ObjType::String_
     }
 
-    fn get_class(&self, vm: &VM) -> Val {
+    fn get_class(&self, vm: &mut VM) -> Val {
         // FIXME This is a temporary hack until we sort out bootstrapping of the String_ class
         if self.is_str {
             vm.str_cls.clone()
@@ -31,11 +31,11 @@ impl Obj for String_ {
         }
     }
 
-    fn to_strval(&self, vm: &VM) -> Result<Val, Box<VMError>> {
+    fn to_strval(&self, vm: &mut VM) -> Result<Val, Box<VMError>> {
         Ok(String_::new(vm, self.s.to_string(), true))
     }
 
-    fn ref_equals(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn ref_equals(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         let other_str: &String_ = other.downcast(vm)?;
 
         Ok(Val::from_bool(
@@ -54,7 +54,7 @@ impl StaticObjType for String_ {
 }
 
 impl String_ {
-    pub fn new(vm: &VM, s: String, is_str: bool) -> Val {
+    pub fn new(vm: &mut VM, s: String, is_str: bool) -> Val {
         Val::from_obj(vm, String_ { s, is_str })
     }
 
@@ -63,7 +63,7 @@ impl String_ {
     }
 
     /// Concatenate this string with another string and return the result.
-    pub fn concatenate(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
+    pub fn concatenate(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         let other_str: &String_ = other.downcast(vm)?;
 
         // Since strings are immutable, concatenating an empty string means we don't need to
@@ -80,7 +80,7 @@ impl String_ {
         Ok(String_::new(vm, new, true))
     }
 
-    pub fn to_symbol(&self, vm: &VM) -> Result<Val, Box<VMError>> {
+    pub fn to_symbol(&self, vm: &mut VM) -> Result<Val, Box<VMError>> {
         Ok(String_::new(vm, self.s.to_string(), false))
     }
 }

--- a/src/lib/vm/somstack.rs
+++ b/src/lib/vm/somstack.rs
@@ -1,6 +1,5 @@
 use std::{
     alloc::{alloc, dealloc, Layout},
-    cell::Cell,
     mem::forget,
     ptr,
 };
@@ -15,17 +14,14 @@ pub const SOM_STACK_LEN: usize = 4096;
 pub struct SOMStack {
     storage: *mut Val,
     /// How many items are used? Note that the stack has an implicit capacity of [`SOM_STACK_LEN`].
-    len: Cell<usize>,
+    len: usize,
 }
 
 impl SOMStack {
     pub fn new() -> SOMStack {
         #![allow(clippy::cast_ptr_alignment)]
         let storage = unsafe { alloc(Layout::array::<Val>(SOM_STACK_LEN).unwrap()) as *mut Val };
-        SOMStack {
-            storage,
-            len: Cell::new(0),
-        }
+        SOMStack { storage, len: 0 }
     }
 
     /// Returns `true` if the stack contains no elements.
@@ -35,7 +31,7 @@ impl SOMStack {
 
     /// Returns the number of elements in the stack.
     pub fn len(&self) -> usize {
-        self.len.get()
+        self.len
     }
 
     /// Returns the number of elements the stack can store before running out of room.
@@ -47,7 +43,7 @@ impl SOMStack {
     /// this function will lead to undefined behaviour.
     pub fn peek(&self) -> Val {
         debug_assert!(!self.is_empty());
-        let v = unsafe { ptr::read(self.storage.add(self.len.get() - 1)) };
+        let v = unsafe { ptr::read(self.storage.add(self.len - 1)) };
         let v2 = v.clone();
         forget(v);
         v2
@@ -55,18 +51,18 @@ impl SOMStack {
 
     /// Pops the top-most value of the stack and returns it. If the stack is empty, calling
     /// this function will lead to undefined behaviour.
-    pub fn pop(&self) -> Val {
+    pub fn pop(&mut self) -> Val {
         debug_assert!(!self.is_empty());
-        self.len.update(|x| x - 1);
-        unsafe { ptr::read(self.storage.add(self.len.get())) }
+        self.len -= 1;
+        unsafe { ptr::read(self.storage.add(self.len)) }
     }
 
     /// Pops the top-most value of the stack and returns it. If the stack is empty, calling
     /// this function will lead to undefined behaviour.
-    pub fn pop_n(&self, n: usize) -> Val {
+    pub fn pop_n(&mut self, n: usize) -> Val {
         debug_assert!(n < self.len());
-        self.len.update(|x| x - 1);
-        let i = self.len.get() - n;
+        self.len -= 1;
+        let i = self.len - n;
         let v = unsafe { ptr::read(self.storage.add(i)) };
         unsafe { ptr::copy(self.storage.add(i + 1), self.storage.add(i), n) };
         v
@@ -75,21 +71,21 @@ impl SOMStack {
     /// Push `v` onto the end of the stack. You must previously have checked (using
     /// [`SOMStack::remaining_capacity`]) that there is room for this value: if there is not,
     /// undefined behaviour will occur.
-    pub fn push(&self, v: Val) {
+    pub fn push(&mut self, v: Val) {
         debug_assert!(self.remaining_capacity() > 0);
-        unsafe { ptr::write(self.storage.add(self.len.get()), v) };
-        self.len.update(|x| x + 1);
+        unsafe { ptr::write(self.storage.add(self.len), v) };
+        self.len += 1;
     }
 
     /// Shortens the stack, keeping the first len elements and dropping the rest.
-    pub fn truncate(&self, len: usize) {
+    pub fn truncate(&mut self, len: usize) {
         debug_assert!(len <= self.len());
-        for i in len..self.len.get() {
+        for i in len..self.len {
             unsafe {
                 ptr::read(self.storage.add(i));
             }
         }
-        self.len.set(len);
+        self.len = len;
     }
 }
 

--- a/src/lib/vm/val.rs
+++ b/src/lib/vm/val.rs
@@ -70,7 +70,7 @@ impl Val {
     ///
     /// [In an ideal world, this would be a function on `Obj` itself, but that would mean that
     /// `Obj` couldn't be a trait object. Oh well.]
-    pub fn from_obj<T: Obj + 'static>(_: &VM, obj: T) -> Self {
+    pub fn from_obj<T: Obj + 'static>(_: &mut VM, obj: T) -> Self {
         debug_assert_eq!(size_of::<*const ThinObj>(), size_of::<usize>());
         let ptr = ThinObj::new(obj).into_raw();
         Val {
@@ -130,7 +130,7 @@ impl Val {
     /// be boxed) or return a `VMError` if the cast is invalid.
     pub fn downcast<T: Obj + StaticObjType + NotUnboxable>(
         &self,
-        vm: &VM,
+        vm: &mut VM,
     ) -> Result<&T, Box<VMError>> {
         match self.valkind() {
             ValKind::INT => Err(VMError::new(
@@ -158,7 +158,7 @@ impl Val {
 
     /// Cast a `Val` into an instance of type `T` (where `T` must statically be a type that cannot
     /// be boxed) or return `None` if the cast is not valid.
-    pub fn try_downcast<T: Obj + StaticObjType + NotUnboxable>(&self, _: &VM) -> Option<&T> {
+    pub fn try_downcast<T: Obj + StaticObjType + NotUnboxable>(&self, _: &mut VM) -> Option<&T> {
         match self.valkind() {
             ValKind::INT => None,
             ValKind::GCBOX => unsafe { self.val_to_tobj() }.downcast(),
@@ -167,7 +167,7 @@ impl Val {
     }
 
     /// Return this `Val`'s box. If the `Val` refers to an unboxed value, this will box it.
-    pub fn tobj(&self, vm: &VM) -> Result<Gc<ThinObj>, Box<VMError>> {
+    pub fn tobj(&self, vm: &mut VM) -> Result<Gc<ThinObj>, Box<VMError>> {
         match self.valkind() {
             ValKind::GCBOX => {
                 debug_assert_eq!(size_of::<*const ThinObj>(), size_of::<usize>());
@@ -177,13 +177,16 @@ impl Val {
                     ))
                 })
             }
-            ValKind::INT => Int::boxed_isize(vm, self.as_isize(vm).unwrap()).map(|v| v.tobj(vm))?,
+            ValKind::INT => {
+                let i = self.as_isize(vm).unwrap();
+                Int::boxed_isize(vm, i).map(|v| v.tobj(vm))?
+            }
             ValKind::ILLEGAL => unreachable!(),
         }
     }
 
     /// Create a (possibly boxed) `Val` representing the `isize` integer `i`.
-    pub fn from_isize(vm: &VM, i: isize) -> Result<Val, Box<VMError>> {
+    pub fn from_isize(vm: &mut VM, i: isize) -> Result<Val, Box<VMError>> {
         let top_bits = i as usize & (INT_BITMASK << (BITSIZE - TAG_BITSIZE - 1));
         if top_bits == 0 || top_bits == INT_BITMASK << (BITSIZE - TAG_BITSIZE - 1) {
             // top_bits == 0: A positive integer that fits in our tagging scheme
@@ -199,7 +202,7 @@ impl Val {
     /// Create a (possibly boxed) `Val` representing the `usize` integer `i`. Notice that this can
     /// fail if `i` is too big (since we don't have BigNum support and ints are internally
     /// represented as `isize`).
-    pub fn from_usize(vm: &VM, i: usize) -> Result<Val, Box<VMError>> {
+    pub fn from_usize(vm: &mut VM, i: usize) -> Result<Val, Box<VMError>> {
         if i & (INT_BITMASK << (BITSIZE - TAG_BITSIZE - 1)) == 0 {
             // The top TAG_BITSIZE bits aren't set, so this fits within our pointer tagging scheme.
             Ok(Val {
@@ -212,7 +215,7 @@ impl Val {
 
     /// If `v == true`, return a `Val` representing `vm.true_`, otherwise return a `Val`
     /// representing `vm.false_`.
-    pub fn from_bool(vm: &VM, v: bool) -> Val {
+    pub fn from_bool(vm: &mut VM, v: bool) -> Val {
         if v {
             vm.true_.clone()
         } else {
@@ -221,7 +224,7 @@ impl Val {
     }
 
     /// If this `Val` represents a non-bigint integer, return its value as an `isize`.
-    pub fn as_isize(&self, vm: &VM) -> Option<isize> {
+    pub fn as_isize(&self, vm: &mut VM) -> Option<isize> {
         match self.valkind() {
             ValKind::GCBOX => self
                 .tobj(vm)
@@ -244,7 +247,7 @@ impl Val {
     }
 
     /// If this `Val` represents a non-bigint integer, return its value as an `usize`.
-    pub fn as_usize(&self, vm: &VM) -> Option<usize> {
+    pub fn as_usize(&self, vm: &mut VM) -> Option<usize> {
         match self.valkind() {
             ValKind::GCBOX => self
                 .tobj(vm)
@@ -273,7 +276,7 @@ impl Val {
 // Implement each function from the `Obj` type so that we can efficiently deal with tagged values.
 impl Val {
     /// What `ObjType` does this `Val` represent?
-    pub fn dyn_objtype(&self, vm: &VM) -> ObjType {
+    pub fn dyn_objtype(&self, vm: &mut VM) -> ObjType {
         match self.valkind() {
             ValKind::INT => ObjType::Int,
             ValKind::GCBOX => self.tobj(vm).unwrap().dyn_objtype(),
@@ -282,7 +285,7 @@ impl Val {
     }
 
     /// What class is this `Val` an instance of?
-    pub fn get_class(&self, vm: &VM) -> Val {
+    pub fn get_class(&self, vm: &mut VM) -> Val {
         match self.valkind() {
             ValKind::INT => vm.int_cls.clone(),
             ValKind::GCBOX => self.tobj(vm).unwrap().get_class(vm),
@@ -290,20 +293,19 @@ impl Val {
         }
     }
 
-    pub fn to_strval(&self, vm: &VM) -> Result<Val, Box<VMError>> {
+    pub fn to_strval(&self, vm: &mut VM) -> Result<Val, Box<VMError>> {
         match self.valkind() {
-            ValKind::INT => Ok(String_::new(
-                vm,
-                self.as_isize(vm).unwrap().to_string(),
-                true,
-            )),
+            ValKind::INT => {
+                let s = self.as_isize(vm).unwrap().to_string();
+                Ok(String_::new(vm, s, true))
+            }
             ValKind::GCBOX => self.tobj(vm).unwrap().to_strval(vm),
             ValKind::ILLEGAL => unreachable!(),
         }
     }
 
     /// Produce a new `Val` which adds `other` to this.
-    pub fn add(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
+    pub fn add(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         debug_assert_eq!(ValKind::INT as usize, 0);
         if self.valkind() == ValKind::INT && other.valkind() == ValKind::INT {
             if let Some(val) = self.val.checked_add(other.val) {
@@ -314,26 +316,22 @@ impl Val {
     }
 
     /// Produce a new `Val` which performs a bitwise and operation with `other` and this.
-    pub fn and(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
+    pub fn and(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         if let Some(lhs) = self.as_isize(vm) {
             if let Some(rhs) = other.as_isize(vm) {
                 return Val::from_isize(vm, lhs & rhs);
             } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
                 return ArbInt::new(vm, BigInt::from_isize(lhs).unwrap() & rhs.bigint());
             }
-            return Err(VMError::new(
-                vm,
-                VMErrorKind::TypeError {
-                    expected: self.dyn_objtype(vm),
-                    got: other.dyn_objtype(vm),
-                },
-            ));
+            let expected = self.dyn_objtype(vm);
+            let got = other.dyn_objtype(vm);
+            return Err(VMError::new(vm, VMErrorKind::TypeError { expected, got }));
         }
         self.tobj(vm).unwrap().and(vm, other)
     }
 
     /// Produce a new `Val` which divides `other` from this.
-    pub fn div(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
+    pub fn div(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         debug_assert_eq!(ValKind::INT as usize, 0);
         if self.valkind() == ValKind::INT && other.valkind() == ValKind::INT {
             if other.val != 0 {
@@ -348,7 +346,7 @@ impl Val {
     }
 
     /// Produce a new `Val` which perfoms a Double divide on `other` with this.
-    pub fn double_div(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
+    pub fn double_div(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         if let Some(lhs) = self.as_isize(vm) {
             if let Some(rhs) = other.as_isize(vm) {
                 if rhs == 0 {
@@ -371,18 +369,14 @@ impl Val {
                     return Ok(Double::new(vm, (lhs as f64) / rhs.double()));
                 }
             }
-            return Err(VMError::new(
-                vm,
-                VMErrorKind::NotANumber {
-                    got: other.dyn_objtype(vm),
-                },
-            ));
+            let got = other.dyn_objtype(vm);
+            return Err(VMError::new(vm, VMErrorKind::NotANumber { got }));
         }
         self.tobj(vm).unwrap().double_div(vm, other)
     }
 
     /// Produce a new `Val` which performs a mod operation on this with `other`.
-    pub fn modulus(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
+    pub fn modulus(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         if let Some(lhs) = self.as_isize(vm) {
             if let Some(rhs) = other.as_isize(vm) {
                 return Val::from_isize(vm, lhs % rhs);
@@ -391,18 +385,14 @@ impl Val {
             } else if let Some(rhs) = other.try_downcast::<Double>(vm) {
                 return Ok(Double::new(vm, (lhs as f64) % rhs.double()));
             }
-            return Err(VMError::new(
-                vm,
-                VMErrorKind::NotANumber {
-                    got: other.dyn_objtype(vm),
-                },
-            ));
+            let got = other.dyn_objtype(vm);
+            return Err(VMError::new(vm, VMErrorKind::NotANumber { got }));
         }
         self.tobj(vm).unwrap().modulus(vm, other)
     }
 
     /// Produce a new `Val` which multiplies `other` to this.
-    pub fn mul(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
+    pub fn mul(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         debug_assert_eq!(ValKind::INT as usize, 0);
         if self.valkind() == ValKind::INT && other.valkind() == ValKind::INT {
             if let Some(val) = self.val.checked_mul(other.val / (1 << TAG_BITSIZE)) {
@@ -413,7 +403,7 @@ impl Val {
     }
 
     /// Produce a new `Val` which shifts `self` `other` bits to the left.
-    pub fn shl(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
+    pub fn shl(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         if let Some(lhs) = self.as_isize(vm) {
             if let Some(rhs) = other.as_isize(vm) {
                 if rhs < 0 {
@@ -441,18 +431,14 @@ impl Val {
             if other.try_downcast::<ArbInt>(vm).is_some() {
                 return Err(VMError::new(vm, VMErrorKind::ShiftTooBig));
             }
-            return Err(VMError::new(
-                vm,
-                VMErrorKind::NotANumber {
-                    got: other.dyn_objtype(vm),
-                },
-            ));
+            let got = other.dyn_objtype(vm);
+            return Err(VMError::new(vm, VMErrorKind::NotANumber { got }));
         }
         self.tobj(vm).unwrap().shl(vm, other)
     }
 
     /// Produces a new `Val` which is the square root of this.
-    pub fn sqrt(&self, vm: &VM) -> Result<Val, Box<VMError>> {
+    pub fn sqrt(&self, vm: &mut VM) -> Result<Val, Box<VMError>> {
         if let Some(lhs) = self.as_isize(vm) {
             if lhs < 0 {
                 return Err(VMError::new(vm, VMErrorKind::DomainError));
@@ -469,7 +455,7 @@ impl Val {
     }
 
     /// Produce a new `Val` which subtracts `other` from this.
-    pub fn sub(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
+    pub fn sub(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         debug_assert_eq!(ValKind::INT as usize, 0);
         if self.valkind() == ValKind::INT && other.valkind() == ValKind::INT {
             if let Some(val) = self.val.checked_sub(other.val) {
@@ -480,27 +466,23 @@ impl Val {
     }
 
     /// Produce a new `Val` which performs a bitwise xor operation with `other` and this.
-    pub fn xor(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
+    pub fn xor(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         if let Some(lhs) = self.as_isize(vm) {
             if let Some(rhs) = other.as_isize(vm) {
                 return Val::from_isize(vm, lhs ^ rhs);
             } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
                 return ArbInt::new(vm, BigInt::from_isize(lhs).unwrap() ^ rhs.bigint());
             }
-            return Err(VMError::new(
-                vm,
-                VMErrorKind::TypeError {
-                    expected: self.dyn_objtype(vm),
-                    got: other.dyn_objtype(vm),
-                },
-            ));
+            let expected = self.dyn_objtype(vm);
+            let got = other.dyn_objtype(vm);
+            return Err(VMError::new(vm, VMErrorKind::TypeError { expected, got }));
         }
         self.tobj(vm).unwrap().xor(vm, other)
     }
 
     /// Is this `Val` reference equal to `other`? Notice that for integers (but not Doubles)
     /// "reference equal" is equivalent to "equals".
-    pub fn ref_equals(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
+    pub fn ref_equals(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         match self.valkind() {
             ValKind::INT => self.equals(vm, other),
             ValKind::GCBOX => self.tobj(vm)?.ref_equals(vm, other),
@@ -512,7 +494,7 @@ impl Val {
 macro_rules! binop_all {
     ($name:ident, $op:tt, $tf:ident) => {
         impl Val {
-            pub fn $name(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
+            pub fn $name(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
                 if let Some(lhs) = self.as_isize(vm) {
                     if let Some(rhs) = other.as_isize(vm) {
                         Ok(Val::from_bool(vm, lhs $op rhs))
@@ -533,7 +515,7 @@ macro_rules! binop_all {
 macro_rules! binop_typeerror {
     ($name:ident, $op:tt) => {
         impl Val {
-            pub fn $name(&self, vm: &VM, other: Val) -> Result<Val, Box<VMError>> {
+            pub fn $name(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
                 if let Some(lhs) = self.as_isize(vm) {
                     if let Some(rhs) = other.as_isize(vm) {
                         Ok(Val::from_bool(vm, lhs $op rhs))
@@ -541,8 +523,9 @@ macro_rules! binop_typeerror {
                         Ok(Val::from_bool(vm,
                             &BigInt::from_isize(lhs).unwrap() $op rhs.bigint()))
                     } else {
+                        let got = other.dyn_objtype(vm);
                         Err(VMError::new(vm, VMErrorKind::NotANumber {
-                          got: other.dyn_objtype(vm),
+                          got
                         }))
                     }
                 } else {
@@ -607,80 +590,80 @@ mod tests {
 
     #[test]
     fn test_isize() {
-        let vm = VM::new_no_bootstrap();
+        let mut vm = VM::new_no_bootstrap();
 
-        let v = Val::from_isize(&vm, 0).unwrap();
+        let v = Val::from_isize(&mut vm, 0).unwrap();
         assert_eq!(v.valkind(), ValKind::INT);
-        assert_eq!(v.as_usize(&vm).unwrap(), 0);
-        assert_eq!(v.as_isize(&vm).unwrap(), 0);
+        assert_eq!(v.as_usize(&mut vm).unwrap(), 0);
+        assert_eq!(v.as_isize(&mut vm).unwrap(), 0);
 
-        let v = Val::from_isize(&vm, -1).unwrap();
+        let v = Val::from_isize(&mut vm, -1).unwrap();
         assert_eq!(v.valkind(), ValKind::INT);
-        assert!(v.as_usize(&vm).is_none());
-        assert_eq!(v.as_isize(&vm).unwrap(), -1);
+        assert!(v.as_usize(&mut vm).is_none());
+        assert_eq!(v.as_isize(&mut vm).unwrap(), -1);
 
-        let v = Val::from_isize(&vm, isize::min_value()).unwrap();
+        let v = Val::from_isize(&mut vm, isize::min_value()).unwrap();
         assert_eq!(v.valkind(), ValKind::GCBOX);
-        assert_eq!(v.as_isize(&vm).unwrap(), isize::min_value());
-        let v = Val::from_isize(&vm, isize::max_value()).unwrap();
+        assert_eq!(v.as_isize(&mut vm).unwrap(), isize::min_value());
+        let v = Val::from_isize(&mut vm, isize::max_value()).unwrap();
         assert_eq!(v.valkind(), ValKind::GCBOX);
-        assert_eq!(v.as_isize(&vm).unwrap(), isize::max_value());
+        assert_eq!(v.as_isize(&mut vm).unwrap(), isize::max_value());
 
-        let v = Val::from_isize(&vm, 1 << (BITSIZE - 1 - TAG_BITSIZE) - 1).unwrap();
+        let v = Val::from_isize(&mut vm, 1 << (BITSIZE - 1 - TAG_BITSIZE) - 1).unwrap();
         assert_eq!(v.valkind(), ValKind::INT);
         assert_eq!(
-            v.as_usize(&vm).unwrap(),
+            v.as_usize(&mut vm).unwrap(),
             1 << (BITSIZE - 1 - TAG_BITSIZE) - 1
         );
         assert_eq!(
-            v.as_isize(&vm).unwrap(),
+            v.as_isize(&mut vm).unwrap(),
             1 << (BITSIZE - 1 - TAG_BITSIZE) - 1
         );
 
-        let v = Val::from_isize(&vm, 1 << (BITSIZE - 2)).unwrap();
+        let v = Val::from_isize(&mut vm, 1 << (BITSIZE - 2)).unwrap();
         assert_eq!(v.valkind(), ValKind::GCBOX);
-        assert_eq!(v.as_usize(&vm).unwrap(), 1 << (BITSIZE - 2));
-        assert_eq!(v.as_isize(&vm).unwrap(), 1 << (BITSIZE - 2));
+        assert_eq!(v.as_usize(&mut vm).unwrap(), 1 << (BITSIZE - 2));
+        assert_eq!(v.as_isize(&mut vm).unwrap(), 1 << (BITSIZE - 2));
     }
 
     #[test]
     fn test_usize() {
-        let vm = VM::new_no_bootstrap();
+        let mut vm = VM::new_no_bootstrap();
 
-        let v = Val::from_usize(&vm, 0).unwrap();
+        let v = Val::from_usize(&mut vm, 0).unwrap();
         assert_eq!(v.valkind(), ValKind::INT);
-        assert_eq!(v.as_usize(&vm).unwrap(), 0);
-        assert_eq!(v.as_isize(&vm).unwrap(), 0);
+        assert_eq!(v.as_usize(&mut vm).unwrap(), 0);
+        assert_eq!(v.as_isize(&mut vm).unwrap(), 0);
 
-        let v = Val::from_usize(&vm, 1 << (BITSIZE - 1 - TAG_BITSIZE) - 1).unwrap();
+        let v = Val::from_usize(&mut vm, 1 << (BITSIZE - 1 - TAG_BITSIZE) - 1).unwrap();
         assert_eq!(v.valkind(), ValKind::INT);
         assert_eq!(
-            v.as_usize(&vm).unwrap(),
+            v.as_usize(&mut vm).unwrap(),
             1 << (BITSIZE - 1 - TAG_BITSIZE) - 1
         );
         assert_eq!(
-            v.as_isize(&vm).unwrap(),
+            v.as_isize(&mut vm).unwrap(),
             1 << (BITSIZE - 1 - TAG_BITSIZE) - 1
         );
 
-        assert!(Val::from_usize(&vm, 1 << (BITSIZE - 1))
+        assert!(Val::from_usize(&mut vm, 1 << (BITSIZE - 1))
             .unwrap()
-            .try_downcast::<ArbInt>(&vm)
+            .try_downcast::<ArbInt>(&mut vm)
             .is_some());
 
-        let v = Val::from_usize(&vm, 1 << (BITSIZE - 2)).unwrap();
+        let v = Val::from_usize(&mut vm, 1 << (BITSIZE - 2)).unwrap();
         assert_eq!(v.valkind(), ValKind::GCBOX);
-        assert_eq!(v.as_usize(&vm).unwrap(), 1 << (BITSIZE - 2));
-        assert_eq!(v.as_isize(&vm).unwrap(), 1 << (BITSIZE - 2));
+        assert_eq!(v.as_usize(&mut vm).unwrap(), 1 << (BITSIZE - 2));
+        assert_eq!(v.as_isize(&mut vm).unwrap(), 1 << (BITSIZE - 2));
     }
 
     #[test]
     fn test_recovery() {
-        let vm = VM::new_no_bootstrap();
+        let mut vm = VM::new_no_bootstrap();
 
         let v = {
-            let v = String_::new(&vm, "s".to_owned(), true);
-            let v_tobj = v.tobj(&vm).unwrap();
+            let v = String_::new(&mut vm, "s".to_owned(), true);
+            let v_tobj = v.tobj(&mut vm).unwrap();
             let v_int: &dyn Obj = v_tobj.deref().deref();
             let v_recovered = Val::recover(v_int);
             assert_eq!(v_recovered.val, v.val);
@@ -688,16 +671,16 @@ mod tests {
         };
         // At this point, we will have dropped one of the references to the String above so the
         // assertion below is really checking that we're not doing a read after free.
-        assert_eq!(v.downcast::<String_>(&vm).unwrap().as_str(), "s");
+        assert_eq!(v.downcast::<String_>(&mut vm).unwrap().as_str(), "s");
     }
 
     #[test]
     fn test_cast() {
-        let vm = VM::new_no_bootstrap();
-        let v = String_::new(&vm, "s".to_owned(), true);
-        assert!(v.downcast::<String_>(&vm).is_ok());
+        let mut vm = VM::new_no_bootstrap();
+        let v = String_::new(&mut vm, "s".to_owned(), true);
+        assert!(v.downcast::<String_>(&mut vm).is_ok());
         assert_eq!(
-            v.downcast::<Class>(&vm).unwrap_err().kind,
+            v.downcast::<Class>(&mut vm).unwrap_err().kind,
             VMErrorKind::TypeError {
                 expected: ObjType::Class,
                 got: ObjType::String_
@@ -707,15 +690,15 @@ mod tests {
 
     #[test]
     fn test_downcast() {
-        let vm = VM::new_no_bootstrap();
-        let v = String_::new(&vm, "s".to_owned(), true);
-        assert!(v.downcast::<String_>(&vm).is_ok());
-        assert!(v.downcast::<Class>(&vm).is_err());
-        assert!(v.try_downcast::<String_>(&vm).is_some());
-        assert!(v.try_downcast::<Class>(&vm).is_none());
+        let mut vm = VM::new_no_bootstrap();
+        let v = String_::new(&mut vm, "s".to_owned(), true);
+        assert!(v.downcast::<String_>(&mut vm).is_ok());
+        assert!(v.downcast::<Class>(&mut vm).is_err());
+        assert!(v.try_downcast::<String_>(&mut vm).is_some());
+        assert!(v.try_downcast::<Class>(&mut vm).is_none());
 
-        let v = Val::from_isize(&vm, 0).unwrap();
-        assert!(v.downcast::<String_>(&vm).is_err());
-        assert!(v.try_downcast::<String_>(&vm).is_none());
+        let v = Val::from_isize(&mut vm, 0).unwrap();
+        assert!(v.downcast::<String_>(&mut vm).is_err());
+        assert!(v.try_downcast::<String_>(&mut vm).is_none());
     }
 }

--- a/src/lib/vm/val.rs
+++ b/src/lib/vm/val.rs
@@ -130,7 +130,7 @@ impl Val {
     /// be boxed) or return a `VMError` if the cast is invalid.
     pub fn downcast<T: Obj + StaticObjType + NotUnboxable>(
         &self,
-        vm: &mut VM,
+        vm: &VM,
     ) -> Result<&T, Box<VMError>> {
         match self.valkind() {
             ValKind::INT => Err(VMError::new(
@@ -158,7 +158,7 @@ impl Val {
 
     /// Cast a `Val` into an instance of type `T` (where `T` must statically be a type that cannot
     /// be boxed) or return `None` if the cast is not valid.
-    pub fn try_downcast<T: Obj + StaticObjType + NotUnboxable>(&self, _: &mut VM) -> Option<&T> {
+    pub fn try_downcast<T: Obj + StaticObjType + NotUnboxable>(&self, _: &VM) -> Option<&T> {
         match self.valkind() {
             ValKind::INT => None,
             ValKind::GCBOX => unsafe { self.val_to_tobj() }.downcast(),
@@ -215,7 +215,7 @@ impl Val {
 
     /// If `v == true`, return a `Val` representing `vm.true_`, otherwise return a `Val`
     /// representing `vm.false_`.
-    pub fn from_bool(vm: &mut VM, v: bool) -> Val {
+    pub fn from_bool(vm: &VM, v: bool) -> Val {
         if v {
             vm.true_.clone()
         } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,9 +33,9 @@ fn main() {
         usage(prog);
     }
 
-    let vm = VM::new(matches.opt_strs("cp"));
+    let mut vm = VM::new(matches.opt_strs("cp"));
     let cls = vm.compile(&Path::new(&matches.free[0]).canonicalize().unwrap(), true);
-    let app = Inst::new(&vm, cls);
+    let app = Inst::new(&mut vm, cls);
     match vm.top_level_send(app, "run", vec![]) {
         Ok(_)
         | Err(box VMError {
@@ -43,7 +43,7 @@ fn main() {
             ..
         }) => (),
         Err(e) => {
-            e.console_print(&vm);
+            e.console_print(&mut vm);
             process::exit(1);
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,7 +43,7 @@ fn main() {
             ..
         }) => (),
         Err(e) => {
-            e.console_print(&mut vm);
+            e.console_print(&vm);
             process::exit(1);
         }
     }


### PR DESCRIPTION
This is a fairly long, but surprisingly mostly-not-too-difficult, PR that removes `UnsafeCell`s from nearly all parts of yksom. https://github.com/softdevteam/yksom/commit/4e13c53bcf5db87d2c24dc160344788f8ecb0aab is the biggie: it makes the core `VM` struct require `&mut self` which ripples throughout the entire system (e.g. requiring a fairly large number of new intermediate variables to keep the borrow checker happy). That commit also contains the explanation which, IMHO, justifies the rest of the PR. Overall, I think this is *probably* a good idea, because it's very clear that it's hard to use large numbers of `UnsafeCell`s correctly, but there is always the possibility that this makes the VM unergonomic in the long term (I suspect that https://github.com/softdevteam/yksom/commit/b2b9e26cbf3e9fdc922f0814c58f4e5afcaffc11 is probably the main way of making things unergonomic in the long term).

After the first commit, it's a mostly mechanical job to remove most other `UnsafeCell`s, with the notable exceptions of https://github.com/softdevteam/yksom/commit/b14d07dd8e209c36f98ecd5707aedd88a6fa01d2 and https://github.com/softdevteam/yksom/commit/09e37e2963cd363dd3e6a2bef92a28ecee43aa40.