### PR TITLE
Fix fast-path integer comparisons between big ints and normal ints.

### DIFF
--- a/lang_tests/fast_integer_comparisons.som
+++ b/lang_tests/fast_integer_comparisons.som
@@ -1,0 +1,93 @@
+"
+VM:
+  status: success
+  stdout:
+    true
+    true
+    true
+    true
+    true
+    true
+    false
+    false
+    false
+    false
+    false
+    false
+    false
+    false
+    false
+    false
+    false
+    false
+    true
+    true
+    true
+    true
+    true
+    true
+    false
+    false
+    false
+    false
+    false
+    false
+    true
+    true
+    true
+    true
+    true
+    true
+"
+
+fast_integer_comparisons = (
+    run = (
+        ((-1 << 100) < 0) println.
+        ((-1 << 100) < -1) println.
+        ((-1 << 100) < 1) println.
+
+        ((-1 << 100) <= 0) println.
+        ((-1 << 100) <= -1) println.
+        ((-1 << 100) <= 1) println.
+
+        ((1 << 100) < 0) println.
+        ((1 << 100) < -1) println.
+        ((1 << 100) < 1) println.
+
+        ((1 << 100) <= 0) println.
+        ((1 << 100) <= -1) println.
+        ((1 << 100) <= 1) println.
+
+        ((-1 << 100) > 0) println.
+        ((-1 << 100) > -1) println.
+        ((-1 << 100) > 1) println.
+
+        ((-1 << 100) >= 0) println.
+        ((-1 << 100) >= -1) println.
+        ((-1 << 100) >= 1) println.
+
+        ((1 << 100) > 0) println.
+        ((1 << 100) > -1) println.
+        ((1 << 100) > 1) println.
+
+        ((1 << 100) >= 0) println.
+        ((1 << 100) >= -1) println.
+        ((1 << 100) >= 1) println.
+
+        ((-1 << 100) = 0) println.
+        ((-1 << 100) = -1) println.
+        ((-1 << 100) = 1) println.
+
+        ((1 << 100) = 0) println.
+        ((1 << 100) = -1) println.
+        ((1 << 100) = 1) println.
+
+        ((-1 << 100) ~= 0) println.
+        ((-1 << 100) ~= -1) println.
+        ((-1 << 100) ~= 1) println.
+
+        ((1 << 100) ~= 0) println.
+        ((1 << 100) ~= -1) println.
+        ((1 << 100) ~= 1) println.
+    )
+)

--- a/src/lib/vm/objects/integers.rs
+++ b/src/lib/vm/objects/integers.rs
@@ -14,7 +14,7 @@
 use std::convert::TryFrom;
 
 use num_bigint::BigInt;
-use num_traits::{FromPrimitive, ToPrimitive, Zero};
+use num_traits::{FromPrimitive, Signed, ToPrimitive, Zero};
 
 use crate::vm::{
     core::VM,
@@ -247,7 +247,7 @@ impl Obj for ArbInt {
 
     fn equals(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         let b = if other.dyn_objtype(vm) == ObjType::Int {
-            debug_assert!(self.val > BigInt::from_isize(other.as_isize(vm).unwrap()).unwrap());
+            debug_assert!(self.val != BigInt::from_isize(other.as_isize(vm).unwrap()).unwrap());
             false
         } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
             self.val == rhs.val
@@ -259,7 +259,7 @@ impl Obj for ArbInt {
 
     fn not_equals(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         let b = if other.dyn_objtype(vm) == ObjType::Int {
-            debug_assert!(self.val > BigInt::from_isize(other.as_isize(vm).unwrap()).unwrap());
+            debug_assert!(self.val != BigInt::from_isize(other.as_isize(vm).unwrap()).unwrap());
             true
         } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
             self.val != rhs.val
@@ -271,8 +271,11 @@ impl Obj for ArbInt {
 
     fn greater_than(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         let b = if other.dyn_objtype(vm) == ObjType::Int {
-            debug_assert!(self.val > BigInt::from_isize(other.as_isize(vm).unwrap()).unwrap());
-            true
+            debug_assert!(
+                !self.val.is_positive()
+                    || self.val > BigInt::from_isize(other.as_isize(vm).unwrap()).unwrap()
+            );
+            self.val.is_positive()
         } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
             self.val > rhs.val
         } else {
@@ -284,8 +287,11 @@ impl Obj for ArbInt {
 
     fn greater_than_equals(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         let b = if other.dyn_objtype(vm) == ObjType::Int {
-            debug_assert!(self.val > BigInt::from_isize(other.as_isize(vm).unwrap()).unwrap());
-            true
+            debug_assert!(
+                !self.val.is_positive()
+                    || self.val >= BigInt::from_isize(other.as_isize(vm).unwrap()).unwrap()
+            );
+            self.val.is_positive()
         } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
             self.val >= rhs.val
         } else {
@@ -297,8 +303,11 @@ impl Obj for ArbInt {
 
     fn less_than(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         let b = if other.dyn_objtype(vm) == ObjType::Int {
-            debug_assert!(self.val > BigInt::from_isize(other.as_isize(vm).unwrap()).unwrap());
-            false
+            debug_assert!(
+                !self.val.is_negative()
+                    || self.val < BigInt::from_isize(other.as_isize(vm).unwrap()).unwrap()
+            );
+            self.val.is_negative()
         } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
             self.val < rhs.val
         } else {
@@ -310,8 +319,11 @@ impl Obj for ArbInt {
 
     fn less_than_equals(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         let b = if other.dyn_objtype(vm) == ObjType::Int {
-            debug_assert!(self.val > BigInt::from_isize(other.as_isize(vm).unwrap()).unwrap());
-            false
+            debug_assert!(
+                !self.val.is_negative()
+                    || self.val <= BigInt::from_isize(other.as_isize(vm).unwrap()).unwrap()
+            );
+            self.val.is_negative()
         } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
             self.val <= rhs.val
         } else {


### PR DESCRIPTION
I had neglected to consider the difference between positive and negative big ints in these comparisons, leading to the original `debug_assert`s firing (which is good, because the code after the `debug_assert`s was wrong!).