### PR TITLE
Add the 'fields' primitive.

### DIFF
--- a/lang_tests/instance_fields.som
+++ b/lang_tests/instance_fields.som
@@ -1,0 +1,19 @@
+"
+VM:
+  status: success
+  stdout:
+    instance of Array
+    true
+    true
+"
+
+instance_fields = (
+    | x y |
+    run = (
+        | fds |
+        fds := instance_fields fields.
+        fds println.
+        (fds contains: #x) println.
+        (fds contains: #y) println.
+    )
+)

--- a/lang_tests/mutate_fields.som
+++ b/lang_tests/mutate_fields.som
@@ -1,0 +1,29 @@
+"
+VM:
+  status: success
+  stdout:
+    true
+    true
+    true
+    true
+    false
+"
+
+mutate_fields = (
+    | x y |
+    run = (
+        | fds |
+        fds := mutate_fields fields.
+        (fds contains: #x) println.
+        (fds contains: #y) println.
+        fds at: 1 put: #z.
+        fds := mutate_fields fields.
+        (fds contains: #x) println.
+        (fds contains: #y) println.
+        (fds contains: #z) println.
+    )
+
+    find: sym = (
+        method_holder methods do: [:e | ((e signature) == sym) ifTrue: [ ^e ]].
+    )
+)

--- a/src/lib/vm/core.rs
+++ b/src/lib/vm/core.rs
@@ -717,7 +717,11 @@ impl VM {
                     ))
                 }
             }
-            Primitive::Fields => todo!(),
+            Primitive::Fields => {
+                let fields = stry!(rcv.downcast::<Class>(self)).fields(self);
+                self.stack.push(fields);
+                SendReturn::Val
+            }
             Primitive::FromString => todo!(),
             Primitive::FullGC => todo!(),
             Primitive::Global => {

--- a/src/lib/vm/objects/class.rs
+++ b/src/lib/vm/objects/class.rs
@@ -12,7 +12,7 @@ use rboehm::Gc;
 use crate::vm::{
     core::VM,
     error::{VMError, VMErrorKind},
-    objects::{Array, Method, MethodsArray, Obj, ObjType, StaticObjType, String_},
+    objects::{Array, Method, MethodsArray, NormalArray, Obj, ObjType, StaticObjType, String_},
     val::{NotUnboxable, Val, ValKind},
 };
 
@@ -162,6 +162,15 @@ impl Class {
             let meth = meth_val.downcast::<Method>(vm).unwrap();
             meth.bootstrap(vm);
         }
+    }
+
+    pub fn fields(&self, vm: &mut VM) -> Val {
+        let field_strs = self
+            .inst_vars_map
+            .keys()
+            .map(|k| String_::new_sym(vm, k.clone()))
+            .collect();
+        NormalArray::from_vec(vm, field_strs)
     }
 
     pub fn methods(&self, _: &VM) -> Val {


### PR DESCRIPTION
This returns a class's fields. However, SOM's semantics on this are currently unclear (see https://github.com/SOM-st/SOM/issues/40). Although we allow users to mutate the 'methods' array, this is less sensible with fields in my opinion, since it would turn SOM from a statically into a dynamically scoped language. Thus, each time you call 'fields' you get a fresh array back such that any mutations made are ignored (see the `mutate_fields` test).