### PR TITLE
Methods with no expressions have nothing to pop before returning.

### DIFF
--- a/lang_tests/empty_method.som
+++ b/lang_tests/empty_method.som
@@ -1,0 +1,13 @@
+"
+VM:
+  status: success
+  stdout: instance of empty_method
+"
+
+empty_method = (
+    run = (
+        self f println.
+    )
+
+    f = ()
+)

--- a/src/lib/compiler/ast_to_instrs.rs
+++ b/src/lib/compiler/ast_to_instrs.rs
@@ -440,7 +440,9 @@ impl<'a, 'input> Compiler<'a, 'input> {
         }
         // Blocks return the value of the last statement, but methods return `self`.
         if is_method {
-            vm.instrs_push(Instr::Pop, span);
+            if exprs.len() > 0 {
+                vm.instrs_push(Instr::Pop, span);
+            }
             debug_assert_eq!(*self.vars_stack.last().unwrap().get("self").unwrap(), 0);
             vm.instrs_push(Instr::VarLookup(0, 0), span);
             max_stack = max(max_stack, 1);


### PR DESCRIPTION
Before this commit, the 'empty_method' test failed because we tried to "pop" an empty SOM stack.