### PR TITLE
Detect overlapping field names

### DIFF
--- a/lang_tests/instance_fields_overlap/test.som
+++ b/lang_tests/instance_fields_overlap/test.som
@@ -1,0 +1,13 @@
+"
+VM:
+  status: error
+  stderr:
+    ...test.som', line 10, column 23:
+      test = test_super ( | a |
+    Field 'a' is already defined in a superclass.
+"
+
+test = test_super ( | a |
+  run = (
+  )
+)

--- a/lang_tests/instance_fields_overlap/test_super.som
+++ b/lang_tests/instance_fields_overlap/test_super.som
@@ -1,0 +1,3 @@
+test_super = (
+    | a |
+)

--- a/lang_tests/instance_fields_overlap2.som
+++ b/lang_tests/instance_fields_overlap2.som
@@ -1,0 +1,12 @@
+"
+VM:
+  status: error
+  stderr:
+    ...instance_fields_overlap2.som', line 11, column 9:
+      | a a |
+    Field 'a' has already been defined in this class.
+"
+
+instance_field_overlap2 = (
+    | a a |
+)

--- a/src/lib/compiler/ast_to_instrs.rs
+++ b/src/lib/compiler/ast_to_instrs.rs
@@ -153,6 +153,15 @@ impl<'a, 'input> Compiler<'a, 'input> {
                     .iter()
                     .map(|(k, v)| (k.to_owned(), *v)),
             );
+            for var in ast_inst_vars {
+                let n = lexer.span_str(*var);
+                if inst_vars.contains_key(n) {
+                    return Err(vec![(
+                        *var,
+                        format!("Field '{}' is already defined in a superclass.", n),
+                    )]);
+                }
+            }
             inst_vars
         } else {
             HashMap::with_capacity(ast_inst_vars.len())

--- a/src/lib/compiler/ast_to_instrs.rs
+++ b/src/lib/compiler/ast_to_instrs.rs
@@ -168,7 +168,21 @@ impl<'a, 'input> Compiler<'a, 'input> {
         };
         for var in ast_inst_vars {
             let vars_len = inst_vars.len();
-            inst_vars.insert(lexer.span_str(*var).to_owned(), vars_len);
+            let n = lexer.span_str(*var).to_owned();
+            match inst_vars.entry(n) {
+                hash_map::Entry::Occupied(_) => {
+                    return Err(vec![(
+                        *var,
+                        format!(
+                            "Field '{}' has already been defined in this class.",
+                            self.lexer.span_str(*var)
+                        ),
+                    )])
+                }
+                hash_map::Entry::Vacant(e) => {
+                    e.insert(vars_len);
+                }
+            }
         }
         self.vars_stack.push(inst_vars);
 


### PR DESCRIPTION
There are two cases to be dealt with:

1. A field name has already been defined in a superclass (https://github.com/softdevteam/yksom/commit/5e00d91257a8865f90f0836e65bbcddb237078a5).
2. A class defines the same field more than once (https://github.com/softdevteam/yksom/pull/147/commits/93706090edfdcd26f2a0e82032500bd19a0f3686).

The first of those was pointed out by @hirevo in https://github.com/SOM-st/SOM/issues/42; the second is a relatively simple variation on the same theme.