### PR TITLE
Implement the 'hashcode' primitive.

### DIFF
--- a/lang_tests/hashcode.som
+++ b/lang_tests/hashcode.som
@@ -1,0 +1,32 @@
+"
+VM:
+  status: success
+  stdout:
+    true
+    true
+    true
+    true
+    true
+    true
+    true
+    true
+"
+
+hashcode = (
+    run = (
+        self cmp: 'a' with: 'a'.
+        self cmp: 123 with: 123.
+        self cmp: self with: self.
+        self cmp: 1.1 with: 1.1.
+        self cmp: (1<<200) with: (1<<200).
+        self cmp: hashcode with: hashcode.
+        self cmp: (hashcode methods) with: (hashcode methods).
+        self cmp: (hashcode methods at: 1) with: (hashcode methods at: 1).
+        #() hashcode.
+        [] hashcode.
+    )
+
+    cmp: x with: y = (
+        ((x hashcode) = (y hashcode)) println.
+    )
+)

--- a/src/lib/vm/core.rs
+++ b/src/lib/vm/core.rs
@@ -749,7 +749,11 @@ impl VM {
             }
             Primitive::Halt => unimplemented!(),
             Primitive::HasGlobal => todo!(),
-            Primitive::Hashcode => unimplemented!(),
+            Primitive::Hashcode => {
+                let hc = rcv.hashcode(self);
+                self.stack.push(hc);
+                SendReturn::Val
+            }
             Primitive::Holder => {
                 let meth = stry!(rcv.downcast::<Method>(self));
                 let cls = meth.holder();

--- a/src/lib/vm/objects/array.rs
+++ b/src/lib/vm/objects/array.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::new_ret_no_self)]
 
-use std::cell::UnsafeCell;
+use std::{cell::UnsafeCell, collections::hash_map::DefaultHasher, hash::Hasher};
 
 use crate::vm::{
     core::VM,
@@ -31,6 +31,12 @@ impl Obj for NormalArray {
 
     fn to_array(&self) -> Result<&dyn Array, Box<VMError>> {
         Ok(self)
+    }
+
+    fn hashcode(&self) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        hasher.write_usize(self as *const _ as usize);
+        hasher.finish()
     }
 
     fn length(&self) -> usize {
@@ -134,6 +140,12 @@ impl Obj for MethodsArray {
 
     fn to_array(&self) -> Result<&dyn Array, Box<VMError>> {
         Ok(self)
+    }
+
+    fn hashcode(&self) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        hasher.write_usize(self as *const _ as usize);
+        hasher.finish()
     }
 
     fn length(&self) -> usize {

--- a/src/lib/vm/objects/block.rs
+++ b/src/lib/vm/objects/block.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::new_ret_no_self)]
 
+use std::{collections::hash_map::DefaultHasher, hash::Hasher};
+
 use rboehm::Gc;
 
 use crate::vm::{
@@ -37,6 +39,12 @@ impl Obj for Block {
 
     fn get_class(&self, _: &mut VM) -> Val {
         self.blockn_cls
+    }
+
+    fn hashcode(&self) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        hasher.write_usize(self as *const _ as usize);
+        hasher.finish()
     }
 }
 

--- a/src/lib/vm/objects/class.rs
+++ b/src/lib/vm/objects/class.rs
@@ -2,7 +2,8 @@
 
 use std::{
     cell::{Cell, UnsafeCell},
-    collections::HashMap,
+    collections::hash_map::{DefaultHasher, HashMap},
+    hash::Hasher,
     path::PathBuf,
     str,
 };
@@ -54,6 +55,12 @@ impl Obj for Class {
     fn inst_var_set(&self, n: usize, v: Val) {
         let inst_vars = unsafe { &mut *self.inst_vars.get() };
         inst_vars[n] = v;
+    }
+
+    fn hashcode(&self) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        hasher.write_usize(self as *const _ as usize);
+        hasher.finish()
     }
 }
 

--- a/src/lib/vm/objects/double.rs
+++ b/src/lib/vm/objects/double.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::new_ret_no_self)]
 
+use std::{collections::hash_map::DefaultHasher, hash::Hasher};
+
 use num_bigint::BigInt;
 use num_traits::{FromPrimitive, ToPrimitive, Zero};
 
@@ -30,6 +32,12 @@ impl Obj for Double {
     fn to_strval(&self, vm: &mut VM) -> Result<Val, Box<VMError>> {
         let mut buf = ryu::Buffer::new();
         Ok(String_::new_str(vm, buf.format(self.val).to_owned()))
+    }
+
+    fn hashcode(&self) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        hasher.write_u64(self.val.to_bits());
+        hasher.finish()
     }
 
     fn add(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {

--- a/src/lib/vm/objects/instance.rs
+++ b/src/lib/vm/objects/instance.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::new_ret_no_self)]
 
-use std::cell::UnsafeCell;
+use std::{cell::UnsafeCell, collections::hash_map::DefaultHasher, hash::Hasher};
 
 use rboehm::Gc;
 
@@ -34,6 +34,12 @@ impl Obj for Inst {
     fn inst_var_set(&self, n: usize, v: Val) {
         let inst_vars = unsafe { &mut *self.inst_vars.get() };
         inst_vars[n] = v;
+    }
+
+    fn hashcode(&self) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        hasher.write_usize(self as *const _ as usize);
+        hasher.finish()
     }
 }
 

--- a/src/lib/vm/objects/method.rs
+++ b/src/lib/vm/objects/method.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::new_ret_no_self)]
 
-use std::cell::Cell;
+use std::{cell::Cell, collections::hash_map::DefaultHasher, hash::Hasher};
 
 use crate::{
     compiler::instrs::Primitive,
@@ -39,6 +39,12 @@ impl Obj for Method {
 
     fn get_class(&self, vm: &mut VM) -> Val {
         vm.method_cls
+    }
+
+    fn hashcode(&self) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        hasher.write_usize(self as *const _ as usize);
+        hasher.finish()
     }
 }
 

--- a/src/lib/vm/objects/mod.rs
+++ b/src/lib/vm/objects/mod.rs
@@ -108,6 +108,11 @@ pub trait Obj: std::fmt::Debug {
         unreachable!();
     }
 
+    /// What is this object's hashcode?
+    fn hashcode(&self) -> u64 {
+        unreachable!();
+    }
+
     /// Produce a new `Val` which adds `other` to this.
     fn add(&self, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
         unreachable!();

--- a/src/lib/vm/objects/string_.rs
+++ b/src/lib/vm/objects/string_.rs
@@ -1,6 +1,11 @@
 #![allow(clippy::new_ret_no_self)]
 
-use std::{cell::Cell, str};
+use std::{
+    cell::Cell,
+    collections::hash_map::DefaultHasher,
+    hash::{Hash, Hasher},
+    str,
+};
 
 use rboehm::Gc;
 
@@ -39,6 +44,12 @@ impl Obj for String_ {
                 s: self.s.clone(),
             },
         ))
+    }
+
+    fn hashcode(&self) -> u64 {
+        let mut s = DefaultHasher::new();
+        self.s.hash(&mut s);
+        s.finish()
     }
 
     fn length(&self) -> usize {

--- a/src/lib/vm/val.rs
+++ b/src/lib/vm/val.rs
@@ -204,6 +204,11 @@ impl Val {
         }
     }
 
+    #[cfg(target_pointer_width = "64")]
+    pub fn from_u64(vm: &mut VM, i: u64) -> Val {
+        Val::from_usize(vm, i as usize)
+    }
+
     /// If `v == true`, return a `Val` representing `vm.true_`, otherwise return a `Val`
     /// representing `vm.false_`.
     pub fn from_bool(vm: &VM, v: bool) -> Val {
@@ -290,6 +295,22 @@ impl Val {
                 Ok(String_::new_str(vm, s))
             }
             ValKind::GCBOX => self.tobj(vm).unwrap().to_strval(vm),
+            ValKind::ILLEGAL => unreachable!(),
+        }
+    }
+
+    /// Produce a new `Val` which adds `other` to this.
+    pub fn hashcode(&self, vm: &mut VM) -> Val {
+        match self.valkind() {
+            ValKind::INT => {
+                // Integer.som (not very sensibly) defines hashing an integer to be the integer
+                // itself.
+                unreachable!()
+            }
+            ValKind::GCBOX => {
+                let hc = self.tobj(vm).unwrap().hashcode();
+                Val::from_u64(vm, hc)
+            }
             ValKind::ILLEGAL => unreachable!(),
         }
     }


### PR DESCRIPTION
In an ideal world, we'd probably define the 'hashcode' function in 'Obj' to be something like:

```
   fn hashcode(&self) -> u64 {
      hash(self as *const _ as usize)
   }
```

However we can't coerce the `Self` type in traits without causing a number of problems that we don't want to go into. So every type has to implement the `hashcode` function.