### PR TITLE
Implement Double.asInteger.

### DIFF
--- a/lang_tests/double_asinteger.som
+++ b/lang_tests/double_asinteger.som
@@ -1,0 +1,26 @@
+"
+VM:
+  status: success
+  stdout:
+    0
+    0
+    1
+    0
+    0
+    -1
+    18446744073709551616
+    -18446744073709551616
+"
+
+double_asinteger = (
+    run = (
+        0.1 asInteger println.
+        0.9 asInteger println.
+        1.1 asInteger println.
+        -0.1 asInteger println.
+        -0.9 asInteger println.
+        -1.1 asInteger println.
+        18446744073709551616.0 asInteger println.
+        -18446744073709551616.0 asInteger println.
+    )
+)

--- a/lib/SOM/Double.som
+++ b/lib/SOM/Double.som
@@ -3,7 +3,7 @@ Double = (
     - argument = primitive
     * argument = primitive
     // argument = primitive
-    % argument = primitive    
+    % argument = primitive
     =  argument = primitive
     <  argument = primitive
     >  argument = ( ^(self >= argument) and: [ self <> argument ] )
@@ -12,4 +12,5 @@ Double = (
     negative = ( ^self < 0.0 )
     sqrt     = primitive
     asString = primitive
+    asInteger = primitive
 )

--- a/src/lib/vm/core.rs
+++ b/src/lib/vm/core.rs
@@ -578,7 +578,12 @@ impl VM {
                 self.stack.push(v);
                 SendReturn::Val
             }
-            Primitive::AsInteger => todo!(),
+            Primitive::AsInteger => {
+                let dbl = stry!(rcv.downcast::<Double>(self));
+                let v = dbl.as_integer(self);
+                self.stack.push(v);
+                SendReturn::Val
+            }
             Primitive::AsString => {
                 let v = stry!(rcv.to_strval(self));
                 let str_maybe: &String_ = stry!(v.downcast(self));

--- a/src/lib/vm/objects/double.rs
+++ b/src/lib/vm/objects/double.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::new_ret_no_self)]
 
-use num_traits::{ToPrimitive, Zero};
+use num_bigint::BigInt;
+use num_traits::{FromPrimitive, ToPrimitive, Zero};
 
 use crate::vm::{
     core::VM,
@@ -185,5 +186,15 @@ impl Double {
 
     pub fn double(&self) -> f64 {
         self.val
+    }
+
+    pub fn as_integer(&self, vm: &mut VM) -> Val {
+        // This could be done more efficiently in the common case that self.val will fit in an
+        // isize.
+        if let Some(bi) = BigInt::from_f64(self.val) {
+            ArbInt::new(vm, bi)
+        } else {
+            todo!();
+        }
     }
 }


### PR DESCRIPTION
Our implementation is rather inefficient, since we convert immediately to a BigInt, but it is simple and hopefully correct.