### PR TITLE
We needn't force a rebuild when something in the SOM directory changes.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -4,7 +4,7 @@ use lrpar::CTParserBuilder;
 use rerun_except::rerun_except;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    rerun_except(&["/lang_tests/*.som", "lib/SOM"])?;
+    rerun_except(&["/lang_tests/*.som", "SOM"])?;
 
     let lex_rule_ids_map = CTParserBuilder::new()
         .yacckind(YaccKind::Grmtools)


### PR DESCRIPTION
This is a hangover from the move from our own (hacked) version of the SOM library to a submodule of the genuine SOM repository.