### PR TITLE
Implement instVarAt:[put:]

### DIFF
--- a/lang_tests/inst_var_at.som
+++ b/lang_tests/inst_var_at.som
@@ -1,0 +1,14 @@
+"
+VM:
+  status: success
+  stdout: 5
+"
+
+inst_var_at = (
+    | x |
+
+    run = (
+        x := 5.
+        (self instVarAt: 1) println.
+    )
+)

--- a/lang_tests/inst_var_at_bad_idx.som
+++ b/lang_tests/inst_var_at_bad_idx.som
@@ -1,0 +1,17 @@
+"
+VM:
+  status: error
+  stderr:
+    Traceback...
+    ...
+    Index 2 not valid for array of length 1.
+"
+
+inst_var_at_bad_idx = (
+    | x |
+
+    run = (
+        x := 5.
+        (self instVarAt: 2) println.
+    )
+)

--- a/lang_tests/inst_var_at_put.som
+++ b/lang_tests/inst_var_at_put.som
@@ -1,0 +1,19 @@
+"
+VM:
+  status: success
+  stdout:
+    5
+    instance of inst_var_at_put
+    6
+"
+
+inst_var_at_put = (
+    | x |
+
+    run = (
+        x := 5.
+        (self instVarAt: 1) println.
+        (self instVarAt: 1 put: 6) println.
+        x println.
+    )
+)

--- a/lang_tests/inst_var_at_put_bad_idx.som
+++ b/lang_tests/inst_var_at_put_bad_idx.som
@@ -1,0 +1,18 @@
+"
+VM:
+  status: error
+  stderr:
+    Traceback...
+    ...
+    Index 2 not valid for array of length 1.
+"
+
+inst_var_at_put_bad_idx = (
+    | x |
+
+    run = (
+        x := 5.
+        self instVarAt: 2 put: 6.
+        x println.
+    )
+)

--- a/lang_tests/inst_var_at_put_superclass/test.som
+++ b/lang_tests/inst_var_at_put_superclass/test.som
@@ -1,0 +1,25 @@
+"
+VM:
+  status: success
+  stdout:
+    1
+    2
+    4
+    3
+"
+
+test = test_super (
+    | d c |
+
+    run = (
+        self instVarAt: 1 put: 1.
+        self instVarAt: 2 put: 2.
+        self instVarAt: 3 put: 3.
+        self instVarAt: 4 put: 4.
+
+        a println.
+        b println.
+        c println.
+        d println.
+    )
+)

--- a/lang_tests/inst_var_at_put_superclass/test_super.som
+++ b/lang_tests/inst_var_at_put_superclass/test_super.som
@@ -1,0 +1,10 @@
+test_super = (
+    | a b |
+
+    f = (
+        (self instVarAt: 1) println.
+        (self instVarAt: 2) println.
+        (self instVarAt: 3) println.
+        (self instVarAt: 4) println.
+    )
+)

--- a/src/lib/vm/core.rs
+++ b/src/lib/vm/core.rs
@@ -822,7 +822,14 @@ impl VM {
                 self.stack.push(v);
                 SendReturn::Val
             }
-            Primitive::InstVarAtPut => unimplemented!(),
+            Primitive::InstVarAtPut => {
+                let v = self.stack.pop();
+                let n = stry!(self.stack.pop().as_usize(self));
+                let inst = stry!(rcv.tobj(self));
+                stry!(inst.inst_var_at_put(self, n, v));
+                self.stack.push(rcv);
+                SendReturn::Val
+            }
             Primitive::InstVarNamed => unimplemented!(),
             Primitive::InvokeOnWith => todo!(),
             Primitive::IsDigits => unimplemented!(),

--- a/src/lib/vm/core.rs
+++ b/src/lib/vm/core.rs
@@ -815,7 +815,13 @@ impl VM {
                 SendReturn::Val
             }
             Primitive::Inspect => unimplemented!(),
-            Primitive::InstVarAt => unimplemented!(),
+            Primitive::InstVarAt => {
+                let n = stry!(self.stack.pop().as_usize(self));
+                let inst = stry!(rcv.tobj(self));
+                let v = stry!(inst.inst_var_at(self, n));
+                self.stack.push(v);
+                SendReturn::Val
+            }
             Primitive::InstVarAtPut => unimplemented!(),
             Primitive::InstVarNamed => unimplemented!(),
             Primitive::InvokeOnWith => todo!(),

--- a/src/lib/vm/core.rs
+++ b/src/lib/vm/core.rs
@@ -487,12 +487,12 @@ impl VM {
                 }
                 Instr::InstVarLookup(n) => {
                     let inst = stry!(rcv.tobj(self));
-                    self.stack.push(inst.inst_var_lookup(n));
+                    self.stack.push(unsafe { inst.unchecked_inst_var_get(n) });
                     pc += 1;
                 }
                 Instr::InstVarSet(n) => {
                     let inst = stry!(rcv.tobj(self));
-                    inst.inst_var_set(n, self.stack.peek());
+                    unsafe { inst.unchecked_inst_var_set(n, self.stack.peek()) };
                     pc += 1;
                 }
                 Instr::Int(i) => {

--- a/src/lib/vm/objects/class.rs
+++ b/src/lib/vm/objects/class.rs
@@ -47,13 +47,13 @@ impl Obj for Class {
         self.metacls.get()
     }
 
-    fn inst_var_lookup(&self, n: usize) -> Val {
-        let inst_vars = unsafe { &mut *self.inst_vars.get() };
+    unsafe fn unchecked_inst_var_get(&self, n: usize) -> Val {
+        let inst_vars = &mut *self.inst_vars.get();
         inst_vars[n]
     }
 
-    fn inst_var_set(&self, n: usize, v: Val) {
-        let inst_vars = unsafe { &mut *self.inst_vars.get() };
+    unsafe fn unchecked_inst_var_set(&self, n: usize, v: Val) {
+        let inst_vars = &mut *self.inst_vars.get();
         inst_vars[n] = v;
     }
 

--- a/src/lib/vm/objects/instance.rs
+++ b/src/lib/vm/objects/instance.rs
@@ -26,13 +26,13 @@ impl Obj for Inst {
         self.class
     }
 
-    fn inst_var_lookup(&self, n: usize) -> Val {
-        let inst_vars = unsafe { &mut *self.inst_vars.get() };
+    unsafe fn unchecked_inst_var_get(&self, n: usize) -> Val {
+        let inst_vars = &mut *self.inst_vars.get();
         inst_vars[n]
     }
 
-    fn inst_var_set(&self, n: usize, v: Val) {
-        let inst_vars = unsafe { &mut *self.inst_vars.get() };
+    unsafe fn unchecked_inst_var_set(&self, n: usize, v: Val) {
+        let inst_vars = &mut *self.inst_vars.get();
         inst_vars[n] = v;
     }
 

--- a/src/lib/vm/objects/instance.rs
+++ b/src/lib/vm/objects/instance.rs
@@ -26,6 +26,10 @@ impl Obj for Inst {
         self.class
     }
 
+    fn num_inst_vars(&self) -> usize {
+        unsafe { &*self.inst_vars.get() }.len()
+    }
+
     unsafe fn unchecked_inst_var_get(&self, n: usize) -> Val {
         let inst_vars = &mut *self.inst_vars.get();
         inst_vars[n]

--- a/src/lib/vm/objects/mod.rs
+++ b/src/lib/vm/objects/mod.rs
@@ -93,13 +93,15 @@ pub trait Obj: std::fmt::Debug {
         unreachable!();
     }
 
-    /// Lookup an instance variable in this object.
-    fn inst_var_lookup(&self, _: usize) -> Val {
+    /// Lookup an instance variable in this object. If `usize` exceeds the number of instance
+    /// variables this will lead to undefined behaviour.
+    unsafe fn unchecked_inst_var_get(&self, _: usize) -> Val {
         unreachable!();
     }
 
-    /// Set an instance variable in this object.
-    fn inst_var_set(&self, _: usize, _: Val) {
+    /// Set an instance variable in this object. If `usize` exceeds the number of instance
+    /// variables this will lead to undefined behaviour.
+    unsafe fn unchecked_inst_var_set(&self, _: usize, _: Val) {
         unreachable!();
     }
 

--- a/src/lib/vm/objects/mod.rs
+++ b/src/lib/vm/objects/mod.rs
@@ -117,6 +117,21 @@ pub trait Obj: std::fmt::Debug {
         }
     }
 
+    /// Return the instance variable at `i` (using SOM indexing).
+    fn inst_var_at_put(&self, vm: &VM, i: usize, v: Val) -> Result<(), Box<VMError>> {
+        if i > 0 && i <= self.num_inst_vars() {
+            Ok(unsafe { self.unchecked_inst_var_set(i - 1, v) })
+        } else {
+            Err(VMError::new(
+                vm,
+                VMErrorKind::IndexError {
+                    tried: i,
+                    max: self.num_inst_vars(),
+                },
+            ))
+        }
+    }
+
     /// Lookup an instance variable in this object. If `usize` exceeds the number of instance
     /// variables this will lead to undefined behaviour.
     unsafe fn unchecked_inst_var_get(&self, _: usize) -> Val {


### PR DESCRIPTION
These are two relatively simple primitives, although while doing this, I realised that some existing functions should be explicitly marked as `unsafe` (https://github.com/softdevteam/yksom/commit/54422e80da444b5e22e9b2e5a6a82756d3803ae1).