### PR TITLE
Array literals don't have to have any items in them.

### DIFF
--- a/lang_tests/array_literals.som
+++ b/lang_tests/array_literals.som
@@ -10,13 +10,14 @@ VM:
     -8.0
     instance of Array
     #b
+    instance of Array
 "
 
 array_literals = (
     run = (
         | x |
 
-        x := #(4 5 6 'a' -7 -8.0 #(9.0 #a) #b).
+        x := #(4 5 6 'a' -7 -8.0 #(9.0 #a) #b #()).
         x doIndexes: [:y | (x at: y) println].
     )
 )

--- a/src/lib/compiler/som.y
+++ b/src/lib/compiler/som.y
@@ -178,7 +178,11 @@ StringConst -> Result<Expr, ()>:
     | "#" BinOp { Ok(Expr::Symbol($2?)) }
     ;
 Array -> Result<Expr, ()>:
-      "#" "(" ArrayList ")" { Ok(Expr::Array { span: $span, items: $3? }) };
+      "#" "(" ArrayListOpt ")" { Ok(Expr::Array { span: $span, items: $3? }) };
+ArrayListOpt -> Result<Vec<Expr>, ()>:
+      ArrayList { $1 }
+    | { Ok(vec![]) }
+    ;
 ArrayList -> Result<Vec<Expr>, ()>:
       Literal { Ok(vec![$1?]) }
     | ArrayList Literal { flattenr($1, $2) }


### PR DESCRIPTION
The grammar previously required, incorrectly, at least one item in array literals.