### PR TITLE
Remove the is_str attribute from String_

### DIFF
--- a/lib/SOM/Symbol.som
+++ b/lib/SOM/Symbol.som
@@ -2,5 +2,5 @@ Symbol = String (
     asString = primitive
     asSymbol = ( ^self )
     "FIXME implement super keyword instead"
-    print    = ( '#' print. (self asString) print )
+    print    = ( '#' print. system printString: self )
 )

--- a/src/lib/compiler/ast_to_instrs.rs
+++ b/src/lib/compiler/ast_to_instrs.rs
@@ -170,7 +170,7 @@ impl<'a, 'input> Compiler<'a, 'input> {
             return Err(errs);
         }
 
-        let name_val = String_::new(vm, name, false);
+        let name_val = String_::new_str(vm, name);
         let cls = Class::new(
             vm,
             vm.cls_cls,

--- a/src/lib/vm/core.rs
+++ b/src/lib/vm/core.rs
@@ -158,61 +158,60 @@ impl VM {
         let v = self.nil_cls;
         self.nil = Inst::new(&mut self, v);
         self.metacls_cls = self.init_builtin_class("Metaclass", false);
-        {
-            // Patch incorrect references.
-            let obj_cls = self.obj_cls;
-            obj_cls
-                .downcast::<Class>(&self)
-                .unwrap()
-                .set_supercls(&self, self.nil);
-            obj_cls
-                .get_class(&mut self)
-                .downcast::<Class>(&self)
-                .unwrap()
-                .set_metacls(&self, self.metacls_cls);
-            obj_cls
-                .get_class(&mut self)
-                .downcast::<Class>(&self)
-                .unwrap()
-                .set_supercls(&self, self.cls_cls);
-            let cls_cls = self.cls_cls;
-            cls_cls
-                .get_class(&mut self)
-                .downcast::<Class>(&self)
-                .unwrap()
-                .set_metacls(&self, self.metacls_cls);
-            let nil_cls = self.nil_cls;
-            nil_cls
-                .get_class(&mut self)
-                .downcast::<Class>(&self)
-                .unwrap()
-                .set_metacls(&self, self.metacls_cls);
-            let metacls_cls = self.metacls_cls;
-            metacls_cls
-                .get_class(&mut self)
-                .downcast::<Class>(&self)
-                .unwrap()
-                .set_metacls(&self, self.metacls_cls);
 
-            self.str_cls = self.init_builtin_class("String", false);
-            let str_cls = self.str_cls;
-            for c in &[obj_cls, cls_cls, nil_cls, metacls_cls, str_cls] {
-                let cls = c.downcast::<Class>(&self).unwrap();
-                cls.name
-                    .downcast::<String_>(&self)
-                    .unwrap()
-                    .set_cls(str_cls);
-                let metacls_val = c.get_class(&mut self);
-                let metacls = metacls_val.downcast::<Class>(&self).unwrap();
-                metacls
-                    .name
-                    .downcast::<String_>(&self)
-                    .unwrap()
-                    .set_cls(str_cls);
-            }
-            for s in &self.strings {
-                s.downcast::<String_>(&self).unwrap().set_cls(str_cls);
-            }
+        // Patch incorrect references.
+        let obj_cls = self.obj_cls;
+        obj_cls
+            .downcast::<Class>(&self)
+            .unwrap()
+            .set_supercls(&self, self.nil);
+        obj_cls
+            .get_class(&mut self)
+            .downcast::<Class>(&self)
+            .unwrap()
+            .set_metacls(&self, self.metacls_cls);
+        obj_cls
+            .get_class(&mut self)
+            .downcast::<Class>(&self)
+            .unwrap()
+            .set_supercls(&self, self.cls_cls);
+        let cls_cls = self.cls_cls;
+        cls_cls
+            .get_class(&mut self)
+            .downcast::<Class>(&self)
+            .unwrap()
+            .set_metacls(&self, self.metacls_cls);
+        let nil_cls = self.nil_cls;
+        nil_cls
+            .get_class(&mut self)
+            .downcast::<Class>(&self)
+            .unwrap()
+            .set_metacls(&self, self.metacls_cls);
+        let metacls_cls = self.metacls_cls;
+        metacls_cls
+            .get_class(&mut self)
+            .downcast::<Class>(&self)
+            .unwrap()
+            .set_metacls(&self, self.metacls_cls);
+
+        self.str_cls = self.init_builtin_class("String", false);
+        let str_cls = self.str_cls;
+        for c in &[obj_cls, cls_cls, nil_cls, metacls_cls, str_cls] {
+            let cls = c.downcast::<Class>(&self).unwrap();
+            cls.name
+                .downcast::<String_>(&self)
+                .unwrap()
+                .set_cls(str_cls);
+            let metacls_val = c.get_class(&mut self);
+            let metacls = metacls_val.downcast::<Class>(&self).unwrap();
+            metacls
+                .name
+                .downcast::<String_>(&self)
+                .unwrap()
+                .set_cls(str_cls);
+        }
+        for s in &self.strings {
+            s.downcast::<String_>(&self).unwrap().set_cls(str_cls);
         }
 
         self

--- a/src/lib/vm/objects/double.rs
+++ b/src/lib/vm/objects/double.rs
@@ -28,7 +28,7 @@ impl Obj for Double {
 
     fn to_strval(&self, vm: &mut VM) -> Result<Val, Box<VMError>> {
         let mut buf = ryu::Buffer::new();
-        Ok(String_::new(vm, buf.format(self.val).to_owned(), true))
+        Ok(String_::new_str(vm, buf.format(self.val).to_owned()))
     }
 
     fn add(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {

--- a/src/lib/vm/objects/integers.rs
+++ b/src/lib/vm/objects/integers.rs
@@ -41,7 +41,7 @@ impl Obj for ArbInt {
     }
 
     fn to_strval(&self, vm: &mut VM) -> Result<Val, Box<VMError>> {
-        Ok(String_::new(vm, self.val.to_string(), true))
+        Ok(String_::new_str(vm, self.val.to_string()))
     }
 
     fn add(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
@@ -350,7 +350,7 @@ impl Obj for Int {
     }
 
     fn to_strval(&self, vm: &mut VM) -> Result<Val, Box<VMError>> {
-        Ok(String_::new(vm, self.val.to_string(), true))
+        Ok(String_::new_str(vm, self.val.to_string()))
     }
 
     fn add(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {

--- a/src/lib/vm/val.rs
+++ b/src/lib/vm/val.rs
@@ -290,7 +290,7 @@ impl Val {
         match self.valkind() {
             ValKind::INT => {
                 let s = self.as_isize(vm).unwrap().to_string();
-                Ok(String_::new(vm, s, true))
+                Ok(String_::new_str(vm, s))
             }
             ValKind::GCBOX => self.tobj(vm).unwrap().to_strval(vm),
             ValKind::ILLEGAL => unreachable!(),
@@ -624,7 +624,7 @@ mod tests {
         let mut vm = VM::new_no_bootstrap();
 
         let v = {
-            let v = String_::new(&mut vm, "s".to_owned(), true);
+            let v = String_::new_str(&mut vm, "s".to_owned());
             let v_tobj = v.tobj(&mut vm).unwrap();
             let v_int: &dyn Obj = v_tobj.deref().deref();
             let v_recovered = Val::recover(v_int);
@@ -640,7 +640,7 @@ mod tests {
     #[serial]
     fn test_cast() {
         let mut vm = VM::new_no_bootstrap();
-        let v = String_::new(&mut vm, "s".to_owned(), true);
+        let v = String_::new_str(&mut vm, "s".to_owned());
         assert!(v.downcast::<String_>(&mut vm).is_ok());
         assert_eq!(
             v.downcast::<Class>(&mut vm).unwrap_err().kind,
@@ -655,7 +655,7 @@ mod tests {
     #[serial]
     fn test_downcast() {
         let mut vm = VM::new_no_bootstrap();
-        let v = String_::new(&mut vm, "s".to_owned(), true);
+        let v = String_::new_str(&mut vm, "s".to_owned());
         assert!(v.downcast::<String_>(&mut vm).is_ok());
         assert!(v.downcast::<Class>(&mut vm).is_err());
         assert!(v.try_downcast::<String_>(&mut vm).is_some());


### PR DESCRIPTION
SOM has `String` and `Symbol` types where the latter is a subclass of the former. This is a bit awkward to model in Rust. Previously `String_`s had an `is_str` boolean (true for `String`, false for `Symbol`), which meant that we ended up branching on it quite often.

This PR changes that so the creator of a string has to specify if they're creating a SOM `String` (`String_::new_str`) or a `Symbol` (`String_::new_sym`), allowing us to embed the appropriate class in the `String_` struct itself. This doesn't increase the size of the struct (since the `is_str` bool was rounded up to a machine word anyway), and it removes all the subsequent branches.

This does however make bootstrapping the VM a bit messier. The last two commits in this PR try to make that part of the code a little less awkward to read.