### PR TITLE
Class methods and fields

### DIFF
--- a/lang_tests/class_methods_fields.som
+++ b/lang_tests/class_methods_fields.som
@@ -1,0 +1,21 @@
+"
+VM:
+  status: success
+  stdout:
+    #class_methods_fields
+    b
+"
+
+class_methods_fields = (
+    run = (
+        class_methods_fields name println.
+        class_methods_fields set: 'b'.
+        class_methods_fields get println.
+    )
+
+    ------
+    | f |
+
+    get = ( ^f )
+    set: o = ( f := o. )
+)

--- a/lang_tests/metaclasses.som
+++ b/lang_tests/metaclasses.som
@@ -1,0 +1,52 @@
+"
+VM:
+  status: success
+  stdout:
+    1
+    Integer
+    Integer class
+    Metaclass
+    Metaclass class
+    Metaclass
+    Metaclass class
+    Class
+    Object class
+    Class
+    Boolean class
+    Class
+    Object
+    nil
+    Class class
+    Metaclass
+    Object
+    Object class
+    Metaclass
+    Class
+    nil
+"
+
+metaclasses = (
+    run = (
+        1 println.
+        1 class println.
+        1 class class println.
+        1 class class class println.
+        1 class class class class println.
+        1 class class class class class println.
+        1 class class class class class class println.
+        Class println.
+        Class class superclass println.
+        Class class superclass superclass println.
+        True class superclass println.
+        Class class superclass superclass println.
+        Class superclass println.
+        Class superclass superclass println.
+        Class class println.
+        Class class class println.
+        Object println.
+        Object class println.
+        Object class class println.
+        Object class superclass println.
+        Object superclass println.
+    )
+)

--- a/lib/SOM/Metaclass.som
+++ b/lib/SOM/Metaclass.som
@@ -1,0 +1,1 @@
+Metaclass = Class ( )

--- a/src/lib/compiler/ast.rs
+++ b/src/lib/compiler/ast.rs
@@ -6,6 +6,8 @@ pub struct Class {
     pub supername: Option<Span>,
     pub inst_vars: Vec<Span>,
     pub methods: Vec<Method>,
+    pub class_inst_vars: Vec<Span>,
+    pub class_methods: Vec<Method>,
 }
 
 #[derive(Debug)]

--- a/src/lib/compiler/ast_to_instrs.rs
+++ b/src/lib/compiler/ast_to_instrs.rs
@@ -16,7 +16,7 @@ use crate::{
     },
     vm::{
         objects::{BlockInfo, Class, Method, MethodBody, String_},
-        val::{Val, ValKind},
+        val::Val,
         VM,
     },
 };
@@ -47,51 +47,57 @@ impl<'a> Compiler<'a> {
             vars_stack: Vec::new(),
             closure_depth: 0,
         };
-        let instrs_off = vm.instrs_len();
 
-        let mut errs = vec![];
         let name = lexer.span_str(astcls.name).to_owned();
-        let supercls;
-        if name != "Object" {
-            if let Some(n) = astcls.supername.map(|x| lexer.span_str(x)) {
-                supercls = match n {
-                    "Block" => Some(vm.block_cls.clone()),
-                    "Boolean" => Some(vm.bool_cls.clone()),
-                    "nil" => None,
-                    "String" => Some(vm.str_cls.clone()),
+        let (supercls, supercls_meta) = if name != "Object" {
+            let supercls = if let Some(n) = astcls.supername.map(|x| lexer.span_str(x)) {
+                match n {
+                    "Block" => vm.block_cls.clone(),
+                    "Class" => vm.cls_cls.clone(),
+                    "Boolean" => vm.bool_cls.clone(),
+                    "String" => vm.str_cls.clone(),
                     _ => unimplemented!(),
-                };
+                }
             } else {
-                supercls = Some(vm.obj_cls.clone());
-            }
-            // Whatever superclass has been chosen, it must have been initialised already or else
-            // bad things will happen.
-            debug_assert_ne!(
-                supercls.as_ref().map(|x| x.valkind()),
-                Some(ValKind::ILLEGAL)
-            );
+                vm.obj_cls.clone()
+            };
+            (supercls.clone(), supercls.get_class(vm).clone())
         } else {
-            supercls = None;
-        }
+            (vm.nil.clone(), vm.nil.clone())
+        };
 
-        let mut inst_vars = HashMap::with_capacity(astcls.inst_vars.len());
-        for var in &astcls.inst_vars {
-            let vars_len = inst_vars.len();
-            inst_vars.insert(lexer.span_str(*var), vars_len);
-        }
-        compiler.vars_stack.push(inst_vars);
-
-        let mut methods = HashMap::with_capacity(astcls.methods.len());
-        for astmeth in &astcls.methods {
-            match compiler.c_method(vm, &astmeth) {
-                Ok(m) => {
-                    methods.insert(m.name.clone(), Gc::new(m));
-                }
-                Err(mut e) => {
-                    errs.extend(e.drain(..));
-                }
+        // Create the "main" class.
+        let mut errs = vec![];
+        let cls = match compiler.c_class(
+            vm,
+            lexer,
+            name.clone(),
+            supercls,
+            &astcls.inst_vars,
+            &astcls.methods,
+        ) {
+            Ok(c) => Some(c),
+            Err(e) => {
+                errs.extend(e);
+                None
             }
-        }
+        };
+
+        // Create the metaclass (i.e. for a class C, this creates a class called "C class").
+        let metacls = match compiler.c_class(
+            vm,
+            lexer,
+            format!("{} class", &name),
+            supercls_meta,
+            &astcls.class_inst_vars,
+            &astcls.class_methods,
+        ) {
+            Ok(c) => Some(c),
+            Err(e) => {
+                errs.extend(e);
+                None
+            }
+        };
 
         if !errs.is_empty() {
             let err_strs = errs
@@ -117,23 +123,70 @@ impl<'a> Compiler<'a> {
             return Err(err_strs);
         }
 
-        let name_val = String_::new(vm, name.clone(), false);
-        let cls_val = Val::from_obj(
+        let cls = cls.unwrap();
+        let metacls = metacls.unwrap();
+        metacls
+            .downcast::<Class>(&vm)
+            .unwrap()
+            .set_metacls(&vm, vm.metacls_cls.clone());
+        cls.downcast::<Class>(&vm)
+            .unwrap()
+            .set_metacls(&vm, metacls);
+
+        Ok((name, cls))
+    }
+
+    fn c_class(
+        &mut self,
+        vm: &mut VM,
+        lexer: &'a dyn Lexer<StorageT>,
+        name: String,
+        supercls: Val,
+        ast_inst_vars: &[Span],
+        ast_methods: &[ast::Method],
+    ) -> CompileResult<Val> {
+        let instrs_off = vm.instrs_len();
+        let mut inst_vars = HashMap::with_capacity(ast_inst_vars.len());
+        for var in ast_inst_vars {
+            let vars_len = inst_vars.len();
+            inst_vars.insert(lexer.span_str(*var), vars_len);
+        }
+        self.vars_stack.push(inst_vars);
+
+        let mut methods = HashMap::with_capacity(ast_methods.len());
+        let mut errs = vec![];
+        for astmeth in ast_methods {
+            match self.c_method(vm, astmeth) {
+                Ok(m) => {
+                    methods.insert(m.name.clone(), Gc::new(m));
+                }
+                Err(mut e) => {
+                    errs.extend(e.drain(..));
+                }
+            }
+        }
+        self.vars_stack.pop();
+        if !errs.is_empty() {
+            return Err(errs);
+        }
+
+        let name_val = String_::new(vm, name, false);
+        let cls = Class::new(
             vm,
-            Class {
-                name: name_val,
-                path: compiler.path.to_path_buf(),
-                instrs_off,
-                supercls,
-                num_inst_vars: astcls.inst_vars.len(),
-                methods,
-            },
+            vm.cls_cls.clone(),
+            name_val,
+            self.path.to_path_buf(),
+            instrs_off,
+            supercls,
+            ast_inst_vars.len(),
+            methods,
         );
+        let cls_val = Val::from_obj(vm, cls);
         let cls: &Class = cls_val.downcast(vm).unwrap();
         for m in cls.methods.values() {
             m.set_class(vm, cls_val.clone());
         }
-        Ok((name, cls_val))
+        Ok(cls_val)
     }
 
     fn c_method(&mut self, vm: &mut VM, astmeth: &ast::Method) -> CompileResult<Method> {

--- a/src/lib/compiler/ast_to_instrs.rs
+++ b/src/lib/compiler/ast_to_instrs.rs
@@ -40,7 +40,7 @@ impl<'a> Compiler<'a> {
         lexer: &dyn Lexer<StorageT>,
         path: &Path,
         astcls: &ast::Class,
-    ) -> Result<Val, String> {
+    ) -> Result<(String, Val), String> {
         let mut compiler = Compiler {
             lexer,
             path,
@@ -117,11 +117,11 @@ impl<'a> Compiler<'a> {
             return Err(err_strs);
         }
 
-        let name = String_::new(vm, name, false);
+        let name_val = String_::new(vm, name.clone(), false);
         let cls_val = Val::from_obj(
             vm,
             Class {
-                name,
+                name: name_val,
                 path: compiler.path.to_path_buf(),
                 instrs_off,
                 supercls,
@@ -133,7 +133,7 @@ impl<'a> Compiler<'a> {
         for m in cls.methods.values() {
             m.set_class(vm, cls_val.clone());
         }
-        Ok(cls_val)
+        Ok((name, cls_val))
     }
 
     fn c_method(&mut self, vm: &mut VM, astmeth: &ast::Method) -> CompileResult<Method> {

--- a/src/lib/compiler/mod.rs
+++ b/src/lib/compiler/mod.rs
@@ -20,7 +20,7 @@ lrpar_mod!("lib/compiler/som.y");
 type StorageT = u32;
 
 /// Compile a class. Should only be called by the `VM`.
-pub fn compile(vm: &mut VM, path: &Path) -> Val {
+pub fn compile(vm: &mut VM, path: &Path) -> (String, Val) {
     let bytes = fs::read(path).unwrap_or_else(|_| panic!("Can't read {}.", path.to_str().unwrap()));
     let txt = String::from_utf8_lossy(&bytes);
 
@@ -32,14 +32,13 @@ pub fn compile(vm: &mut VM, path: &Path) -> Val {
     }
     match astopt {
         Some(Ok(astcls)) => {
-            let cls = ast_to_instrs::Compiler::compile(vm, &lexer, &path, &astcls).unwrap_or_else(
-                |msg| {
+            let (name, cls) = ast_to_instrs::Compiler::compile(vm, &lexer, &path, &astcls)
+                .unwrap_or_else(|msg| {
                     eprintln!("{}", msg);
                     process::exit(1);
-                },
-            );
+                });
             if errs.is_empty() {
-                cls
+                (name, cls)
             } else {
                 process::exit(1);
             }

--- a/src/lib/compiler/som.y
+++ b/src/lib/compiler/som.y
@@ -3,7 +3,15 @@
 %%
 ClassDef -> Result<Class, ()>:
       "ID" "=" SuperClass "(" NameDefs MethodsOpt ClassMethods ")"
-      { Ok(Class{ name: map_err($1)?.span(), supername: $3?, inst_vars: $5?, methods: $6? }) }
+      { let (class_inst_vars, class_methods) = $7?;
+        Ok(Class{ name: map_err($1)?.span(),
+                  supername: $3?,
+                  inst_vars: $5?,
+                  methods: $6?,
+                  class_inst_vars,
+                  class_methods
+                })
+      }
     ;
 SuperClass -> Result<Option<Span>, ()>:
       "ID" { Ok(Some(map_err($1)?.span())) }
@@ -17,9 +25,11 @@ Methods -> Result<Vec<Method>, ()>:
       Method { Ok(vec![$1?]) }
     | Methods Method { flattenr($1, $2) }
     ;
-ClassMethods -> Result<(), ()>:
-          "SEPARATOR" NameDefs MethodsOpt { unimplemented!() }
-    | { Ok(()) }
+ClassMethods -> Result<(Vec<Span>, Vec<Method>), ()>:
+      "SEPARATOR" NameDefs MethodsOpt {
+        todo!()
+      }
+    | { Ok((vec![], vec![])) }
     ;
 Method -> Result<Method, ()>:
       MethodName "=" MethodBody

--- a/src/lib/compiler/som.y
+++ b/src/lib/compiler/som.y
@@ -27,7 +27,7 @@ Methods -> Result<Vec<Method>, ()>:
     ;
 ClassMethods -> Result<(Vec<Span>, Vec<Method>), ()>:
       "SEPARATOR" NameDefs MethodsOpt {
-        todo!()
+        Ok(($2?, $3?))
       }
     | { Ok((vec![], vec![])) }
     ;

--- a/src/lib/vm/core.rs
+++ b/src/lib/vm/core.rs
@@ -426,12 +426,12 @@ impl VM {
                     pc += 1;
                 }
                 Instr::InstVarLookup(n) => {
-                    let inst: &Inst = rcv.downcast(self).unwrap();
+                    let inst = stry!(rcv.tobj(self));
                     self.stack.push(inst.inst_var_lookup(n));
                     pc += 1;
                 }
                 Instr::InstVarSet(n) => {
-                    let inst: &Inst = rcv.downcast(self).unwrap();
+                    let inst = stry!(rcv.tobj(self));
                     inst.inst_var_set(n, self.stack.peek());
                     pc += 1;
                 }

--- a/src/lib/vm/core.rs
+++ b/src/lib/vm/core.rs
@@ -175,12 +175,12 @@ impl VM {
     /// Compile the file at `path`. `inst_vars_allowed` should be set to `false` only for those
     /// builtin classes which do not lead to run-time instances of `Inst`.
     pub fn compile(&mut self, path: &Path, inst_vars_allowed: bool) -> Val {
-        let cls_val = compile(self, path);
+        let (name, cls_val) = compile(self, path);
         let cls: &Class = cls_val.downcast(self).unwrap();
         if !inst_vars_allowed && cls.num_inst_vars > 0 {
             panic!("No instance vars allowed in {}", path.to_str().unwrap());
         }
-        self.classes.push(cls_val.clone());
+        self.set_global(&name, cls_val.clone());
         cls_val
     }
 

--- a/src/lib/vm/core.rs
+++ b/src/lib/vm/core.rs
@@ -62,7 +62,6 @@ pub struct VM {
     pub system: Val,
     pub true_: Val,
     blockinfos: Vec<BlockInfo>,
-    classes: Vec<Val>,
     /// The current known set of globals including those not yet assigned to: in other words, it is
     /// expected that some entries of this `Vec` are illegal (i.e. created by `Val::illegal`).
     globals: Vec<Val>,
@@ -115,7 +114,6 @@ impl VM {
             system: Val::illegal(),
             true_: Val::illegal(),
             blockinfos: Vec::new(),
-            classes: Vec::new(),
             globals: Vec::new(),
             reverse_globals: HashMap::new(),
             inline_caches: Vec::new(),
@@ -1040,7 +1038,6 @@ impl VM {
             system: Val::illegal(),
             true_: Val::illegal(),
             blockinfos: Vec::new(),
-            classes: Vec::new(),
             globals: Vec::new(),
             reverse_globals: HashMap::new(),
             inline_caches: Vec::new(),

--- a/src/lib/vm/objects/class.rs
+++ b/src/lib/vm/objects/class.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::new_ret_no_self)]
 
-use std::{collections::HashMap, path::PathBuf, str};
+use std::{cell::UnsafeCell, collections::HashMap, path::PathBuf, str};
 
 use abgc::Gc;
 use abgc_derive::GcLayout;
@@ -9,16 +9,17 @@ use crate::vm::{
     core::VM,
     error::{VMError, VMErrorKind},
     objects::{Method, Obj, ObjType, StaticObjType},
-    val::{NotUnboxable, Val},
+    val::{NotUnboxable, Val, ValKind},
 };
 
 #[derive(Debug, GcLayout)]
 pub struct Class {
+    metacls: UnsafeCell<Val>,
     pub name: Val,
     pub path: PathBuf,
     /// Offset to this class's instructions in VM::instrs.
     pub instrs_off: usize,
-    pub supercls: Option<Val>,
+    supercls: UnsafeCell<Val>,
     pub num_inst_vars: usize,
     pub methods: HashMap<String, Gc<Method>>,
 }
@@ -28,8 +29,9 @@ impl Obj for Class {
         ObjType::Class
     }
 
-    fn get_class(&self, vm: &mut VM) -> Val {
-        vm.cls_cls.clone()
+    fn get_class(&self, _: &mut VM) -> Val {
+        debug_assert!(unsafe { &*self.metacls.get() }.valkind() != ValKind::ILLEGAL);
+        unsafe { &*self.metacls.get() }.clone()
     }
 }
 
@@ -42,6 +44,27 @@ impl StaticObjType for Class {
 }
 
 impl Class {
+    pub fn new(
+        _: &VM,
+        metacls: Val,
+        name: Val,
+        path: PathBuf,
+        instrs_off: usize,
+        supercls: Val,
+        num_inst_vars: usize,
+        methods: HashMap<String, Gc<Method>>,
+    ) -> Self {
+        Class {
+            metacls: UnsafeCell::new(metacls),
+            name,
+            path,
+            instrs_off,
+            supercls: UnsafeCell::new(supercls),
+            num_inst_vars,
+            methods,
+        }
+    }
+
     pub fn name(&self, _: &VM) -> Result<Val, Box<VMError>> {
         Ok(self.name.clone())
     }
@@ -50,16 +73,25 @@ impl Class {
         self.methods
             .get(msg)
             .map(|x| Ok(Gc::clone(x)))
-            .unwrap_or_else(|| match &self.supercls {
-                Some(scls) => scls.downcast::<Class>(vm)?.get_method(vm, msg),
-                None => Err(VMError::new(vm, VMErrorKind::UnknownMethod(msg.to_owned()))),
+            .unwrap_or_else(|| {
+                let supercls = self.supercls(vm);
+                if supercls != vm.nil {
+                    supercls.downcast::<Class>(vm)?.get_method(vm, msg)
+                } else {
+                    Err(VMError::new(vm, VMErrorKind::UnknownMethod(msg.to_owned())))
+                }
             })
     }
 
-    pub fn superclass(&self, vm: &VM) -> Val {
-        if let Some(superclass) = &self.supercls {
-            return superclass.clone();
-        }
-        vm.nil.clone()
+    pub fn set_metacls(&self, _: &VM, cls: Val) {
+        *unsafe { &mut *self.metacls.get() } = cls;
+    }
+
+    pub fn supercls(&self, _: &VM) -> Val {
+        unsafe { &*self.supercls.get() }.clone()
+    }
+
+    pub fn set_supercls(&self, _: &VM, cls: Val) {
+        *unsafe { &mut *self.supercls.get() } = cls;
     }
 }

--- a/src/lib/vm/objects/instance.rs
+++ b/src/lib/vm/objects/instance.rs
@@ -25,6 +25,16 @@ impl Obj for Inst {
     fn get_class(&self, _: &mut VM) -> Val {
         self.class.clone()
     }
+
+    fn inst_var_lookup(&self, n: usize) -> Val {
+        let inst_vars = unsafe { &mut *self.inst_vars.get() };
+        inst_vars[n].clone()
+    }
+
+    fn inst_var_set(&self, n: usize, v: Val) {
+        let inst_vars = unsafe { &mut *self.inst_vars.get() };
+        inst_vars[n] = v;
+    }
 }
 
 impl NotUnboxable for Inst {}
@@ -45,15 +55,5 @@ impl Inst {
             inst_vars: UnsafeCell::new(inst_vars),
         };
         Val::from_obj(vm, inst)
-    }
-
-    pub fn inst_var_lookup(&self, n: usize) -> Val {
-        let inst_vars = unsafe { &mut *self.inst_vars.get() };
-        inst_vars[n].clone()
-    }
-
-    pub fn inst_var_set(&self, n: usize, v: Val) {
-        let inst_vars = unsafe { &mut *self.inst_vars.get() };
-        inst_vars[n] = v;
     }
 }

--- a/src/lib/vm/objects/mod.rs
+++ b/src/lib/vm/objects/mod.rs
@@ -83,6 +83,16 @@ pub trait Obj: std::fmt::Debug + abgc::GcLayout {
         unimplemented!();
     }
 
+    /// Lookup an instance variable in this object.
+    fn inst_var_lookup(&self, _: usize) -> Val {
+        todo!();
+    }
+
+    /// Set an instance variable in this object.
+    fn inst_var_set(&self, _: usize, _: Val) {
+        todo!();
+    }
+
     /// Produce a new `Val` which adds `other` to this.
     fn add(&self, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
         unimplemented!();


### PR DESCRIPTION
This PR adds support for class methods and fields, which also requires metaclasses too. I needed a bit of help from @smarr to understand this, because in essence if you define a class:

```
  C = (
    |x|
    m1 = ( 'm1' println. )
    ------
    |y|
    m2 = ( 'm2' println. )
  )
```

you're actually defining two classes. The class C is:

```
  C = (
    |x|
    m1 = ( 'm1' println. )
  )
```

and its metaclass:

```
  Cclass = (
    |y|
    m2 = ( 'm2' println. )
  )
```

The [`class_methods_fields.som`](https://github.com/ltratt/yksom/blob/f47e711582b4d6e9d43c1337904df82696445fcd/lang_tests/class_methods_fields.som) lang_test shows this in action. However, the first major step towards this is metaclasses (https://github.com/softdevteam/yksom/commit/31555a97c348860551892a83af057a4072bcd178), which is much trickier, as we have to deal with the fact that during VM initialisation we want to create references to objects which don't yet exist. Once that's done properly, most of the other bits fall into place relatively easily (famous last words).

@smarr Are there any tests you think should be added here?