### PR TITLE
super sends

### DIFF
--- a/lang_tests/binary_super.som
+++ b/lang_tests/binary_super.som
@@ -1,0 +1,14 @@
+"
+VM:
+  status: error
+  stderr:
+    Traceback ...
+    ...
+    Unknown method '+'.
+"
+
+binary_super = (
+    run = (
+        super + 1.
+    )
+)

--- a/lang_tests/super_var.som
+++ b/lang_tests/super_var.som
@@ -1,0 +1,19 @@
+"
+VM:
+  status: success
+  stdout:
+    instance of super_var
+    nil
+    nil
+"
+
+super_var = (
+    run = (
+        | x |
+        self println.
+        x = self.
+        x println.
+        x = super.
+        x println.
+    )
+)

--- a/lib/SOM/Symbol.som
+++ b/lib/SOM/Symbol.som
@@ -2,5 +2,5 @@ Symbol = String (
     asString = primitive
     asSymbol = ( ^self )
     "FIXME implement super keyword instead"
-    print    = ( '#' print. system printString: self )
+    print    = ( '#' print. super print )
 )

--- a/src/lib/compiler/instrs.rs
+++ b/src/lib/compiler/instrs.rs
@@ -11,6 +11,7 @@ pub enum Instr {
     Return,
     Send(usize, usize),
     String(usize),
+    SuperSend(usize, usize),
     Symbol(usize),
     VarLookup(usize, usize),
     VarSet(usize, usize),

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -12,6 +12,7 @@
 
 #![feature(alloc_layout_extra)]
 #![feature(allocator_api)]
+#![feature(box_patterns)]
 #![feature(coerce_unsized)]
 #![feature(specialization)]
 #![feature(unsize)]


### PR DESCRIPTION
In SOM, "super" is mostly an alias for "self" *except* when you get a message send such as "super x" which means "call the method 'x' in my superclass (or, if not found, recursively in its superclasses)". This allows us to make another part of Symbol.som identical to the SOM standard library.