### PR TITLE
Clarify the layers of instance variables.

### DIFF
--- a/src/lib/compiler/ast_to_instrs.rs
+++ b/src/lib/compiler/ast_to_instrs.rs
@@ -64,23 +64,7 @@ impl<'a, 'input> Compiler<'a, 'input> {
             (vm.nil, vm.nil)
         };
 
-        // Create the "main" class.
         let mut errs = vec![];
-        let cls = match compiler.c_class(
-            vm,
-            lexer,
-            name.clone(),
-            supercls_val,
-            &astcls.inst_vars,
-            &astcls.methods,
-        ) {
-            Ok(c) => Some(c),
-            Err(e) => {
-                errs.extend(e);
-                None
-            }
-        };
-
         // Create the metaclass (i.e. for a class C, this creates a class called "C class").
         let metacls = match compiler.c_class(
             vm,
@@ -89,6 +73,22 @@ impl<'a, 'input> Compiler<'a, 'input> {
             supercls_meta_val,
             &astcls.class_inst_vars,
             &astcls.class_methods,
+        ) {
+            Ok(c) => Some(c),
+            Err(e) => {
+                errs.extend(e);
+                None
+            }
+        };
+
+        // Create the "main" class.
+        let cls = match compiler.c_class(
+            vm,
+            lexer,
+            name.clone(),
+            supercls_val,
+            &astcls.inst_vars,
+            &astcls.methods,
         ) {
             Ok(c) => Some(c),
             Err(e) => {
@@ -147,7 +147,7 @@ impl<'a, 'input> Compiler<'a, 'input> {
         let mut inst_vars = if supercls_val != vm.nil {
             let supercls = supercls_val.downcast::<Class>(vm).unwrap();
             let mut inst_vars =
-                HashMap::with_capacity(supercls.num_inst_vars + ast_inst_vars.len());
+                HashMap::with_capacity(supercls.inst_vars_map.len() + ast_inst_vars.len());
             inst_vars.extend(
                 supercls
                     .inst_vars_map

--- a/src/lib/vm/core.rs
+++ b/src/lib/vm/core.rs
@@ -275,7 +275,7 @@ impl VM {
     fn compile(&mut self, path: &Path, inst_vars_allowed: bool) -> Val {
         let (name, cls_val) = compile(self, path);
         let cls: Gc<Class> = cls_val.downcast(self).unwrap();
-        if !inst_vars_allowed && cls.num_inst_vars > 0 {
+        if !inst_vars_allowed && cls.inst_vars_map.len() > 0 {
             panic!("No instance vars allowed in {}", path.to_str().unwrap());
         }
         self.set_global(&name, cls_val);


### PR DESCRIPTION
Because of SOM's meta-class hierarchy, it's quite easy to get a bit lost as to where you are in it. I compounded that by not understanding it at first and hacking it in a bit later. That meant that we had a variable "num_inst_vars" in classes which described how many instance variables *instances* of the class would possess, but not how many the class itself has. Since I just managed to thoroughly confuse myself over this, this commit moves a few things around so that we no longer have that attribute, which hopefully makes things a little clearer for the next person who stumbles into this part of the code.