### PR TITLE
Use SmartString.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ num-integer = "0.1"
 num_enum = "0.5"
 num-traits = "0.2"
 ryu = "1.0"
+smartstring = "0.2"
 static_assertions = "1.1"
 termion = "1.5"
 

--- a/src/lib/compiler/mod.rs
+++ b/src/lib/compiler/mod.rs
@@ -38,7 +38,7 @@ pub fn compile(vm: &mut VM, path: &Path) -> (String, Val) {
                     process::exit(1);
                 });
             if errs.is_empty() {
-                (name, cls)
+                (name.into(), cls)
             } else {
                 process::exit(1);
             }

--- a/src/lib/vm/error.rs
+++ b/src/lib/vm/error.rs
@@ -2,6 +2,7 @@ use std::{fs::read_to_string, io::stderr};
 
 use lrpar::Span;
 use rboehm::Gc;
+use smartstring::alias::String as SmartString;
 use termion::{is_tty, style};
 
 use crate::vm::{
@@ -103,7 +104,7 @@ impl VMError {
             }
         }
         match self.kind.to_string(vm) {
-            Ok(s) => eprintln!("{}.", s),
+            Ok(s) => eprintln!("{}.", s.as_str()),
             Err(_) => {
                 // We could do something more clever here, but it's not clear that it's worth it.
                 eprintln!("<Fatal error when running error handler>")
@@ -162,7 +163,7 @@ pub enum VMErrorKind {
         got_cls: Val,
     },
     /// Tried to convert an invalid string to a number.
-    InvalidInteger(String),
+    InvalidInteger(SmartString),
     /// Tried to access a global before it being initialised.
     InvalidSymbol,
     /// Tried to do a shl or shr with a value below zero.
@@ -179,7 +180,7 @@ pub enum VMErrorKind {
     /// Tried to do a shl that would overflow memory and/or not fit in the required integer size.
     ShiftTooBig,
     /// An unknown global.
-    UnknownGlobal(String),
+    UnknownGlobal(SmartString),
     /// An unknown method.
     UnknownMethod,
     /// Tried calling a method with the wrong number of arguments.
@@ -225,9 +226,10 @@ impl VMErrorKind {
                     got_name.as_str()
                 ))
             }
-            VMErrorKind::InvalidInteger(s) => {
-                Ok(format!("'{}' cannot be converted to an Integer", s))
-            }
+            VMErrorKind::InvalidInteger(s) => Ok(format!(
+                "'{}' cannot be converted to an Integer",
+                s.as_str()
+            )),
             VMErrorKind::InvalidSymbol => Ok("Invalid symbol".to_owned()),
             VMErrorKind::NegativeShift => Ok("Negative shift".to_owned()),
             VMErrorKind::NotANumber { got } => Ok(format!(
@@ -237,7 +239,7 @@ impl VMErrorKind {
             VMErrorKind::PrimitiveError => Ok("Primitive Error".to_owned()),
             VMErrorKind::RemainderError => Ok("Division by zero or overflow".to_owned()),
             VMErrorKind::ShiftTooBig => Ok("Shift too big".to_owned()),
-            VMErrorKind::UnknownGlobal(name) => Ok(format!("Unknown global '{}'", name)),
+            VMErrorKind::UnknownGlobal(name) => Ok(format!("Unknown global '{}'", name.as_str())),
             VMErrorKind::UnknownMethod => Ok("Unknown method".to_owned()),
             VMErrorKind::WrongNumberOfArgs { wanted, got } => Ok(format!(
                 "Tried passing {} arguments to a function that requires {}",

--- a/src/lib/vm/objects/class.rs
+++ b/src/lib/vm/objects/class.rs
@@ -9,6 +9,7 @@ use std::{
 };
 
 use rboehm::Gc;
+use smartstring::alias::String as SmartString;
 
 use crate::vm::{
     core::VM,
@@ -26,14 +27,14 @@ pub struct Class {
     pub instrs_off: usize,
     supercls: Cell<Val>,
     pub num_inst_vars: usize,
-    pub inst_vars_map: HashMap<String, usize>,
+    pub inst_vars_map: HashMap<SmartString, usize>,
     /// A SOM Array of methods (though note that it is *not* guaranteed that these definitely point
     /// to SOM `Method` instances -- anything can be stored in this array!).
     methods: Val,
     /// A map from method names to indexes into the methods SOM Array. Note that indexes are stored
     /// with SOM indexing (starting from 1). We guarantee that the indexes are valid indexes for
     /// the `methods` array.
-    methods_map: HashMap<String, usize>,
+    methods_map: HashMap<SmartString, usize>,
     inst_vars: UnsafeCell<Vec<Val>>,
 }
 
@@ -80,9 +81,9 @@ impl Class {
         path: PathBuf,
         instrs_off: usize,
         supercls: Val,
-        inst_vars_map: HashMap<String, usize>,
+        inst_vars_map: HashMap<SmartString, usize>,
         methods: Val,
-        methods_map: HashMap<String, usize>,
+        methods_map: HashMap<SmartString, usize>,
     ) -> Self {
         #[cfg(debug_assertions)]
         {

--- a/src/lib/vm/objects/double.rs
+++ b/src/lib/vm/objects/double.rs
@@ -4,6 +4,7 @@ use std::{collections::hash_map::DefaultHasher, hash::Hasher};
 
 use num_bigint::BigInt;
 use num_traits::{FromPrimitive, ToPrimitive, Zero};
+use smartstring::alias::String as SmartString;
 
 use crate::vm::{
     core::VM,
@@ -31,7 +32,10 @@ impl Obj for Double {
 
     fn to_strval(&self, vm: &mut VM) -> Result<Val, Box<VMError>> {
         let mut buf = ryu::Buffer::new();
-        Ok(String_::new_str(vm, buf.format(self.val).to_owned()))
+        Ok(String_::new_str(
+            vm,
+            SmartString::from(buf.format(self.val)),
+        ))
     }
 
     fn hashcode(&self) -> u64 {

--- a/src/lib/vm/objects/integers.rs
+++ b/src/lib/vm/objects/integers.rs
@@ -41,7 +41,7 @@ impl Obj for ArbInt {
     }
 
     fn to_strval(&self, vm: &mut VM) -> Result<Val, Box<VMError>> {
-        Ok(String_::new_str(vm, self.val.to_string()))
+        Ok(String_::new_str(vm, self.val.to_string().into()))
     }
 
     fn add(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
@@ -405,7 +405,7 @@ impl Obj for Int {
     }
 
     fn to_strval(&self, vm: &mut VM) -> Result<Val, Box<VMError>> {
-        Ok(String_::new_str(vm, self.val.to_string()))
+        Ok(String_::new_str(vm, self.val.to_string().into()))
     }
 
     fn add(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {

--- a/src/lib/vm/val.rs
+++ b/src/lib/vm/val.rs
@@ -292,7 +292,7 @@ impl Val {
         match self.valkind() {
             ValKind::INT => {
                 let s = self.as_isize(vm).unwrap().to_string();
-                Ok(String_::new_str(vm, s))
+                Ok(String_::new_str(vm, s.into()))
             }
             ValKind::GCBOX => self.tobj(vm).unwrap().to_strval(vm),
             ValKind::ILLEGAL => unreachable!(),
@@ -633,6 +633,7 @@ mod tests {
     };
 
     use serial_test::serial;
+    use smartstring::alias::String as SmartString;
     use std::ops::Deref;
 
     #[test]
@@ -704,7 +705,7 @@ mod tests {
         assert_eq!(v.as_usize(&mut vm).unwrap(), 1 << (BITSIZE - 2));
         assert_eq!(v.as_isize(&mut vm).unwrap(), 1 << (BITSIZE - 2));
 
-        let v = String_::new_str(&mut vm, "".to_owned());
+        let v = String_::new_str(&mut vm, SmartString::new());
         assert!(v.as_usize(&mut vm).is_err());
     }
 
@@ -714,7 +715,7 @@ mod tests {
         let mut vm = VM::new_no_bootstrap();
 
         let v = {
-            let v = String_::new_str(&mut vm, "s".to_owned());
+            let v = String_::new_str(&mut vm, SmartString::from("s"));
             let v_tobj = v.tobj(&mut vm).unwrap();
             let v_int: &dyn Obj = v_tobj.deref().deref();
             let v_recovered = Val::recover(v_int);
@@ -730,7 +731,7 @@ mod tests {
     #[serial]
     fn test_cast() {
         let mut vm = VM::new_no_bootstrap();
-        let v = String_::new_str(&mut vm, "s".to_owned());
+        let v = String_::new_str(&mut vm, SmartString::from("s"));
         assert!(v.downcast::<String_>(&mut vm).is_ok());
         assert_eq!(
             v.downcast::<Class>(&mut vm).unwrap_err().kind,
@@ -745,7 +746,7 @@ mod tests {
     #[serial]
     fn test_downcast() {
         let mut vm = VM::new_no_bootstrap();
-        let v = String_::new_str(&mut vm, "s".to_owned());
+        let v = String_::new_str(&mut vm, SmartString::from("s"));
         assert!(v.downcast::<String_>(&mut vm).is_ok());
         assert!(v.downcast::<Class>(&mut vm).is_err());
         assert!(v.try_downcast::<String_>(&mut vm).is_some());

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use std::{
 };
 
 use getopts::Options;
+use smartstring::alias::String as SmartString;
 
 use yksom::vm::{
     objects::{NormalArray, String_},
@@ -36,7 +37,7 @@ fn usage(prog: &str) -> ! {
 }
 
 fn main() {
-    let args: Vec<String> = env::args().collect();
+    let args = env::args().collect::<Vec<_>>();
     let prog = &args[0];
     let matches = Options::new()
         .optmulti("", "cp", "Path to System classes", "<path>")
@@ -65,14 +66,14 @@ fn main() {
         Some(x) => x,
         None => todo!(),
     };
-    let src_fname_val = String_::new_sym(&mut vm, src_fname.to_owned());
+    let src_fname_val = String_::new_sym(&mut vm, SmartString::from(src_fname));
     let mut args_vec = vec![src_fname_val];
     args_vec.extend(
         matches
             .free
             .iter()
             .skip(1)
-            .map(|x| String_::new_str(&mut vm, x.to_owned())),
+            .map(|x| String_::new_str(&mut vm, SmartString::from(x))),
     );
     let args = NormalArray::from_vec(&mut vm, args_vec);
     match vm.top_level_send(system, "initialize:", vec![args]) {


### PR DESCRIPTION
The [SmartString](https://crates.io/crates/smartstring) library avoids allocating memory for strings if they're small enough to fit inside the existing String struct. This is quite appealing for an interpreter where in general there are quite a lot of small strings that are
critical for performance (e.g. function names; though, admittedly, Smalltalk has many unusually long function names).

This commit is a fairly simple port (note that we generally import `SmartString` as `String` i.e. `String` no longer means `std::string::String` as per normal). Here's how long the test suite takes on my desktop before this commit:

```
  $ multitime -n 30 -s0 -q target/release/yksom --cp SOM/Smalltalk/ SOM/TestSuite/TestHarness.som
  ===> multitime results
  1: -q target/release/yksom --cp SOM/Smalltalk/ SOM/TestSuite/TestHarness.som
              Mean        Std.Dev.    Min         Median      Max
  real        0.214       0.002       0.210       0.214       0.220
  user        0.318       0.028       0.260       0.310       0.360
  sys         0.015       0.011       0.000       0.015       0.040
```

And here's after:

```
  $ multitime -n 30 -s0 -q target/release/yksom --cp SOM/Smalltalk/ SOM/TestSuite/TestHarness.som
  ===> multitime results
  1: -q target/release/yksom --cp SOM/Smalltalk/ SOM/TestSuite/TestHarness.som
              Mean        Std.Dev.    Min         Median      Max
  real        0.194       0.004       0.189       0.193       0.207
  user        0.259       0.035       0.200       0.260       0.310
  sys         0.015       0.013       0.000       0.010       0.050
```

The mean time has decreased by about 10% which is good, but the big question is whether this is just due to our currently-very-slow GC or not. In other words, would this performance change decrease (almost certainly) or disappear (who knows) if/when our GC performance improves. This is something of an unknowable at the moment and means that I'm unsure whether we should consider this for merging or not.