### PR TITLE
Implement the 'fullGC' primitive.

### DIFF
--- a/lang_tests/fullgc.som
+++ b/lang_tests/fullgc.som
@@ -1,0 +1,11 @@
+"
+VM:
+  status: success
+  stdout: false
+"
+
+fullgc = (
+    run = (
+        system fullGC println.
+    )
+)

--- a/src/lib/vm/core.rs
+++ b/src/lib/vm/core.rs
@@ -719,7 +719,10 @@ impl VM {
             }
             Primitive::Fields => todo!(),
             Primitive::FromString => todo!(),
-            Primitive::FullGC => todo!(),
+            Primitive::FullGC => {
+                self.stack.push(self.false_);
+                SendReturn::Val
+            }
             Primitive::Global => {
                 let name_val = self.stack.pop();
                 let name = stry!(String_::symbol_to_string_(self, name_val));


### PR DESCRIPTION
We do not actually do a GC, since a) we have no way of forcing one b) asking a VM to GC should be a hint rather than a request so not doing anything is a valid thing to do anyway.