### PR TITLE
Partiallly implement the 'rem:' operator.

### DIFF
--- a/lang_tests/remainder.som
+++ b/lang_tests/remainder.som
@@ -1,0 +1,14 @@
+"
+VM:
+  status: success
+  stdout:
+    1
+    2
+"
+
+remainder = (
+    run = (
+        (10 rem: 3) println.
+        (20 rem: 3) println.
+    )
+)

--- a/lang_tests/remainder_zero.som
+++ b/lang_tests/remainder_zero.som
@@ -1,0 +1,14 @@
+"
+VM:
+  status: error
+  stderr:
+    Traceback...
+    ...
+    Division by zero or overflow.
+"
+
+remainder_zero = (
+    run = (
+        (10 rem: 0) println.
+    )
+)

--- a/src/lib/vm/core.rs
+++ b/src/lib/vm/core.rs
@@ -929,7 +929,12 @@ impl VM {
                 self.stack.push(v);
                 SendReturn::Val
             }
-            Primitive::Rem => todo!(),
+            Primitive::Rem => {
+                let v = self.stack.pop();
+                let v = stry!(rcv.remainder(self, v));
+                self.stack.push(v);
+                SendReturn::Val
+            }
             Primitive::Round => {
                 let dbl = rcv.downcast::<Double>(self).unwrap();
                 let v = dbl.round(self);

--- a/src/lib/vm/error.rs
+++ b/src/lib/vm/error.rs
@@ -174,6 +174,8 @@ pub enum VMErrorKind {
     },
     /// Something went wrong when trying to execute a primitive.
     PrimitiveError,
+    /// Tried to calculate a remainder that was a divide by zero or resulted in overflow.
+    RemainderError,
     /// Tried to do a shl that would overflow memory and/or not fit in the required integer size.
     ShiftTooBig,
     /// An unknown global.
@@ -228,6 +230,7 @@ impl VMErrorKind {
                 got.as_str()
             )),
             VMErrorKind::PrimitiveError => Ok("Primitive Error".to_owned()),
+            VMErrorKind::RemainderError => Ok("Division by zero or overflow".to_owned()),
             VMErrorKind::ShiftTooBig => Ok("Shift too big".to_owned()),
             VMErrorKind::UnknownGlobal(name) => Ok(format!("Unknown global '{}'", name)),
             VMErrorKind::UnknownMethod => Ok("Unknown method".to_owned()),

--- a/src/lib/vm/objects/integers.rs
+++ b/src/lib/vm/objects/integers.rs
@@ -172,6 +172,10 @@ impl Obj for ArbInt {
         }
     }
 
+    fn remainder(&self, _vm: &mut VM, _other: Val) -> Result<Val, Box<VMError>> {
+        todo!();
+    }
+
     fn shl(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         if let Some(rhs) = other.as_isize(vm) {
             if rhs < 0 {

--- a/src/lib/vm/objects/mod.rs
+++ b/src/lib/vm/objects/mod.rs
@@ -142,6 +142,11 @@ pub trait Obj: std::fmt::Debug {
         unreachable!();
     }
 
+    /// Produce a new `Val` which returns the remainder of dividing this with `other`.
+    fn remainder(&self, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
+        unreachable!();
+    }
+
     /// Produce a new `Val` which shifts `self` `other` bits to the left.
     fn shl(&self, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
         unreachable!();

--- a/src/lib/vm/val.rs
+++ b/src/lib/vm/val.rs
@@ -422,6 +422,25 @@ impl Val {
         self.tobj(vm).unwrap().mul(vm, other)
     }
 
+    /// Produce a new `Val` which performs a mod operation on this with `other`.
+    pub fn remainder(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
+        if let Some(lhs) = self.as_isize(vm) {
+            if let Some(rhs) = other.as_isize(vm) {
+                match lhs.checked_rem(rhs) {
+                    Some(i) => return Ok(Val::from_isize(vm, i)),
+                    None => return Err(VMError::new(vm, VMErrorKind::RemainderError)),
+                }
+            } else if let Some(_) = other.try_downcast::<ArbInt>(vm) {
+                todo!();
+            } else if let Some(_) = other.try_downcast::<Double>(vm) {
+                todo!();
+            }
+            let got = other.dyn_objtype(vm);
+            return Err(VMError::new(vm, VMErrorKind::NotANumber { got }));
+        }
+        self.tobj(vm).unwrap().remainder(vm, other)
+    }
+
     /// Produce a new `Val` which shifts `self` `other` bits to the left.
     pub fn shl(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         if let Some(lhs) = self.as_isize(vm) {


### PR DESCRIPTION
This calculates remainders. Fully implementing this for all the possible types is surprisingly tricky because BigInt doesn't provide `checked_rem`. Since Java SOM also can't deal with any of the tricky cases (a big int / non-big int errors with "TODO"), I think the very basic support here is just about acceptable.