### PR TITLE
Raise errors when passing a string instead of a symbol

### DIFF
--- a/lang_tests/system_global_lookup_string.som
+++ b/lang_tests/system_global_lookup_string.som
@@ -1,15 +1,14 @@
 "
-ignore: currently symbols are not properly handled
 VM:
   status: error
   stderr:
-    xxx
+    ...
+    Expected instance of 'Symbol' but got instance of 'String'.
 "
 
 
-system_global_unset_global = (
+system_global_lookup_string = (
     run = (
         (system global: 'ab') println.
     )
 )
-

--- a/lang_tests/system_global_put_string.som
+++ b/lang_tests/system_global_put_string.som
@@ -1,0 +1,14 @@
+"
+VM:
+  status: error
+  stderr:
+    ...
+    Expected instance of 'Symbol' but got instance of 'String'.
+"
+
+
+system_global_put_string = (
+    run = (
+        (system global: 'ab' put: 2).
+    )
+)

--- a/src/lib/vm/core.rs
+++ b/src/lib/vm/core.rs
@@ -622,7 +622,10 @@ impl VM {
                 } else {
                     let expected = Int::static_objtype();
                     let got = c_val.dyn_objtype(self);
-                    SendReturn::Err(VMError::new(self, VMErrorKind::TypeError { expected, got }))
+                    SendReturn::Err(VMError::new(
+                        self,
+                        VMErrorKind::BuiltinTypeError { expected, got },
+                    ))
                 }
             }
             Primitive::Fields => todo!(),

--- a/src/lib/vm/core.rs
+++ b/src/lib/vm/core.rs
@@ -632,14 +632,20 @@ impl VM {
             Primitive::FromString => todo!(),
             Primitive::Global => {
                 let name_val = self.stack.pop();
-                // XXX This should use Symbols not strings.
                 if name_val.get_class(self) == self.sym_cls {
                     let name: &String_ = stry!(name_val.downcast(self));
                     let g = self.get_global_or_nil(name.as_str());
                     self.stack.push(g);
                     SendReturn::Val
                 } else {
-                    todo!();
+                    let got_cls = name_val.get_class(self);
+                    SendReturn::Err(VMError::new(
+                        self,
+                        VMErrorKind::InstanceTypeError {
+                            expected_cls: self.sym_cls,
+                            got_cls,
+                        },
+                    ))
                 }
             }
             Primitive::GlobalPut => {

--- a/src/lib/vm/core.rs
+++ b/src/lib/vm/core.rs
@@ -657,7 +657,14 @@ impl VM {
                     self.stack.push(rcv);
                     SendReturn::Val
                 } else {
-                    todo!();
+                    let got_cls = name_val.get_class(self);
+                    SendReturn::Err(VMError::new(
+                        self,
+                        VMErrorKind::InstanceTypeError {
+                            expected_cls: self.sym_cls,
+                            got_cls,
+                        },
+                    ))
                 }
             }
             Primitive::GreaterThan => {

--- a/src/lib/vm/error.rs
+++ b/src/lib/vm/error.rs
@@ -127,6 +127,11 @@ impl VMError {
 
 #[derive(Debug, PartialEq)]
 pub enum VMErrorKind {
+    /// We expected a Rust type `expected` but at run-time got a Rust type `got`.
+    BuiltinTypeError {
+        expected: ObjType,
+        got: ObjType,
+    },
     /// A value which can't be represented in an `f64`.
     CantRepresentAsDouble,
     /// A value which can't be represented in an `isize`.
@@ -151,11 +156,6 @@ pub enum VMErrorKind {
     PrimitiveError,
     /// Tried to do a shl that would overflow memory and/or not fit in the required integer size.
     ShiftTooBig,
-    /// A dynamic type error.
-    TypeError {
-        expected: ObjType,
-        got: ObjType,
-    },
     /// An unknown global.
     UnknownGlobal(String),
     /// An unknown method.
@@ -165,6 +165,11 @@ pub enum VMErrorKind {
 impl VMErrorKind {
     fn to_string(&self, _: &VM) -> String {
         match self {
+            VMErrorKind::BuiltinTypeError { expected, got } => format!(
+                "Expected object of type '{}' but got type '{}'",
+                expected.as_str(),
+                got.as_str()
+            ),
             VMErrorKind::CantRepresentAsDouble => "Can't represent as double".to_owned(),
             VMErrorKind::CantRepresentAsIsize => {
                 "Can't represent as signed machine integer".to_owned()
@@ -182,11 +187,6 @@ impl VMErrorKind {
             }
             VMErrorKind::PrimitiveError => "Primitive Error".to_owned(),
             VMErrorKind::ShiftTooBig => "Shift too big".to_owned(),
-            VMErrorKind::TypeError { expected, got } => format!(
-                "Expected object of type '{}' but got type '{}'",
-                expected.as_str(),
-                got.as_str()
-            ),
             VMErrorKind::UnknownGlobal(name) => format!("Unknown global '{}'", name),
             VMErrorKind::UnknownMethod(name) => format!("Unknown method '{}'", name),
         }

--- a/src/lib/vm/error.rs
+++ b/src/lib/vm/error.rs
@@ -6,7 +6,8 @@ use termion::{is_tty, style};
 
 use crate::vm::{
     core::VM,
-    objects::{Class, Method, ObjType},
+    objects::{Class, Method, ObjType, String_},
+    val::Val,
 };
 
 #[derive(Debug)]
@@ -101,7 +102,13 @@ impl VMError {
                 eprintln!("File {}:", cls_path);
             }
         }
-        eprintln!("{}.", self.kind.to_string(vm));
+        match self.kind.to_string(vm) {
+            Ok(s) => eprintln!("{}.", s),
+            Err(_) => {
+                // We could do something more clever here, but it's not clear that it's worth it.
+                eprintln!("<Fatal error when running error handler>")
+            }
+        }
     }
 
     fn newlines(&self, d: &str) -> Vec<usize> {
@@ -143,6 +150,12 @@ pub enum VMErrorKind {
     DomainError,
     /// The VM is trying to exit.
     Exit,
+    /// We expected a SOM value that is an instance of `expected_cls` but at run-time got a SOM
+    /// value that is an instance of `got_cls`.
+    InstanceTypeError {
+        expected_cls: Val,
+        got_cls: Val,
+    },
     /// Tried to access a global before it being initialised.
     InvalidSymbol,
     /// Tried to do a shl or shr with a value below zero.
@@ -163,32 +176,47 @@ pub enum VMErrorKind {
 }
 
 impl VMErrorKind {
-    fn to_string(&self, _: &VM) -> String {
+    fn to_string(&self, vm: &VM) -> Result<String, Box<VMError>> {
         match self {
-            VMErrorKind::BuiltinTypeError { expected, got } => format!(
+            VMErrorKind::BuiltinTypeError { expected, got } => Ok(format!(
                 "Expected object of type '{}' but got type '{}'",
                 expected.as_str(),
                 got.as_str()
-            ),
-            VMErrorKind::CantRepresentAsDouble => "Can't represent as double".to_owned(),
+            )),
+            VMErrorKind::CantRepresentAsDouble => Ok("Can't represent as double".to_owned()),
             VMErrorKind::CantRepresentAsIsize => {
-                "Can't represent as signed machine integer".to_owned()
+                Ok("Can't represent as signed machine integer".to_owned())
             }
             VMErrorKind::CantRepresentAsUsize => {
-                "Can't represent as unsigned machine integer".to_owned()
+                Ok("Can't represent as unsigned machine integer".to_owned())
             }
-            VMErrorKind::DivisionByZero => "Division by zero".to_owned(),
-            VMErrorKind::DomainError => "Domain error".to_owned(),
-            VMErrorKind::Exit => "Exit".to_owned(),
-            VMErrorKind::InvalidSymbol => "Invalid symbol".to_owned(),
-            VMErrorKind::NegativeShift => "Negative shift".to_owned(),
-            VMErrorKind::NotANumber { got } => {
-                format!("Expected a numeric type but got type '{}'", got.as_str())
+            VMErrorKind::DivisionByZero => Ok("Division by zero".to_owned()),
+            VMErrorKind::DomainError => Ok("Domain error".to_owned()),
+            VMErrorKind::Exit => Ok("Exit".to_owned()),
+            VMErrorKind::InstanceTypeError {
+                expected_cls,
+                got_cls,
+            } => {
+                let expected_name_val = expected_cls.downcast::<Class>(vm)?.name;
+                let got_name_val = got_cls.downcast::<Class>(vm)?.name;
+                let expected_name: &String_ = expected_name_val.downcast(vm)?;
+                let got_name: &String_ = got_name_val.downcast(vm)?;
+                Ok(format!(
+                    "Expected instance of '{}' but got instance of '{}'",
+                    expected_name.as_str(),
+                    got_name.as_str()
+                ))
             }
-            VMErrorKind::PrimitiveError => "Primitive Error".to_owned(),
-            VMErrorKind::ShiftTooBig => "Shift too big".to_owned(),
-            VMErrorKind::UnknownGlobal(name) => format!("Unknown global '{}'", name),
-            VMErrorKind::UnknownMethod(name) => format!("Unknown method '{}'", name),
+            VMErrorKind::InvalidSymbol => Ok("Invalid symbol".to_owned()),
+            VMErrorKind::NegativeShift => Ok("Negative shift".to_owned()),
+            VMErrorKind::NotANumber { got } => Ok(format!(
+                "Expected a numeric type but got type '{}'",
+                got.as_str()
+            )),
+            VMErrorKind::PrimitiveError => Ok("Primitive Error".to_owned()),
+            VMErrorKind::ShiftTooBig => Ok("Shift too big".to_owned()),
+            VMErrorKind::UnknownGlobal(name) => Ok(format!("Unknown global '{}'", name)),
+            VMErrorKind::UnknownMethod(name) => Ok(format!("Unknown method '{}'", name)),
         }
     }
 }

--- a/src/lib/vm/objects/integers.rs
+++ b/src/lib/vm/objects/integers.rs
@@ -68,7 +68,10 @@ impl Obj for ArbInt {
         } else {
             let expected = self.dyn_objtype();
             let got = other.dyn_objtype(vm);
-            Err(VMError::new(vm, VMErrorKind::TypeError { expected, got }))
+            Err(VMError::new(
+                vm,
+                VMErrorKind::BuiltinTypeError { expected, got },
+            ))
         }
     }
 
@@ -220,7 +223,10 @@ impl Obj for ArbInt {
         } else {
             let expected = self.dyn_objtype();
             let got = other.dyn_objtype(vm);
-            Err(VMError::new(vm, VMErrorKind::TypeError { expected, got }))
+            Err(VMError::new(
+                vm,
+                VMErrorKind::BuiltinTypeError { expected, got },
+            ))
         }
     }
 

--- a/src/lib/vm/val.rs
+++ b/src/lib/vm/val.rs
@@ -132,7 +132,7 @@ impl Val {
         match self.valkind() {
             ValKind::INT => Err(VMError::new(
                 vm,
-                VMErrorKind::TypeError {
+                VMErrorKind::BuiltinTypeError {
                     expected: T::static_objtype(),
                     got: Int::static_objtype(),
                 },
@@ -142,7 +142,7 @@ impl Val {
                 tobj.downcast().ok_or_else(|| {
                     VMError::new(
                         vm,
-                        VMErrorKind::TypeError {
+                        VMErrorKind::BuiltinTypeError {
                             expected: T::static_objtype(),
                             got: tobj.deref().dyn_objtype(),
                         },
@@ -318,7 +318,10 @@ impl Val {
             }
             let expected = self.dyn_objtype(vm);
             let got = other.dyn_objtype(vm);
-            return Err(VMError::new(vm, VMErrorKind::TypeError { expected, got }));
+            return Err(VMError::new(
+                vm,
+                VMErrorKind::BuiltinTypeError { expected, got },
+            ));
         }
         self.tobj(vm).unwrap().and(vm, other)
     }
@@ -468,7 +471,10 @@ impl Val {
             }
             let expected = self.dyn_objtype(vm);
             let got = other.dyn_objtype(vm);
-            return Err(VMError::new(vm, VMErrorKind::TypeError { expected, got }));
+            return Err(VMError::new(
+                vm,
+                VMErrorKind::BuiltinTypeError { expected, got },
+            ));
         }
         self.tobj(vm).unwrap().xor(vm, other)
     }
@@ -644,7 +650,7 @@ mod tests {
         assert!(v.downcast::<String_>(&mut vm).is_ok());
         assert_eq!(
             v.downcast::<Class>(&mut vm).unwrap_err().kind,
-            VMErrorKind::TypeError {
+            VMErrorKind::BuiltinTypeError {
                 expected: ObjType::Class,
                 got: ObjType::String_
             }


### PR DESCRIPTION
This PR has a simple goal in mind (`global:s` should raise an error if `s` is anything other than a SOM `Symbol`), but has to go through some hoops to get there. It might be easiest to start with the last commit (https://github.com/softdevteam/yksom/commit/6f14292fc172cd739924a222ef5d11a02d45e810) to see what the goal is.

The challenge is then set out in the commit message https://github.com/softdevteam/yksom/commit/fc3f3f9eebf0fa4c4ba449d98cce2f08c8baf2a0: in essence, at least internally to the VM, there are two different kinds of type errors, and previously we only supported one. So this PR adds a second kind (after renaming things a bit in https://github.com/softdevteam/yksom/commit/c569349966d2e5c709dca5f720d0cfb74b1f9d7e) so that, ultimately, we can raise the error message you see in https://github.com/softdevteam/yksom/commit/6f14292fc172cd739924a222ef5d11a02d45e810. This probably makes it sound more complicated than it is -- sorry!