### PR TITLE
Implement three string primitives

### DIFF
--- a/lang_tests/is_digits.som
+++ b/lang_tests/is_digits.som
@@ -1,0 +1,26 @@
+"
+VM:
+  status: success
+  stdout:
+    true
+    true
+    true
+    true
+    false
+    false
+    false
+    false
+"
+
+is_digits = (
+    run = (
+        '0' isDigits println.
+        '1' isDigits println.
+        '10' isDigits println.
+        '987987982347829374234' isDigits println.
+        '0b1' isDigits println.
+        '0_1' isDigits println.
+        'a' isDigits println.
+        '' isDigits println.
+    )
+)

--- a/lang_tests/is_letters.som
+++ b/lang_tests/is_letters.som
@@ -1,0 +1,22 @@
+"
+VM:
+  status: success
+  stdout:
+    true
+    true
+    true
+    false
+    false
+    false
+"
+
+is_letters = (
+    run = (
+        'a' isLetters println.
+        'abcdrohtra' isLetters println.
+        'æ' isLetters println.
+        'a0' isLetters println.
+        '¾' isLetters println.
+        '' isLetters println.
+    )
+)

--- a/lang_tests/is_whitespace.som
+++ b/lang_tests/is_whitespace.som
@@ -1,0 +1,23 @@
+"
+VM:
+  status: success
+  stdout:
+    true
+    true
+    true
+    false
+    false
+"
+
+is_whitespace = (
+    run = (
+        "Space"
+        ' ' isWhiteSpace println.
+        "Tab"
+        '	' isWhiteSpace println.
+        "Space and tab"
+        '	 ' isWhiteSpace println.
+        ' a ' isWhiteSpace println.
+        '' isWhiteSpace println.
+    )
+)

--- a/src/lib/vm/core.rs
+++ b/src/lib/vm/core.rs
@@ -836,7 +836,10 @@ impl VM {
                 stry!(self.str_is(rcv, |x| x.is_ascii_digit()));
                 SendReturn::Val
             }
-            Primitive::IsLetters => unimplemented!(),
+            Primitive::IsLetters => {
+                stry!(self.str_is(rcv, |x| x.is_alphabetic()));
+                SendReturn::Val
+            }
             Primitive::IsWhiteSpace => unimplemented!(),
             Primitive::Length => {
                 // Only Arrays and Strings can have this primitive installed.

--- a/src/lib/vm/core.rs
+++ b/src/lib/vm/core.rs
@@ -840,7 +840,10 @@ impl VM {
                 stry!(self.str_is(rcv, |x| x.is_alphabetic()));
                 SendReturn::Val
             }
-            Primitive::IsWhiteSpace => unimplemented!(),
+            Primitive::IsWhiteSpace => {
+                stry!(self.str_is(rcv, |x| x.is_whitespace()));
+                SendReturn::Val
+            }
             Primitive::Length => {
                 // Only Arrays and Strings can have this primitive installed.
                 debug_assert!(rcv.valkind() == ValKind::GCBOX);

--- a/src/lib/vm/core.rs
+++ b/src/lib/vm/core.rs
@@ -832,7 +832,10 @@ impl VM {
             }
             Primitive::InstVarNamed => unimplemented!(),
             Primitive::InvokeOnWith => todo!(),
-            Primitive::IsDigits => unimplemented!(),
+            Primitive::IsDigits => {
+                stry!(self.str_is(rcv, |x| x.is_ascii_digit()));
+                SendReturn::Val
+            }
             Primitive::IsLetters => unimplemented!(),
             Primitive::IsWhiteSpace => unimplemented!(),
             Primitive::Length => {
@@ -1093,6 +1096,22 @@ impl VM {
             }
             Err(e) => return SendReturn::Err(e),
         }
+    }
+
+    /// Does every character in the SOM string in `rcv` satisfy the condition `f`? Pushes true/false onto the SOM
+    /// stack. Note that empty strings are considered not to satisfy the condition by definition.
+    pub fn str_is<F>(&mut self, rcv: Val, f: F) -> Result<(), Box<VMError>>
+    where
+        F: Fn(char) -> bool,
+    {
+        let str_val = rcv.downcast::<String_>(self)?;
+        let str_ = str_val.as_str();
+        if !str_.is_empty() && str_.chars().all(f) {
+            self.stack.push(self.true_);
+        } else {
+            self.stack.push(self.false_);
+        }
+        Ok(())
     }
 
     fn current_frame(&mut self) -> &mut Frame {


### PR DESCRIPTION
This PR implements the `isDigits`, `isLetters`, and `isWhitespace` primitives. They're all very related. Note that I have assumed that `isDigits` only matches *ASCII* digit characters, but that the other two primitives match *Unicode* letters/whitespace.