### PR TITLE
Print out the class name when a method is not found.

### DIFF
--- a/lang_tests/binary_super.som
+++ b/lang_tests/binary_super.som
@@ -4,7 +4,7 @@ VM:
   stderr:
     Traceback ...
     ...
-    Unknown method '+'.
+    Unknown method '+' in instance of 'binary_super'.
 "
 
 binary_super = (

--- a/src/lib/vm/error.rs
+++ b/src/lib/vm/error.rs
@@ -177,7 +177,7 @@ pub enum VMErrorKind {
     /// An unknown global.
     UnknownGlobal(String),
     /// An unknown method.
-    UnknownMethod(String),
+    UnknownMethod(Val, String),
 }
 
 impl VMErrorKind {
@@ -225,7 +225,15 @@ impl VMErrorKind {
             VMErrorKind::PrimitiveError => Ok("Primitive Error".to_owned()),
             VMErrorKind::ShiftTooBig => Ok("Shift too big".to_owned()),
             VMErrorKind::UnknownGlobal(name) => Ok(format!("Unknown global '{}'", name)),
-            VMErrorKind::UnknownMethod(name) => Ok(format!("Unknown method '{}'", name)),
+            VMErrorKind::UnknownMethod(class_val, name) => {
+                let class_name_val = class_val.downcast::<Class>(vm)?.name(vm).unwrap();
+                let class_name = class_name_val.downcast::<String_>(vm)?;
+                Ok(format!(
+                    "Unknown method '{}' in instance of '{}'",
+                    name,
+                    class_name.as_str()
+                ))
+            }
         }
     }
 }

--- a/src/lib/vm/objects/class.rs
+++ b/src/lib/vm/objects/class.rs
@@ -114,10 +114,14 @@ impl Class {
             None => {
                 let supercls = self.supercls(vm);
                 if supercls != vm.nil {
-                    supercls.downcast::<Class>(vm)?.get_method(vm, msg)
-                } else {
-                    Err(VMError::new(vm, VMErrorKind::UnknownMethod(msg.to_owned())))
+                    if let Ok(m) = supercls.downcast::<Class>(vm)?.get_method(vm, msg) {
+                        return Ok(m);
+                    }
                 }
+                Err(VMError::new(
+                    vm,
+                    VMErrorKind::UnknownMethod(Val::recover(self), msg.to_owned()),
+                ))
             }
         }
     }


### PR DESCRIPTION
This makes it much easier to work out what the root cause of the dynamic typing error is.