### PR TITLE
Run the SOM testsuite on buildbot.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -26,3 +26,6 @@ fi
 
 cargo test
 cargo test --release
+
+cargo run -- --cp SOM/Smalltalk SOM/TestSuite/TestHarness.som
+cargo run --release -- --cp SOM/Smalltalk SOM/TestSuite/TestHarness.som


### PR DESCRIPTION
Since https://github.com/SOM-st/SOM/pull/49 has been merged, we can now easily run the test suite, so I think it makes sense to do that during CI.