### PR TITLE
We don't use specialisation.

### DIFF
--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -14,7 +14,6 @@
 #![feature(allocator_api)]
 #![feature(box_patterns)]
 #![feature(coerce_unsized)]
-#![feature(specialization)]
 #![feature(unsize)]
 #![allow(clippy::cognitive_complexity)]
 #![allow(clippy::float_cmp)]


### PR DESCRIPTION
Recent rustc nightlies warn against using this feature so, since we don't need it, we might as well remove it.