### PR TITLE
Move exit primitive to the System class.

### DIFF
--- a/lib/SOM/Object.som
+++ b/lib/SOM/Object.som
@@ -9,8 +9,6 @@ Object = nil (
 
     value = ( ^self )
 
-    exit: error  = primitive
-    exit         = ( self exit: 0 )
     error: string = ( '' println. ('ERROR: ' + string) println. system exit: 1 )
 
     unknownGlobal: name = ( ^system resolve: name )

--- a/lib/SOM/System.som
+++ b/lib/SOM/System.som
@@ -3,6 +3,8 @@ System = (
     global: name put: value = primitive
     printString: string     = primitive
     printNewline            = primitive
+    exit: error             = primitive
+    exit                    = ( self exit: 0 )
 
     load: symbol = primitive
     resolve: symbol = (


### PR DESCRIPTION
This was only ever temporarily placed in Object; the proper home for it is System. 