### PR TITLE
Empty blocks evaluate to nil.

### DIFF
--- a/lang_tests/empty_block.som
+++ b/lang_tests/empty_block.som
@@ -1,0 +1,11 @@
+"
+VM:
+  status: success
+  stdout: nil
+"
+
+empty_block = (
+    run = (
+        [] value println.
+    )
+)

--- a/src/lib/compiler/ast_to_instrs.rs
+++ b/src/lib/compiler/ast_to_instrs.rs
@@ -438,7 +438,13 @@ impl<'a, 'input> Compiler<'a, 'input> {
             max_stack = max(max_stack, 1);
             vm.instrs_push(Instr::Return, span);
         } else {
-            vm.instrs_push(Instr::Return, exprs.iter().last().unwrap().span());
+            if exprs.len() == 0 {
+                let idx = vm.add_global("nil");
+                vm.instrs_push(Instr::GlobalLookup(idx), span);
+                vm.instrs_push(Instr::Return, span);
+            } else {
+                vm.instrs_push(Instr::Return, exprs.iter().last().unwrap().span());
+            }
         }
         self.vars_stack.pop();
 
@@ -638,7 +644,7 @@ impl<'a, 'input> Compiler<'a, 'input> {
                         }
                     }
                     None => {
-                        let name = self.lexer.span_str(*span).to_owned();
+                        let name = self.lexer.span_str(*span);
                         let instr = Instr::GlobalLookup(vm.add_global(name));
                         vm.instrs_push(instr, *span);
                     }

--- a/src/lib/vm/core.rs
+++ b/src/lib/vm/core.rs
@@ -992,14 +992,12 @@ impl VM {
 
     /// Add the global `n` to the VM, returning its index. Note that global names (like strings)
     /// are reused, so indexes are also reused.
-    pub fn add_global(&mut self, s: String) -> usize {
-        // We want to avoid `clone`ing `s` in the (hopefully common) case of a cache hit, hence
-        // this slightly laborious dance and double-lookup.
-        if let Some(i) = self.reverse_globals.get(&s) {
+    pub fn add_global(&mut self, s: &str) -> usize {
+        if let Some(i) = self.reverse_globals.get(s) {
             *i
         } else {
             let len = self.globals.len();
-            self.reverse_globals.insert(s, len);
+            self.reverse_globals.insert(s.to_owned(), len);
             self.globals.push(Val::illegal());
             len
         }


### PR DESCRIPTION
Whilst here, it is silly for `add_global` to take a `String` when both callers have to call `to_owned` for the `&str` they really have.

Note this is different behaviour from (at least) Java SOM (see https://github.com/SOM-st/SOM/issues/36).