### PR TITLE
Implement the 'perform:WithArguments' and friends primitives.

### DIFF
--- a/lang_tests/perform_in_superclass.som
+++ b/lang_tests/perform_in_superclass.som
@@ -1,0 +1,18 @@
+"
+VM:
+  status: success
+  stdout:
+    2
+    instance of perform_in_superclass
+"
+
+perform_in_superclass = (
+    run = (
+        self println.
+        self perform: #println inSuperclass: Object.
+    )
+
+    println = (
+        2 println.
+    )
+)

--- a/lang_tests/perform_in_superclass_with_args.som
+++ b/lang_tests/perform_in_superclass_with_args.som
@@ -1,0 +1,20 @@
+"
+VM:
+  status: success
+  stdout:
+    2
+    4
+    instance of perform_in_superclass_with_args
+"
+
+perform_in_superclass_with_args = (
+    run = (
+        (self ifNil: 2) println.
+        (self perform: #ifNil: withArguments: #(3) inSuperclass: Object) println.
+    )
+
+    ifNil: aBlock = (
+        aBlock println.
+        ^ 4.
+    )
+)

--- a/lang_tests/perform_witharguments.som
+++ b/lang_tests/perform_witharguments.som
@@ -1,0 +1,20 @@
+"
+VM:
+  status: success
+  stdout:
+    5
+    6
+    7
+"
+
+perform_witharguments = (
+    run = (
+        self perform: #f:b:c: withArguments: #(5 6 7).
+    )
+
+    f: a b: b c: c = (
+        a println.
+        b println.
+        c println.
+    )
+)

--- a/lang_tests/perform_witharguments_wrong.som
+++ b/lang_tests/perform_witharguments_wrong.som
@@ -1,0 +1,20 @@
+"
+VM:
+  status: error
+  stderr:
+    Traceback...
+    ...
+    Tried passing 1 arguments to a function that requires 3.
+"
+
+perform_witharguments_wrong = (
+    run = (
+        self perform: #f:b:c: withArguments: #(5).
+    )
+
+    f: a b: b c: c = (
+        a println.
+        b println.
+        c println.
+    )
+)

--- a/src/lib/compiler/ast_to_instrs.rs
+++ b/src/lib/compiler/ast_to_instrs.rs
@@ -248,9 +248,10 @@ impl<'a, 'input> Compiler<'a, 'input> {
                 ((pairs[0].0, name), args)
             }
         };
+        let args_len = args.len();
         let body = self.c_body(vm, astmeth.span, (name.0, &name.1), args, &astmeth.body)?;
         let sig = String_::new_sym(vm, name.1.clone());
-        let meth = Method::new(vm, sig, body);
+        let meth = Method::new(vm, sig, args_len, body);
         Ok((name.1, Val::from_obj(vm, meth)))
     }
 

--- a/src/lib/vm/error.rs
+++ b/src/lib/vm/error.rs
@@ -182,6 +182,11 @@ pub enum VMErrorKind {
     UnknownGlobal(String),
     /// An unknown method.
     UnknownMethod,
+    /// Tried calling a method with the wrong number of arguments.
+    WrongNumberOfArgs {
+        wanted: usize,
+        got: usize,
+    },
 }
 
 impl VMErrorKind {
@@ -234,6 +239,10 @@ impl VMErrorKind {
             VMErrorKind::ShiftTooBig => Ok("Shift too big".to_owned()),
             VMErrorKind::UnknownGlobal(name) => Ok(format!("Unknown global '{}'", name)),
             VMErrorKind::UnknownMethod => Ok("Unknown method".to_owned()),
+            VMErrorKind::WrongNumberOfArgs { wanted, got } => Ok(format!(
+                "Tried passing {} arguments to a function that requires {}",
+                got, wanted
+            )),
         }
     }
 }

--- a/src/lib/vm/objects/method.rs
+++ b/src/lib/vm/objects/method.rs
@@ -14,6 +14,7 @@ use crate::{
 #[derive(Debug)]
 pub struct Method {
     sig: Cell<Val>,
+    num_params: usize,
     pub body: MethodBody,
     holder: Cell<Val>,
 }
@@ -57,9 +58,10 @@ impl StaticObjType for Method {
 }
 
 impl Method {
-    pub fn new(vm: &VM, sig: Val, body: MethodBody) -> Method {
+    pub fn new(vm: &VM, sig: Val, num_params: usize, body: MethodBody) -> Method {
         Method {
             sig: Cell::new(sig),
+            num_params,
             body,
             holder: Cell::new(vm.nil),
         }
@@ -67,6 +69,10 @@ impl Method {
 
     pub fn holder(&self) -> Val {
         self.holder.get()
+    }
+
+    pub fn num_params(&self) -> usize {
+        self.num_params
     }
 
     pub fn set_holder(&self, _: &VM, class: Val) {


### PR DESCRIPTION
This PR implements the various `perform:withArguments` primitives.

Some of the complexity in https://github.com/softdevteam/yksom/pull/149/commits/ef599ea6e4f06de015c8036fdb82334c86b23119 is to make sure that yksom doesn't suffer from the same problems as JavaSOM (see https://github.com/SOM-st/SOM/issues/43#issuecomment-643378401). https://github.com/softdevteam/yksom/pull/149/commits/bf02eaa4da0ba4e1f0a9962a6a51ae79f2ef431b is then a simple general optimisation opened up by the first commit. I then factored out the common `perform` code in https://github.com/softdevteam/yksom/pull/149/commits/d58f3e886f761912338ae7fad4244b8c8345e5c2 which made implementing the other primitives relatively simple.