### PR TITLE
Remove clones

### DIFF
--- a/src/lib/compiler/ast_to_instrs.rs
+++ b/src/lib/compiler/ast_to_instrs.rs
@@ -52,18 +52,18 @@ impl<'a> Compiler<'a> {
         let (supercls, supercls_meta) = if name != "Object" {
             let supercls = if let Some(n) = astcls.supername.map(|x| lexer.span_str(x)) {
                 match n {
-                    "Block" => vm.block_cls.clone(),
-                    "Class" => vm.cls_cls.clone(),
-                    "Boolean" => vm.bool_cls.clone(),
-                    "String" => vm.str_cls.clone(),
+                    "Block" => vm.block_cls,
+                    "Class" => vm.cls_cls,
+                    "Boolean" => vm.bool_cls,
+                    "String" => vm.str_cls,
                     _ => unimplemented!(),
                 }
             } else {
-                vm.obj_cls.clone()
+                vm.obj_cls
             };
-            (supercls.clone(), supercls.get_class(vm).clone())
+            (supercls, supercls.get_class(vm))
         } else {
-            (vm.nil.clone(), vm.nil.clone())
+            (vm.nil, vm.nil)
         };
 
         // Create the "main" class.
@@ -128,7 +128,7 @@ impl<'a> Compiler<'a> {
         metacls
             .downcast::<Class>(&vm)
             .unwrap()
-            .set_metacls(&vm, vm.metacls_cls.clone());
+            .set_metacls(&vm, vm.metacls_cls);
         cls.downcast::<Class>(&vm)
             .unwrap()
             .set_metacls(&vm, metacls);
@@ -173,7 +173,7 @@ impl<'a> Compiler<'a> {
         let name_val = String_::new(vm, name, false);
         let cls = Class::new(
             vm,
-            vm.cls_cls.clone(),
+            vm.cls_cls,
             name_val,
             self.path.to_path_buf(),
             instrs_off,
@@ -184,7 +184,7 @@ impl<'a> Compiler<'a> {
         let cls_val = Val::from_obj(vm, cls);
         let cls: &Class = cls_val.downcast(vm).unwrap();
         for m in cls.methods.values() {
-            m.set_class(vm, cls_val.clone());
+            m.set_class(vm, cls_val);
         }
         Ok(cls_val)
     }

--- a/src/lib/compiler/ast_to_instrs.rs
+++ b/src/lib/compiler/ast_to_instrs.rs
@@ -4,9 +4,9 @@ use std::{
     path::Path,
 };
 
-use rboehm::Gc;
 use itertools::Itertools;
 use lrpar::{Lexer, Span};
+use rboehm::Gc;
 
 use crate::{
     compiler::{

--- a/src/lib/vm/core.rs
+++ b/src/lib/vm/core.rs
@@ -140,44 +140,44 @@ impl VM {
         vm.obj_cls = vm.init_builtin_class("Object", false);
         vm.cls_cls = vm.init_builtin_class("Class", false);
         vm.nil_cls = vm.init_builtin_class("Nil", true);
-        let v = vm.nil_cls.clone();
+        let v = vm.nil_cls;
         vm.nil = Inst::new(&mut vm, v);
         vm.metacls_cls = vm.init_builtin_class("Metaclass", false);
         {
             // Patch incorrect references.
-            let obj_cls = vm.obj_cls.clone();
+            let obj_cls = vm.obj_cls;
             obj_cls
                 .downcast::<Class>(&vm)
                 .unwrap()
-                .set_supercls(&vm, vm.nil.clone());
-            obj_cls
-                .get_class(&mut vm)
-                .downcast::<Class>(&vm)
-                .unwrap()
-                .set_metacls(&vm, vm.metacls_cls.clone());
+                .set_supercls(&vm, vm.nil);
             obj_cls
                 .get_class(&mut vm)
                 .downcast::<Class>(&vm)
                 .unwrap()
-                .set_supercls(&vm, vm.cls_cls.clone());
-            let cls_cls = vm.cls_cls.clone();
+                .set_metacls(&vm, vm.metacls_cls);
+            obj_cls
+                .get_class(&mut vm)
+                .downcast::<Class>(&vm)
+                .unwrap()
+                .set_supercls(&vm, vm.cls_cls);
+            let cls_cls = vm.cls_cls;
             cls_cls
                 .get_class(&mut vm)
                 .downcast::<Class>(&vm)
                 .unwrap()
-                .set_metacls(&vm, vm.metacls_cls.clone());
-            let nil_cls = vm.nil_cls.clone();
+                .set_metacls(&vm, vm.metacls_cls);
+            let nil_cls = vm.nil_cls;
             nil_cls
                 .get_class(&mut vm)
                 .downcast::<Class>(&vm)
                 .unwrap()
-                .set_metacls(&vm, vm.metacls_cls.clone());
-            let metacls_cls = vm.metacls_cls.clone();
+                .set_metacls(&vm, vm.metacls_cls);
+            let metacls_cls = vm.metacls_cls;
             metacls_cls
                 .get_class(&mut vm)
                 .downcast::<Class>(&vm)
                 .unwrap()
-                .set_metacls(&vm, vm.metacls_cls.clone());
+                .set_metacls(&vm, vm.metacls_cls);
         }
 
         // The slightly delicate phase.
@@ -194,18 +194,18 @@ impl VM {
         vm.sym_cls = vm.init_builtin_class("Symbol", false);
         vm.system_cls = vm.init_builtin_class("System", false);
         vm.true_cls = vm.init_builtin_class("True", false);
-        let v = vm.false_cls.clone();
+        let v = vm.false_cls;
         vm.false_ = Inst::new(&mut vm, v);
-        let v = vm.system_cls.clone();
+        let v = vm.system_cls;
         vm.system = Inst::new(&mut vm, v);
-        let v = vm.true_cls.clone();
+        let v = vm.true_cls;
         vm.true_ = Inst::new(&mut vm, v);
 
         // Populate globals.
-        vm.set_global("false", vm.false_.clone());
-        vm.set_global("nil", vm.nil.clone());
-        vm.set_global("true", vm.true_.clone());
-        let v = vm.system_cls.clone();
+        vm.set_global("false", vm.false_);
+        vm.set_global("nil", vm.nil);
+        vm.set_global("true", vm.true_);
+        let v = vm.system_cls;
         let v = Inst::new(&mut vm, v);
         vm.set_global("system", v);
 
@@ -220,7 +220,7 @@ impl VM {
         if !inst_vars_allowed && cls.num_inst_vars > 0 {
             panic!("No instance vars allowed in {}", path.to_str().unwrap());
         }
-        self.set_global(&name, cls_val.clone());
+        self.set_global(&name, cls_val);
         cls_val
     }
 
@@ -244,7 +244,7 @@ impl VM {
             .unwrap_or_else(|_| panic!("Can't find builtin class '{}'", name));
 
         let val = self.compile(&path, inst_vars_allowed);
-        self.set_global(name, val.clone());
+        self.set_global(name, val);
 
         val
     }
@@ -281,7 +281,7 @@ impl VM {
                 for a in args {
                     self.stack.push(a);
                 }
-                let frame = Frame::new(self, true, rcv.clone(), None, num_vars, nargs);
+                let frame = Frame::new(self, true, rcv, None, num_vars, nargs);
                 self.frames.push(frame);
                 let r = self.exec_user(rcv, meth, bytecode_off);
                 self.frame_pop();
@@ -306,7 +306,7 @@ impl VM {
                 if self.stack.remaining_capacity() < max_stack {
                     panic!("Not enough stack space to execute method.");
                 }
-                let nframe = Frame::new(self, true, rcv.clone(), None, num_vars, nargs);
+                let nframe = Frame::new(self, true, rcv, None, num_vars, nargs);
                 self.frames.push(nframe);
                 let r = self.exec_user(rcv, method, bytecode_off);
                 self.frame_pop();
@@ -363,7 +363,7 @@ impl VM {
                         (blkinfo.num_params, blkinfo.bytecode_end)
                     };
                     let closure = self.current_frame().closure;
-                    let v = Block::new(self, method, rcv.clone(), blkinfo_off, closure, num_params);
+                    let v = Block::new(self, method, rcv, blkinfo_off, closure, num_params);
                     self.stack.push(v);
                     pc = bytecode_end;
                 }
@@ -392,10 +392,10 @@ impl VM {
                     pc += 1;
                 }
                 Instr::GlobalLookup(i) => {
-                    let v = &self.globals[i];
+                    let v = self.globals[i];
                     if v.valkind() != ValKind::ILLEGAL {
                         // The global value is already set
-                        self.stack.push(v.clone());
+                        self.stack.push(v);
                     } else {
                         // We have to call `self unknownGlobal:<symbol name>`.
                         let cls_val = rcv.get_class(self);
@@ -410,11 +410,11 @@ impl VM {
                                 .find(|(_, j)| **j == i)
                                 .map(|(n, _)| n)
                                 .unwrap()
-                                .clone()
+                                .to_string()
                         };
                         let v = String_::new(self, name, false);
                         self.stack.push(v);
-                        send_args_on_stack!(rcv.clone(), meth, 1);
+                        send_args_on_stack!(rcv, meth, 1);
                     }
                     pc += 1;
                 }
@@ -478,13 +478,13 @@ impl VM {
                 }
                 Instr::String(string_off) => {
                     debug_assert!(self.strings.len() > string_off);
-                    let s = unsafe { self.strings.get_unchecked(string_off) }.clone();
+                    let s = *unsafe { self.strings.get_unchecked(string_off) };
                     self.stack.push(s);
                     pc += 1;
                 }
                 Instr::Symbol(symbol_off) => {
                     debug_assert!(self.symbols.len() > symbol_off);
-                    let s = unsafe { self.symbols.get_unchecked(symbol_off) }.clone();
+                    let s = *unsafe { self.symbols.get_unchecked(symbol_off) };
                     self.stack.push(s);
                     pc += 1;
                 }
@@ -657,7 +657,7 @@ impl VM {
                         self.stack.push(cls);
                     }
                     Err(_) => {
-                        let v = self.nil.clone();
+                        let v = self.nil;
                         self.stack.push(v);
                     }
                 }
@@ -708,7 +708,7 @@ impl VM {
             Primitive::Restart => unreachable!(),
             Primitive::PrintNewline => {
                 println!();
-                let v = self.system.clone();
+                let v = self.system;
                 self.stack.push(v);
                 SendReturn::Val
             }
@@ -716,7 +716,7 @@ impl VM {
                 let v = self.stack.pop();
                 let str_: &String_ = stry!(v.downcast(self));
                 print!("{}", str_.as_str());
-                let v = self.system.clone();
+                let v = self.system;
                 self.stack.push(v);
                 SendReturn::Val
             }
@@ -759,13 +759,13 @@ impl VM {
                 let frame = Frame::new(
                     self,
                     false,
-                    rcv.clone(),
+                    rcv,
                     Some(rcv_blk.parent_closure),
                     num_vars,
                     nargs as usize,
                 );
                 self.frames.push(frame);
-                let r = self.exec_user(rcv_blk.inst.clone(), rcv_blk.method, bytecode_off);
+                let r = self.exec_user(rcv_blk.inst, rcv_blk.method, bytecode_off);
                 self.frame_pop();
                 r
             }
@@ -896,7 +896,7 @@ impl VM {
             *i
         } else {
             let len = self.globals.len();
-            self.reverse_globals.insert(s.clone(), len);
+            self.reverse_globals.insert(s, len);
             self.globals.push(Val::illegal());
             len
         }
@@ -905,21 +905,21 @@ impl VM {
     /// Lookup the global `name`: if it has not been added, or has been added but not set, then
     /// `self.nil` will be returned.
     pub fn get_global_or_nil(&self, name: &str) -> Val {
-        if let Some(i) = self.reverse_globals.get(name).cloned() {
-            let v = &self.globals[i];
+        if let Some(i) = self.reverse_globals.get(name) {
+            let v = self.globals[*i];
             if v.valkind() != ValKind::ILLEGAL {
-                return v.clone();
+                return v;
             }
         }
-        self.nil.clone()
+        self.nil
     }
 
     /// Get the global at position `i`: if it has not been set (i.e. is `ValKind::ILLEGAL`) this
     /// will return `Err(...)`.
     pub fn get_legal_global(&self, i: usize) -> Result<Val, Box<VMError>> {
-        let v = &self.globals[i];
+        let v = self.globals[i];
         if v.valkind() != ValKind::ILLEGAL {
-            return Ok(v.clone());
+            return Ok(v);
         }
         Err(VMError::new(
             self,
@@ -975,14 +975,14 @@ impl Frame {
                 vars[num_args - i] = vm.stack.pop();
             }
             for v in vars.iter_mut().skip(num_args + 1).take(num_vars) {
-                *v = vm.nil.clone();
+                *v = vm.nil;
             }
         } else {
             for i in 0..num_args {
                 vars[num_args - i - 1] = vm.stack.pop();
             }
             for v in vars.iter_mut().skip(num_args).take(num_vars) {
-                *v = vm.nil.clone();
+                *v = vm.nil;
             }
         }
 
@@ -1040,7 +1040,7 @@ impl Closure {
     }
 
     fn get_var(&self, var: usize) -> Val {
-        unsafe { (&*self.vars.0.get()).get_unchecked(var) }.clone()
+        *unsafe { (&*self.vars.0.get()).get_unchecked(var) }
     }
 
     fn set_var(&self, var: usize, val: Val) {

--- a/src/lib/vm/error.rs
+++ b/src/lib/vm/error.rs
@@ -1,7 +1,7 @@
 use std::{fs::read_to_string, io::stderr};
 
-use rboehm::Gc;
 use lrpar::Span;
+use rboehm::Gc;
 use termion::{is_tty, style};
 
 use crate::vm::{

--- a/src/lib/vm/objects/block.rs
+++ b/src/lib/vm/objects/block.rs
@@ -36,7 +36,7 @@ impl Obj for Block {
     }
 
     fn get_class(&self, _: &mut VM) -> Val {
-        self.blockn_cls.clone()
+        self.blockn_cls
     }
 }
 
@@ -58,9 +58,9 @@ impl Block {
         num_params: usize,
     ) -> Val {
         let blockn_cls = match num_params {
-            0 => vm.block_cls.clone(),
-            1 => vm.block2_cls.clone(),
-            2 => vm.block3_cls.clone(),
+            0 => vm.block_cls,
+            1 => vm.block2_cls,
+            2 => vm.block3_cls,
             _ => unimplemented!(),
         };
         Val::from_obj(

--- a/src/lib/vm/objects/class.rs
+++ b/src/lib/vm/objects/class.rs
@@ -36,7 +36,7 @@ impl Obj for Class {
 
     fn inst_var_lookup(&self, n: usize) -> Val {
         let inst_vars = unsafe { &mut *self.inst_vars.get() };
-        inst_vars[n].clone()
+        inst_vars[n]
     }
 
     fn inst_var_set(&self, n: usize, v: Val) {
@@ -65,7 +65,7 @@ impl Class {
         methods: HashMap<String, Gc<Method>>,
     ) -> Self {
         let cls = Class {
-            metacls: UnsafeCell::new(metacls.clone()),
+            metacls: UnsafeCell::new(metacls),
             name,
             path,
             instrs_off,
@@ -79,7 +79,7 @@ impl Class {
     }
 
     pub fn name(&self, _: &VM) -> Result<Val, Box<VMError>> {
-        Ok(self.name.clone())
+        Ok(self.name)
     }
 
     pub fn get_method(&self, vm: &VM, msg: &str) -> Result<Gc<Method>, Box<VMError>> {

--- a/src/lib/vm/objects/class.rs
+++ b/src/lib/vm/objects/class.rs
@@ -83,17 +83,14 @@ impl Class {
     }
 
     pub fn get_method(&self, vm: &VM, msg: &str) -> Result<Gc<Method>, Box<VMError>> {
-        self.methods
-            .get(msg)
-            .map(|x| Ok(Gc::clone(x)))
-            .unwrap_or_else(|| {
-                let supercls = self.supercls(vm);
-                if supercls != vm.nil {
-                    supercls.downcast::<Class>(vm)?.get_method(vm, msg)
-                } else {
-                    Err(VMError::new(vm, VMErrorKind::UnknownMethod(msg.to_owned())))
-                }
-            })
+        self.methods.get(msg).map(|x| Ok(*x)).unwrap_or_else(|| {
+            let supercls = self.supercls(vm);
+            if supercls != vm.nil {
+                supercls.downcast::<Class>(vm)?.get_method(vm, msg)
+            } else {
+                Err(VMError::new(vm, VMErrorKind::UnknownMethod(msg.to_owned())))
+            }
+        })
     }
 
     pub fn set_metacls(&self, vm: &VM, cls_val: Val) {

--- a/src/lib/vm/objects/double.rs
+++ b/src/lib/vm/objects/double.rs
@@ -23,7 +23,7 @@ impl Obj for Double {
     }
 
     fn get_class(&self, vm: &mut VM) -> Val {
-        vm.double_cls.clone()
+        vm.double_cls
     }
 
     fn to_strval(&self, vm: &mut VM) -> Result<Val, Box<VMError>> {

--- a/src/lib/vm/objects/instance.rs
+++ b/src/lib/vm/objects/instance.rs
@@ -21,12 +21,12 @@ impl Obj for Inst {
     }
 
     fn get_class(&self, _: &mut VM) -> Val {
-        self.class.clone()
+        self.class
     }
 
     fn inst_var_lookup(&self, n: usize) -> Val {
         let inst_vars = unsafe { &mut *self.inst_vars.get() };
-        inst_vars[n].clone()
+        inst_vars[n]
     }
 
     fn inst_var_set(&self, n: usize, v: Val) {

--- a/src/lib/vm/objects/integers.rs
+++ b/src/lib/vm/objects/integers.rs
@@ -37,7 +37,7 @@ impl Obj for ArbInt {
     }
 
     fn get_class(&self, vm: &mut VM) -> Val {
-        vm.int_cls.clone()
+        vm.int_cls
     }
 
     fn to_strval(&self, vm: &mut VM) -> Result<Val, Box<VMError>> {
@@ -346,7 +346,7 @@ impl Obj for Int {
     }
 
     fn get_class(&self, vm: &mut VM) -> Val {
-        vm.int_cls.clone()
+        vm.int_cls
     }
 
     fn to_strval(&self, vm: &mut VM) -> Result<Val, Box<VMError>> {
@@ -564,26 +564,26 @@ mod tests {
         // Different LHS and RHS types
         assert!(Val::from_isize(&mut vm, 1)
             .unwrap()
-            .add(&mut vm, bi.clone())
+            .add(&mut vm, bi)
             .unwrap()
             .downcast::<ArbInt>(&mut vm)
             .is_ok());
         assert!(Val::from_isize(&mut vm, 1)
             .unwrap()
-            .sub(&mut vm, bi.clone())
+            .sub(&mut vm, bi)
             .unwrap()
             .downcast::<ArbInt>(&mut vm)
             .is_ok());
         assert!(Val::from_isize(&mut vm, 1)
             .unwrap()
-            .mul(&mut vm, bi.clone())
+            .mul(&mut vm, bi)
             .unwrap()
             .downcast::<ArbInt>(&mut vm)
             .is_ok());
         assert_eq!(
             Val::from_isize(&mut vm, 1)
                 .unwrap()
-                .div(&mut vm, bi.clone())
+                .div(&mut vm, bi)
                 .unwrap()
                 .valkind(),
             ValKind::INT
@@ -591,26 +591,23 @@ mod tests {
 
         let v = Val::from_isize(&mut vm, 1).unwrap();
         assert!(bi
-            .clone()
             .add(&mut vm, v)
             .unwrap()
             .downcast::<ArbInt>(&mut vm)
             .is_ok());
         let v = Val::from_isize(&mut vm, 1).unwrap();
         assert!(bi
-            .clone()
             .sub(&mut vm, v)
             .unwrap()
             .downcast::<ArbInt>(&mut vm)
             .is_ok());
         let v = Val::from_isize(&mut vm, 1).unwrap();
         assert!(bi
-            .clone()
             .mul(&mut vm, v)
             .unwrap()
             .downcast::<ArbInt>(&mut vm)
             .is_ok());
         let v = Val::from_isize(&mut vm, 99999999).unwrap();
-        assert_eq!(bi.clone().div(&mut vm, v).unwrap().valkind(), ValKind::INT);
+        assert_eq!(bi.div(&mut vm, v).unwrap().valkind(), ValKind::INT);
     }
 }

--- a/src/lib/vm/objects/integers.rs
+++ b/src/lib/vm/objects/integers.rs
@@ -471,8 +471,8 @@ impl Int {
 mod tests {
     use super::*;
     use crate::vm::val::{ValKind, BITSIZE, TAG_BITSIZE};
-    use std::str::FromStr;
     use serial_test::serial;
+    use std::str::FromStr;
 
     #[test]
     #[serial]

--- a/src/lib/vm/objects/method.rs
+++ b/src/lib/vm/objects/method.rs
@@ -55,7 +55,7 @@ impl Method {
         Method {
             name,
             body,
-            class: UnsafeCell::new(vm.nil.clone()),
+            class: UnsafeCell::new(vm.nil),
         }
     }
 

--- a/src/lib/vm/objects/method.rs
+++ b/src/lib/vm/objects/method.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::new_ret_no_self)]
 
-use std::cell::UnsafeCell;
+use std::cell::Cell;
 
 use crate::{
     compiler::instrs::Primitive,
@@ -15,7 +15,7 @@ use crate::{
 pub struct Method {
     pub name: String,
     pub body: MethodBody,
-    class: UnsafeCell<Val>,
+    class: Cell<Val>,
 }
 
 #[derive(Debug)]
@@ -55,15 +55,15 @@ impl Method {
         Method {
             name,
             body,
-            class: UnsafeCell::new(vm.nil),
+            class: Cell::new(vm.nil),
         }
     }
 
     pub fn class(&self) -> Val {
-        unsafe { &*self.class.get() }.clone()
+        self.class.get()
     }
 
     pub fn set_class(&self, _: &VM, class: Val) {
-        *unsafe { &mut *self.class.get() } = class;
+        self.class.set(class);
     }
 }

--- a/src/lib/vm/objects/mod.rs
+++ b/src/lib/vm/objects/mod.rs
@@ -36,8 +36,8 @@ pub use integers::{ArbInt, Int};
 pub use method::{Method, MethodBody};
 pub use string_::String_;
 
-use rboehm::Gc;
 use natrob::narrowable_rboehm;
+use rboehm::Gc;
 
 use crate::vm::{core::VM, error::VMError, val::Val};
 

--- a/src/lib/vm/objects/string_.rs
+++ b/src/lib/vm/objects/string_.rs
@@ -23,9 +23,9 @@ impl Obj for String_ {
     fn get_class(&self, vm: &mut VM) -> Val {
         // FIXME This is a temporary hack until we sort out bootstrapping of the String_ class
         if self.is_str {
-            vm.str_cls.clone()
+            vm.str_cls
         } else {
-            vm.sym_cls.clone()
+            vm.sym_cls
         }
     }
 

--- a/src/lib/vm/somstack.rs
+++ b/src/lib/vm/somstack.rs
@@ -44,7 +44,7 @@ impl SOMStack {
     pub fn peek(&self) -> Val {
         debug_assert!(!self.is_empty());
         let v = unsafe { ptr::read(self.storage.add(self.len - 1)) };
-        let v2 = v.clone();
+        let v2 = v;
         forget(v);
         v2
     }

--- a/src/lib/vm/val.rs
+++ b/src/lib/vm/val.rs
@@ -8,10 +8,10 @@ use std::{
     ops::Deref,
 };
 
-use rboehm::{self, Gc};
 use num_bigint::BigInt;
 use num_enum::{IntoPrimitive, UnsafeFromPrimitive};
 use num_traits::{FromPrimitive, ToPrimitive, Zero};
+use rboehm::{self, Gc};
 
 use super::{
     core::VM,
@@ -73,9 +73,7 @@ impl Val {
         debug_assert_eq!(size_of::<*const ThinObj>(), size_of::<usize>());
         let ptr = Gc::into_raw(ThinObj::new(obj));
         Val {
-            val: unsafe {
-                transmute::<*const ThinObj, usize>(ptr) | (ValKind::GCBOX as usize)
-            },
+            val: unsafe { transmute::<*const ThinObj, usize>(ptr) | (ValKind::GCBOX as usize) },
         }
     }
 
@@ -170,11 +168,7 @@ impl Val {
         match self.valkind() {
             ValKind::GCBOX => {
                 debug_assert_eq!(size_of::<*const ThinObj>(), size_of::<usize>());
-                Ok(unsafe {
-                    Gc::from_raw(
-                        self.val_to_tobj() as *const _ as *mut _
-                    )
-                })
+                Ok(unsafe { Gc::from_raw(self.val_to_tobj() as *const _ as *mut _) })
             }
             ValKind::INT => {
                 let i = self.as_isize(vm).unwrap();
@@ -550,8 +544,8 @@ mod tests {
         objects::{Class, ObjType, String_},
     };
 
-    use std::ops::Deref;
     use serial_test::serial;
+    use std::ops::Deref;
 
     #[test]
     #[serial]

--- a/src/lib/vm/val.rs
+++ b/src/lib/vm/val.rs
@@ -57,7 +57,7 @@ pub trait NotUnboxable {}
 
 /// The core struct representing values in the language runtime: boxed and unboxed values are
 /// hidden behind this, such that they can be treated in exactly the same way.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub struct Val {
     // We use this usize for pointer tagging. Needless to say, this is highly dangerous, and needs
     // several parts of the code to cooperate in order to be correct.
@@ -210,9 +210,9 @@ impl Val {
     /// representing `vm.false_`.
     pub fn from_bool(vm: &VM, v: bool) -> Val {
         if v {
-            vm.true_.clone()
+            vm.true_
         } else {
-            vm.false_.clone()
+            vm.false_
         }
     }
 
@@ -280,7 +280,7 @@ impl Val {
     /// What class is this `Val` an instance of?
     pub fn get_class(&self, vm: &mut VM) -> Val {
         match self.valkind() {
-            ValKind::INT => vm.int_cls.clone(),
+            ValKind::INT => vm.int_cls,
             ValKind::GCBOX => self.tobj(vm).unwrap().get_class(vm),
             ValKind::ILLEGAL => unreachable!(),
         }
@@ -495,7 +495,7 @@ macro_rules! binop_all {
                         Ok(Val::from_bool(vm,
                             &BigInt::from_isize(lhs).unwrap() $op rhs.bigint()))
                     } else {
-                        Ok(vm.$tf.clone())
+                        Ok(vm.$tf)
                     }
                 } else {
                     self.tobj(vm).unwrap().$name(vm, other)


### PR DESCRIPTION
This PR removes many unnecessary `clone` calls now that `Gc` is `Copy` (which allows us to make `Val` `Copy` too). This is a mix of automatic and manual work.