### PR TITLE
Implement the 'Shr' primitive.

### DIFF
--- a/lang_tests/shift_right.som
+++ b/lang_tests/shift_right.som
@@ -1,0 +1,25 @@
+"
+VM:
+  status: success
+  stdout:
+    0
+    512
+    127
+    -1
+    9223372036854775807
+    9223372036854775296
+    1
+"
+
+shift_right = (
+    run = (
+        (1 >>> 1) println.
+        (1024 >>> 1) println.
+        (1023 >>> 3) println.
+        (-1 >>> 0) println.
+        (-1 >>> 1) println.
+        (-1024 >>> 1) println.
+
+        ((1 << 200) >>> 200) println.
+    )
+)

--- a/lang_tests/shift_right_too_big.som
+++ b/lang_tests/shift_right_too_big.som
@@ -1,0 +1,14 @@
+"
+VM:
+  status: error
+  stderr:
+    Traceback...
+    ...
+    Shift too big.
+"
+
+shift_right = (
+    run = (
+        1 >>> (1 << 100).
+    )
+)

--- a/lang_tests/shift_right_type_err.som
+++ b/lang_tests/shift_right_type_err.som
@@ -1,0 +1,14 @@
+"
+VM:
+  status: error
+  stderr:
+    Traceback...
+    ...
+    Expected a numeric type but got type 'String_'.
+"
+
+shift_right = (
+    run = (
+        (1 >>> 'a') println.
+    )
+)

--- a/src/lib/vm/core.rs
+++ b/src/lib/vm/core.rs
@@ -973,7 +973,12 @@ impl VM {
                 self.stack.push(v);
                 SendReturn::Val
             }
-            Primitive::Shr => todo!(),
+            Primitive::Shr => {
+                let v = self.stack.pop();
+                let v = stry!(rcv.shr(self, v));
+                self.stack.push(v);
+                SendReturn::Val
+            }
             Primitive::Signature => {
                 let meth = rcv.downcast::<Method>(self).unwrap();
                 self.stack.push(meth.sig(self));

--- a/src/lib/vm/objects/integers.rs
+++ b/src/lib/vm/objects/integers.rs
@@ -193,6 +193,27 @@ impl Obj for ArbInt {
         }
     }
 
+    fn shr(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
+        if let Some(rhs) = other.as_isize(vm) {
+            if rhs < 0 {
+                Err(VMError::new(vm, VMErrorKind::NegativeShift))
+            } else {
+                let rhs_i =
+                    usize::try_from(rhs).map_err(|_| VMError::new(vm, VMErrorKind::ShiftTooBig))?;
+                if self.val.is_positive() {
+                    Ok(ArbInt::new(vm, &self.val >> rhs_i))
+                } else {
+                    todo!();
+                }
+            }
+        } else if other.try_downcast::<ArbInt>(vm).is_some() {
+            Err(VMError::new(vm, VMErrorKind::ShiftTooBig))
+        } else {
+            let got = other.dyn_objtype(vm);
+            Err(VMError::new(vm, VMErrorKind::NotANumber { got }))
+        }
+    }
+
     fn sqrt(&self, vm: &mut VM) -> Result<Val, Box<VMError>> {
         if self.val < Zero::zero() {
             Err(VMError::new(vm, VMErrorKind::DomainError))

--- a/src/lib/vm/objects/mod.rs
+++ b/src/lib/vm/objects/mod.rs
@@ -152,6 +152,12 @@ pub trait Obj: std::fmt::Debug {
         unreachable!();
     }
 
+    /// Produce a new `Val` which shifts `self` `other` bits to the right, treating `self` as if it
+    /// did not have a sign bit.
+    fn shr(&self, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
+        unreachable!();
+    }
+
     /// Produces a new `Val` which is the square root of this.
     fn sqrt(&self, _: &mut VM) -> Result<Val, Box<VMError>> {
         unreachable!();


### PR DESCRIPTION
Java SOM seems to define "shift right" as "treat the int as unsigned, shift right, then treat as signed". This is fairly easy for us in the case of word-sized integers, but awkward to implement for negative big ints -- I've left that for the future (if anyone should ever encounter such a case, which might be quite some time away!).