### PR TITLE
Use arbitrary self types so that we can use `self: Gc<Self>`.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -9,20 +9,13 @@ export CARGO_HOME="`pwd`/.cargo"
 export RUSTUP_HOME="`pwd`/.rustup"
 
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rustup.sh
-sh rustup.sh --default-host x86_64-unknown-linux-gnu --default-toolchain nightly -y --no-modify-path
+# Install no toolchain initially to ensure toolchain rollback.
+sh rustup.sh --default-host x86_64-unknown-linux-gnu --default-toolchain none -y --no-modify-path
 
 export PATH=`pwd`/.cargo/bin/:$PATH
+rustup install nightly
 
-# Sometimes rustfmt is so broken that there is no way to install it at all.
-# Rather than refusing to merge, we just can't rust rustfmt at such a point.
-rustup component add --toolchain nightly rustfmt-preview \
-    || cargo +nightly install --force rustfmt-nightly \
-    || true
-rustfmt=0
-cargo fmt 2>&1 | grep "not installed for the toolchain" > /dev/null || rustfmt=1
-if [ $rustfmt -eq 1 ]; then
-    cargo +nightly fmt --all -- --check
-fi
+cargo +nightly fmt --all -- --check
 
 cargo test
 cargo test --release

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -12,8 +12,10 @@
 
 #![feature(alloc_layout_extra)]
 #![feature(allocator_api)]
+#![feature(arbitrary_self_types)]
 #![feature(box_patterns)]
 #![feature(coerce_unsized)]
+#![feature(dispatch_from_dyn)]
 #![feature(unsize)]
 #![allow(clippy::cognitive_complexity)]
 #![allow(clippy::float_cmp)]

--- a/src/lib/vm/objects/array.rs
+++ b/src/lib/vm/objects/array.rs
@@ -2,6 +2,8 @@
 
 use std::{cell::UnsafeCell, collections::hash_map::DefaultHasher, hash::Hasher};
 
+use rboehm::Gc;
+
 use crate::vm::{
     core::VM,
     error::{VMError, VMErrorKind},
@@ -12,18 +14,18 @@ use crate::vm::{
 pub trait Array {
     /// Return the item at index `idx` (using SOM indexing starting at 1) or an error if the index
     /// is invalid.
-    fn at(&self, vm: &VM, idx: usize) -> Result<Val, Box<VMError>>;
+    fn at(self: Gc<Self>, vm: &VM, idx: usize) -> Result<Val, Box<VMError>>;
 
     /// Return the item at index `idx` (using SOM indexing starting at 1). This will lead to
     /// undefined behaviour if the index is invalid.
-    unsafe fn unchecked_at(&self, idx: usize) -> Val;
+    unsafe fn unchecked_at(self: Gc<Self>, idx: usize) -> Val;
 
     /// Set the item at index `idx` (using SOM indexing starting at 1) to `val` or return an error
     /// if the index is invalid.
-    fn at_put(&self, vm: &mut VM, idx: usize, val: Val) -> Result<(), Box<VMError>>;
+    fn at_put(self: Gc<Self>, vm: &mut VM, idx: usize, val: Val) -> Result<(), Box<VMError>>;
 
     /// Iterate over this array's values.
-    fn iter(&self) -> ArrayIterator<'_>;
+    fn iter(self: Gc<Self>) -> ArrayIterator;
 }
 
 #[derive(Debug)]
@@ -32,25 +34,25 @@ pub struct NormalArray {
 }
 
 impl Obj for NormalArray {
-    fn dyn_objtype(&self) -> ObjType {
+    fn dyn_objtype(self: Gc<Self>) -> ObjType {
         ObjType::Array
     }
 
-    fn get_class(&self, vm: &mut VM) -> Val {
+    fn get_class(self: Gc<Self>, vm: &mut VM) -> Val {
         vm.array_cls
     }
 
-    fn to_array(&self) -> Result<&dyn Array, Box<VMError>> {
+    fn to_array(self: Gc<Self>) -> Result<Gc<dyn Array>, Box<VMError>> {
         Ok(self)
     }
 
-    fn hashcode(&self) -> u64 {
+    fn hashcode(self: Gc<Self>) -> u64 {
         let mut hasher = DefaultHasher::new();
-        hasher.write_usize(self as *const _ as usize);
+        hasher.write_usize(Gc::into_raw(self) as *const _ as usize);
         hasher.finish()
     }
 
-    fn length(&self) -> usize {
+    fn length(self: Gc<Self>) -> usize {
         let store = unsafe { &*self.store.get() };
         store.len()
     }
@@ -65,7 +67,7 @@ impl StaticObjType for NormalArray {
 }
 
 impl Array for NormalArray {
-    fn at(&self, vm: &VM, mut idx: usize) -> Result<Val, Box<VMError>> {
+    fn at(self: Gc<Self>, vm: &VM, mut idx: usize) -> Result<Val, Box<VMError>> {
         let store = unsafe { &*self.store.get() };
         if idx > 0 && idx <= store.len() {
             idx -= 1;
@@ -81,7 +83,7 @@ impl Array for NormalArray {
         }
     }
 
-    unsafe fn unchecked_at(&self, mut idx: usize) -> Val {
+    unsafe fn unchecked_at(self: Gc<Self>, mut idx: usize) -> Val {
         debug_assert!(idx > 0);
         let store = &*self.store.get();
         debug_assert!(idx <= store.len());
@@ -89,7 +91,7 @@ impl Array for NormalArray {
         *store.get_unchecked(idx)
     }
 
-    fn at_put(&self, vm: &mut VM, mut idx: usize, val: Val) -> Result<(), Box<VMError>> {
+    fn at_put(self: Gc<Self>, vm: &mut VM, mut idx: usize, val: Val) -> Result<(), Box<VMError>> {
         let store = unsafe { &mut *self.store.get() };
         if idx > 0 && idx <= store.len() {
             idx -= 1;
@@ -106,7 +108,7 @@ impl Array for NormalArray {
         }
     }
 
-    fn iter(&self) -> ArrayIterator<'_> {
+    fn iter(self: Gc<Self>) -> ArrayIterator {
         ArrayIterator {
             arr: self,
             len: self.length(),
@@ -143,25 +145,25 @@ pub struct MethodsArray {
 }
 
 impl Obj for MethodsArray {
-    fn dyn_objtype(&self) -> ObjType {
+    fn dyn_objtype(self: Gc<Self>) -> ObjType {
         ObjType::Array
     }
 
-    fn get_class(&self, vm: &mut VM) -> Val {
+    fn get_class(self: Gc<Self>, vm: &mut VM) -> Val {
         vm.array_cls
     }
 
-    fn to_array(&self) -> Result<&dyn Array, Box<VMError>> {
+    fn to_array(self: Gc<Self>) -> Result<Gc<dyn Array>, Box<VMError>> {
         Ok(self)
     }
 
-    fn hashcode(&self) -> u64 {
+    fn hashcode(self: Gc<Self>) -> u64 {
         let mut hasher = DefaultHasher::new();
-        hasher.write_usize(self as *const _ as usize);
+        hasher.write_usize(Gc::into_raw(self) as *const _ as usize);
         hasher.finish()
     }
 
-    fn length(&self) -> usize {
+    fn length(self: Gc<Self>) -> usize {
         let store = unsafe { &*self.store.get() };
         store.len()
     }
@@ -176,7 +178,7 @@ impl StaticObjType for MethodsArray {
 }
 
 impl Array for MethodsArray {
-    fn at(&self, vm: &VM, mut idx: usize) -> Result<Val, Box<VMError>> {
+    fn at(self: Gc<Self>, vm: &VM, mut idx: usize) -> Result<Val, Box<VMError>> {
         let store = unsafe { &*self.store.get() };
         if idx > 0 && idx <= store.len() {
             idx -= 1;
@@ -192,7 +194,7 @@ impl Array for MethodsArray {
         }
     }
 
-    unsafe fn unchecked_at(&self, mut idx: usize) -> Val {
+    unsafe fn unchecked_at(self: Gc<Self>, mut idx: usize) -> Val {
         debug_assert!(idx > 0);
         let store = &*self.store.get();
         debug_assert!(idx <= store.len());
@@ -200,7 +202,7 @@ impl Array for MethodsArray {
         *store.get_unchecked(idx)
     }
 
-    fn at_put(&self, vm: &mut VM, mut idx: usize, val: Val) -> Result<(), Box<VMError>> {
+    fn at_put(self: Gc<Self>, vm: &mut VM, mut idx: usize, val: Val) -> Result<(), Box<VMError>> {
         let store = unsafe { &mut *self.store.get() };
         if idx > 0 && idx <= store.len() {
             idx -= 1;
@@ -218,7 +220,7 @@ impl Array for MethodsArray {
         }
     }
 
-    fn iter(&self) -> ArrayIterator<'_> {
+    fn iter(self: Gc<Self>) -> ArrayIterator {
         ArrayIterator {
             arr: self,
             len: self.length(),
@@ -238,13 +240,13 @@ impl MethodsArray {
     }
 }
 
-pub struct ArrayIterator<'a> {
-    arr: &'a dyn Array,
+pub struct ArrayIterator {
+    arr: Gc<dyn Array>,
     len: usize,
     i: usize,
 }
 
-impl<'a> Iterator for ArrayIterator<'a> {
+impl Iterator for ArrayIterator {
     type Item = Val;
 
     fn next(&mut self) -> Option<Val> {

--- a/src/lib/vm/objects/block.rs
+++ b/src/lib/vm/objects/block.rs
@@ -33,17 +33,17 @@ pub struct Block {
 }
 
 impl Obj for Block {
-    fn dyn_objtype(&self) -> ObjType {
+    fn dyn_objtype(self: Gc<Self>) -> ObjType {
         ObjType::Block
     }
 
-    fn get_class(&self, _: &mut VM) -> Val {
+    fn get_class(self: Gc<Self>, _: &mut VM) -> Val {
         self.blockn_cls
     }
 
-    fn hashcode(&self) -> u64 {
+    fn hashcode(self: Gc<Self>) -> u64 {
         let mut hasher = DefaultHasher::new();
-        hasher.write_usize(self as *const _ as usize);
+        hasher.write_usize(Gc::into_raw(self) as *const _ as usize);
         hasher.finish()
     }
 }

--- a/src/lib/vm/objects/class.rs
+++ b/src/lib/vm/objects/class.rs
@@ -38,35 +38,35 @@ pub struct Class {
 }
 
 impl Obj for Class {
-    fn dyn_objtype(&self) -> ObjType {
+    fn dyn_objtype(self: Gc<Self>) -> ObjType {
         ObjType::Class
     }
 
-    fn get_class(&self, _: &mut VM) -> Val {
+    fn get_class(self: Gc<Self>, _: &mut VM) -> Val {
         debug_assert!(self.metacls.get().valkind() != ValKind::ILLEGAL);
         self.metacls.get()
     }
 
-    fn num_inst_vars(&self) -> usize {
+    fn num_inst_vars(self: Gc<Self>) -> usize {
         let inst_vars = unsafe { &*self.inst_vars.get() };
         inst_vars.len()
     }
 
-    unsafe fn unchecked_inst_var_get(&self, n: usize) -> Val {
+    unsafe fn unchecked_inst_var_get(self: Gc<Self>, n: usize) -> Val {
         debug_assert!(n < self.num_inst_vars());
         let inst_vars = &mut *self.inst_vars.get();
         inst_vars[n]
     }
 
-    unsafe fn unchecked_inst_var_set(&self, n: usize, v: Val) {
+    unsafe fn unchecked_inst_var_set(self: Gc<Self>, n: usize, v: Val) {
         debug_assert!(n < self.num_inst_vars());
         let inst_vars = &mut *self.inst_vars.get();
         inst_vars[n] = v;
     }
 
-    fn hashcode(&self) -> u64 {
+    fn hashcode(self: Gc<Self>) -> u64 {
         let mut hasher = DefaultHasher::new();
-        hasher.write_usize(self as *const _ as usize);
+        hasher.write_usize(Gc::into_raw(self) as *const _ as usize);
         hasher.finish()
     }
 }

--- a/src/lib/vm/objects/double.rs
+++ b/src/lib/vm/objects/double.rs
@@ -4,6 +4,7 @@ use std::{collections::hash_map::DefaultHasher, hash::Hasher};
 
 use num_bigint::BigInt;
 use num_traits::{FromPrimitive, ToPrimitive, Zero};
+use rboehm::Gc;
 use smartstring::alias::String as SmartString;
 
 use crate::vm::{
@@ -22,15 +23,15 @@ pub struct Double {
 impl NotUnboxable for Double {}
 
 impl Obj for Double {
-    fn dyn_objtype(&self) -> ObjType {
+    fn dyn_objtype(self: Gc<Self>) -> ObjType {
         ObjType::Double
     }
 
-    fn get_class(&self, vm: &mut VM) -> Val {
+    fn get_class(self: Gc<Self>, vm: &mut VM) -> Val {
         vm.double_cls
     }
 
-    fn to_strval(&self, vm: &mut VM) -> Result<Val, Box<VMError>> {
+    fn to_strval(self: Gc<Self>, vm: &mut VM) -> Result<Val, Box<VMError>> {
         let mut buf = ryu::Buffer::new();
         Ok(String_::new_str(
             vm,
@@ -38,13 +39,13 @@ impl Obj for Double {
         ))
     }
 
-    fn hashcode(&self) -> u64 {
+    fn hashcode(self: Gc<Self>) -> u64 {
         let mut hasher = DefaultHasher::new();
         hasher.write_u64(self.val.to_bits());
         hasher.finish()
     }
 
-    fn add(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn add(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         if let Some(rhs) = other.as_isize(vm) {
             Ok(Double::new(vm, self.val + (rhs as f64)))
         } else if let Some(rhs) = other.try_downcast::<Double>(vm) {
@@ -60,7 +61,7 @@ impl Obj for Double {
         }
     }
 
-    fn double_div(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn double_div(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         if let Some(rhs) = other.as_isize(vm) {
             if rhs == 0 {
                 Err(VMError::new(vm, VMErrorKind::DivisionByZero))
@@ -88,7 +89,7 @@ impl Obj for Double {
         }
     }
 
-    fn modulus(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn modulus(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         if let Some(rhs) = other.as_isize(vm) {
             Ok(Double::new(vm, self.val % (rhs as f64)))
         } else if let Some(rhs) = other.try_downcast::<Double>(vm) {
@@ -104,7 +105,7 @@ impl Obj for Double {
         }
     }
 
-    fn mul(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn mul(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         if let Some(rhs) = other.as_isize(vm) {
             Ok(Double::new(vm, self.val * (rhs as f64)))
         } else if let Some(rhs) = other.try_downcast::<Double>(vm) {
@@ -120,11 +121,11 @@ impl Obj for Double {
         }
     }
 
-    fn sqrt(&self, vm: &mut VM) -> Result<Val, Box<VMError>> {
+    fn sqrt(self: Gc<Self>, vm: &mut VM) -> Result<Val, Box<VMError>> {
         Ok(Double::new(vm, self.val.sqrt()))
     }
 
-    fn sub(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn sub(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         if let Some(rhs) = other.as_isize(vm) {
             Ok(Double::new(vm, self.val - (rhs as f64)))
         } else if let Some(rhs) = other.try_downcast::<Double>(vm) {
@@ -140,11 +141,11 @@ impl Obj for Double {
         }
     }
 
-    fn ref_equals(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn ref_equals(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         self.equals(vm, other)
     }
 
-    fn equals(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn equals(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         let b = if let Some(rhs) = other.as_isize(vm) {
             self.val == (rhs as f64)
         } else if let Some(rhs) = other.try_downcast::<Double>(vm) {
@@ -161,7 +162,7 @@ impl Obj for Double {
         Ok(Val::from_bool(vm, b))
     }
 
-    fn less_than(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn less_than(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         let b = if let Some(rhs) = other.as_isize(vm) {
             self.val < (rhs as f64)
         } else if let Some(rhs) = other.try_downcast::<Double>(vm) {

--- a/src/lib/vm/objects/instance.rs
+++ b/src/lib/vm/objects/instance.rs
@@ -18,34 +18,34 @@ pub struct Inst {
 }
 
 impl Obj for Inst {
-    fn dyn_objtype(&self) -> ObjType {
+    fn dyn_objtype(self: Gc<Self>) -> ObjType {
         ObjType::Inst
     }
 
-    fn get_class(&self, _: &mut VM) -> Val {
+    fn get_class(self: Gc<Self>, _: &mut VM) -> Val {
         self.class
     }
 
-    fn num_inst_vars(&self) -> usize {
+    fn num_inst_vars(self: Gc<Self>) -> usize {
         unsafe { &*self.inst_vars.get() }.len()
     }
 
-    unsafe fn unchecked_inst_var_get(&self, n: usize) -> Val {
+    unsafe fn unchecked_inst_var_get(self: Gc<Self>, n: usize) -> Val {
         let inst_vars = &mut *self.inst_vars.get();
         debug_assert!(n < inst_vars.len());
         debug_assert!(inst_vars[n].valkind() != ValKind::ILLEGAL);
         inst_vars[n]
     }
 
-    unsafe fn unchecked_inst_var_set(&self, n: usize, v: Val) {
+    unsafe fn unchecked_inst_var_set(self: Gc<Self>, n: usize, v: Val) {
         let inst_vars = &mut *self.inst_vars.get();
         debug_assert!(n < inst_vars.len());
         inst_vars[n] = v;
     }
 
-    fn hashcode(&self) -> u64 {
+    fn hashcode(self: Gc<Self>) -> u64 {
         let mut hasher = DefaultHasher::new();
-        hasher.write_usize(self as *const _ as usize);
+        hasher.write_usize(Gc::into_raw(self) as *const _ as usize);
         hasher.finish()
     }
 }

--- a/src/lib/vm/objects/integers.rs
+++ b/src/lib/vm/objects/integers.rs
@@ -15,6 +15,7 @@ use std::convert::TryFrom;
 
 use num_bigint::BigInt;
 use num_traits::{FromPrimitive, Signed, ToPrimitive, Zero};
+use rboehm::Gc;
 
 use crate::vm::{
     core::VM,
@@ -32,19 +33,19 @@ pub struct ArbInt {
 impl NotUnboxable for ArbInt {}
 
 impl Obj for ArbInt {
-    fn dyn_objtype(&self) -> ObjType {
+    fn dyn_objtype(self: Gc<Self>) -> ObjType {
         ObjType::ArbInt
     }
 
-    fn get_class(&self, vm: &mut VM) -> Val {
+    fn get_class(self: Gc<Self>, vm: &mut VM) -> Val {
         vm.int_cls
     }
 
-    fn to_strval(&self, vm: &mut VM) -> Result<Val, Box<VMError>> {
+    fn to_strval(self: Gc<Self>, vm: &mut VM) -> Result<Val, Box<VMError>> {
         Ok(String_::new_str(vm, self.val.to_string().into()))
     }
 
-    fn add(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn add(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         if let Some(rhs) = other.as_isize(vm) {
             Ok(ArbInt::new(vm, &self.val + rhs))
         } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
@@ -60,7 +61,7 @@ impl Obj for ArbInt {
         }
     }
 
-    fn and(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn and(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         if let Some(rhs) = other.as_isize(vm) {
             Ok(ArbInt::new(
                 vm,
@@ -78,7 +79,7 @@ impl Obj for ArbInt {
         }
     }
 
-    fn div(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn div(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         if let Some(rhs) = other.as_isize(vm) {
             if rhs == 0 {
                 Err(VMError::new(vm, VMErrorKind::DivisionByZero))
@@ -105,7 +106,7 @@ impl Obj for ArbInt {
         }
     }
 
-    fn double_div(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn double_div(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         if let Some(rhs) = other.as_isize(vm) {
             if rhs == 0 {
                 Err(VMError::new(vm, VMErrorKind::DivisionByZero))
@@ -140,7 +141,7 @@ impl Obj for ArbInt {
         }
     }
 
-    fn modulus(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn modulus(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         if let Some(rhs) = other.as_isize(vm) {
             Ok(ArbInt::new(vm, ((&self.val % rhs) + rhs) % rhs))
         } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
@@ -162,7 +163,7 @@ impl Obj for ArbInt {
         }
     }
 
-    fn mul(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn mul(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         if let Some(rhs) = other.as_isize(vm) {
             Ok(ArbInt::new(vm, &self.val * rhs))
         } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
@@ -178,11 +179,11 @@ impl Obj for ArbInt {
         }
     }
 
-    fn remainder(&self, _vm: &mut VM, _other: Val) -> Result<Val, Box<VMError>> {
+    fn remainder(self: Gc<Self>, _vm: &mut VM, _other: Val) -> Result<Val, Box<VMError>> {
         todo!();
     }
 
-    fn shl(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn shl(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         if let Some(rhs) = other.as_isize(vm) {
             if rhs < 0 {
                 Err(VMError::new(vm, VMErrorKind::NegativeShift))
@@ -199,7 +200,7 @@ impl Obj for ArbInt {
         }
     }
 
-    fn shr(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn shr(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         if let Some(rhs) = other.as_isize(vm) {
             if rhs < 0 {
                 Err(VMError::new(vm, VMErrorKind::NegativeShift))
@@ -220,7 +221,7 @@ impl Obj for ArbInt {
         }
     }
 
-    fn sqrt(&self, vm: &mut VM) -> Result<Val, Box<VMError>> {
+    fn sqrt(self: Gc<Self>, vm: &mut VM) -> Result<Val, Box<VMError>> {
         if self.val < Zero::zero() {
             Err(VMError::new(vm, VMErrorKind::DomainError))
         } else {
@@ -233,7 +234,7 @@ impl Obj for ArbInt {
         }
     }
 
-    fn sub(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn sub(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         if let Some(rhs) = other.as_isize(vm) {
             Ok(ArbInt::new(vm, &self.val - rhs))
         } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
@@ -249,7 +250,7 @@ impl Obj for ArbInt {
         }
     }
 
-    fn xor(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn xor(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         if let Some(rhs) = other.as_isize(vm) {
             Ok(ArbInt::new(
                 vm,
@@ -267,7 +268,7 @@ impl Obj for ArbInt {
         }
     }
 
-    fn ref_equals(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn ref_equals(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         let b = if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
             self.val == rhs.val
         } else {
@@ -276,7 +277,7 @@ impl Obj for ArbInt {
         Ok(Val::from_bool(vm, b))
     }
 
-    fn equals(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn equals(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         let b = if other.dyn_objtype(vm) == ObjType::Int {
             debug_assert!(self.val != BigInt::from_isize(other.as_isize(vm).unwrap()).unwrap());
             false
@@ -288,7 +289,7 @@ impl Obj for ArbInt {
         Ok(Val::from_bool(vm, b))
     }
 
-    fn not_equals(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn not_equals(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         let b = if other.dyn_objtype(vm) == ObjType::Int {
             debug_assert!(self.val != BigInt::from_isize(other.as_isize(vm).unwrap()).unwrap());
             true
@@ -300,7 +301,7 @@ impl Obj for ArbInt {
         Ok(Val::from_bool(vm, b))
     }
 
-    fn greater_than(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn greater_than(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         let b = if other.dyn_objtype(vm) == ObjType::Int {
             debug_assert!(
                 !self.val.is_positive()
@@ -316,7 +317,7 @@ impl Obj for ArbInt {
         Ok(Val::from_bool(vm, b))
     }
 
-    fn greater_than_equals(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn greater_than_equals(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         let b = if other.dyn_objtype(vm) == ObjType::Int {
             debug_assert!(
                 !self.val.is_positive()
@@ -332,7 +333,7 @@ impl Obj for ArbInt {
         Ok(Val::from_bool(vm, b))
     }
 
-    fn less_than(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn less_than(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         let b = if other.dyn_objtype(vm) == ObjType::Int {
             debug_assert!(
                 !self.val.is_negative()
@@ -348,7 +349,7 @@ impl Obj for ArbInt {
         Ok(Val::from_bool(vm, b))
     }
 
-    fn less_than_equals(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn less_than_equals(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         let b = if other.dyn_objtype(vm) == ObjType::Int {
             debug_assert!(
                 !self.val.is_negative()
@@ -396,19 +397,19 @@ pub struct Int {
 }
 
 impl Obj for Int {
-    fn dyn_objtype(&self) -> ObjType {
+    fn dyn_objtype(self: Gc<Self>) -> ObjType {
         ObjType::Int
     }
 
-    fn get_class(&self, vm: &mut VM) -> Val {
+    fn get_class(self: Gc<Self>, vm: &mut VM) -> Val {
         vm.int_cls
     }
 
-    fn to_strval(&self, vm: &mut VM) -> Result<Val, Box<VMError>> {
+    fn to_strval(self: Gc<Self>, vm: &mut VM) -> Result<Val, Box<VMError>> {
         Ok(String_::new_str(vm, self.val.to_string().into()))
     }
 
-    fn add(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn add(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         if let Some(rhs) = other.as_isize(vm) {
             match self.val.checked_add(rhs) {
                 Some(i) => Ok(Val::from_isize(vm, i)),
@@ -427,7 +428,7 @@ impl Obj for Int {
         }
     }
 
-    fn div(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn div(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         if let Some(rhs) = other.as_isize(vm) {
             if rhs == 0 {
                 Err(VMError::new(vm, VMErrorKind::DivisionByZero))
@@ -457,7 +458,7 @@ impl Obj for Int {
         }
     }
 
-    fn mul(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn mul(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         if let Some(rhs) = other.as_isize(vm) {
             match self.val.checked_mul(rhs) {
                 Some(i) => Ok(Val::from_isize(vm, i)),
@@ -476,7 +477,7 @@ impl Obj for Int {
         }
     }
 
-    fn sub(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn sub(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         if let Some(rhs) = other.as_isize(vm) {
             match self.val.checked_sub(rhs) {
                 Some(i) => Ok(Val::from_isize(vm, i)),
@@ -593,12 +594,22 @@ mod tests {
         assert!(bi.downcast::<ArbInt>(&mut vm).is_ok());
         let v = Val::from_isize(&mut vm, 1 << (TAG_BITSIZE + 2));
         assert_eq!(
-            bi.tobj(&mut vm).unwrap().sub(&mut vm, v).unwrap().valkind(),
+            bi.tobj(&mut vm)
+                .unwrap()
+                .as_gc()
+                .sub(&mut vm, v)
+                .unwrap()
+                .valkind(),
             ValKind::GCBOX
         );
         let v = Val::from_isize(&mut vm, isize::max_value());
         assert_eq!(
-            bi.tobj(&mut vm).unwrap().sub(&mut vm, v).unwrap().valkind(),
+            bi.tobj(&mut vm)
+                .unwrap()
+                .as_gc()
+                .sub(&mut vm, v)
+                .unwrap()
+                .valkind(),
             ValKind::INT
         );
         // Different LHS and RHS types

--- a/src/lib/vm/objects/method.rs
+++ b/src/lib/vm/objects/method.rs
@@ -2,6 +2,8 @@
 
 use std::{cell::Cell, collections::hash_map::DefaultHasher, hash::Hasher};
 
+use rboehm::Gc;
+
 use crate::{
     compiler::instrs::Primitive,
     vm::{
@@ -34,17 +36,17 @@ pub enum MethodBody {
 }
 
 impl Obj for Method {
-    fn dyn_objtype(&self) -> ObjType {
+    fn dyn_objtype(self: Gc<Self>) -> ObjType {
         ObjType::Method
     }
 
-    fn get_class(&self, vm: &mut VM) -> Val {
+    fn get_class(self: Gc<Self>, vm: &mut VM) -> Val {
         vm.method_cls
     }
 
-    fn hashcode(&self) -> u64 {
+    fn hashcode(self: Gc<Self>) -> u64 {
         let mut hasher = DefaultHasher::new();
-        hasher.write_usize(self as *const _ as usize);
+        hasher.write_usize(Gc::into_raw(self) as *const _ as usize);
         hasher.finish()
     }
 }

--- a/src/lib/vm/objects/mod.rs
+++ b/src/lib/vm/objects/mod.rs
@@ -82,28 +82,28 @@ impl ObjType {
 #[narrowable_rboehm(ThinObj)]
 pub trait Obj: std::fmt::Debug {
     /// What `ObjType` does this `Val` represent?
-    fn dyn_objtype(&self) -> ObjType;
+    fn dyn_objtype(self: Gc<Self>) -> ObjType;
     /// What class is this object an instance of?
-    fn get_class(&self, vm: &mut VM) -> Val;
+    fn get_class(self: Gc<Self>, vm: &mut VM) -> Val;
 
     /// If (and only if) this object implements the [Array] trait then return a reference to this
     /// object as an [Array] trait object.
-    fn to_array(&self) -> Result<&dyn Array, Box<VMError>> {
+    fn to_array(self: Gc<Self>) -> Result<Gc<dyn Array>, Box<VMError>> {
         todo!();
     }
 
     /// Convert this object to a `Val` that represents a SOM string.
-    fn to_strval(&self, _: &mut VM) -> Result<Val, Box<VMError>> {
+    fn to_strval(self: Gc<Self>, _: &mut VM) -> Result<Val, Box<VMError>> {
         unreachable!();
     }
 
     /// How many instance variables does this object contain?
-    fn num_inst_vars(&self) -> usize {
+    fn num_inst_vars(self: Gc<Self>) -> usize {
         unreachable!();
     }
 
     /// Return the instance variable at `i` (using SOM indexing).
-    fn inst_var_at(&self, vm: &VM, i: usize) -> Result<Val, Box<VMError>> {
+    fn inst_var_at(self: Gc<Self>, vm: &VM, i: usize) -> Result<Val, Box<VMError>> {
         if i > 0 && i <= self.num_inst_vars() {
             Ok(unsafe { self.unchecked_inst_var_get(i - 1) })
         } else {
@@ -118,7 +118,7 @@ pub trait Obj: std::fmt::Debug {
     }
 
     /// Return the instance variable at `i` (using SOM indexing).
-    fn inst_var_at_put(&self, vm: &VM, i: usize, v: Val) -> Result<(), Box<VMError>> {
+    fn inst_var_at_put(self: Gc<Self>, vm: &VM, i: usize, v: Val) -> Result<(), Box<VMError>> {
         if i > 0 && i <= self.num_inst_vars() {
             unsafe { self.unchecked_inst_var_set(i - 1, v) };
             Ok(())
@@ -135,125 +135,125 @@ pub trait Obj: std::fmt::Debug {
 
     /// Lookup an instance variable in this object. If `usize` exceeds the number of instance
     /// variables this will lead to undefined behaviour.
-    unsafe fn unchecked_inst_var_get(&self, _: usize) -> Val {
+    unsafe fn unchecked_inst_var_get(self: Gc<Self>, _: usize) -> Val {
         unreachable!();
     }
 
     /// Set an instance variable in this object. If `usize` exceeds the number of instance
     /// variables this will lead to undefined behaviour.
-    unsafe fn unchecked_inst_var_set(&self, _: usize, _: Val) {
+    unsafe fn unchecked_inst_var_set(self: Gc<Self>, _: usize, _: Val) {
         unreachable!();
     }
 
     /// What is this object's length?
-    fn length(&self) -> usize {
+    fn length(self: Gc<Self>) -> usize {
         unreachable!();
     }
 
     /// What is this object's hashcode?
-    fn hashcode(&self) -> u64 {
+    fn hashcode(self: Gc<Self>) -> u64 {
         unreachable!();
     }
 
     /// Produce a new `Val` which adds `other` to this.
-    fn add(&self, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
+    fn add(self: Gc<Self>, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
         unreachable!();
     }
 
     /// Produce a new `Val` which performs a bitwise and with `other` and this.
-    fn and(&self, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
+    fn and(self: Gc<Self>, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
         unreachable!();
     }
 
     /// Produce a new `Val` which divides `other` from this.
-    fn div(&self, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
+    fn div(self: Gc<Self>, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
         unreachable!();
     }
 
-    fn double_div(&self, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
+    fn double_div(self: Gc<Self>, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
         unreachable!();
     }
 
     /// Produce a new `Val` which performs a mod operation on this with `other`.
-    fn modulus(&self, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
+    fn modulus(self: Gc<Self>, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
         unreachable!();
     }
 
     /// Produce a new `Val` which multiplies `other` to this.
-    fn mul(&self, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
+    fn mul(self: Gc<Self>, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
         unreachable!();
     }
 
     /// Produce a new `Val` which returns the remainder of dividing this with `other`.
-    fn remainder(&self, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
+    fn remainder(self: Gc<Self>, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
         unreachable!();
     }
 
     /// Produce a new `Val` which shifts `self` `other` bits to the left.
-    fn shl(&self, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
+    fn shl(self: Gc<Self>, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
         unreachable!();
     }
 
     /// Produce a new `Val` which shifts `self` `other` bits to the right, treating `self` as if it
     /// did not have a sign bit.
-    fn shr(&self, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
+    fn shr(self: Gc<Self>, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
         unreachable!();
     }
 
     /// Produces a new `Val` which is the square root of this.
-    fn sqrt(&self, _: &mut VM) -> Result<Val, Box<VMError>> {
+    fn sqrt(self: Gc<Self>, _: &mut VM) -> Result<Val, Box<VMError>> {
         unreachable!();
     }
 
     /// Produce a new `Val` which subtracts `other` from this.
-    fn sub(&self, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
+    fn sub(self: Gc<Self>, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
         unreachable!();
     }
 
     /// Produce a new `Val` which performs a bitwise xor with `other` and this
-    fn xor(&self, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
+    fn xor(self: Gc<Self>, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
         unreachable!();
     }
 
     /// Is this `Val` reference equality equal to `other`? Only immutable SOM types are likely to
     /// want to override this.
-    fn ref_equals(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn ref_equals(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         let other_tobj = other.tobj(vm)?;
         let other_data =
             unsafe { std::mem::transmute::<&dyn Obj, (*const u8, usize)>(&**other_tobj).0 };
         Ok(Val::from_bool(
             vm,
-            (self as *const _ as *const u8) == other_data,
+            (Gc::into_raw(self) as *const _ as *const u8) == other_data,
         ))
     }
 
     /// Does this `Val` equal `other`?
-    fn equals(&self, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
+    fn equals(self: Gc<Self>, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
         unreachable!();
     }
 
     /// Does this `Val` not equal `other`?
-    fn not_equals(&self, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
+    fn not_equals(self: Gc<Self>, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
         unreachable!();
     }
 
     /// Is this `Val` greater than `other`?
-    fn greater_than(&self, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
+    fn greater_than(self: Gc<Self>, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
         unreachable!();
     }
 
     /// Is this `Val` greater than or equal to `other`?
-    fn greater_than_equals(&self, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
+    fn greater_than_equals(self: Gc<Self>, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
         unreachable!();
     }
 
     /// Is this `Val` less than `other`?
-    fn less_than(&self, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
+    fn less_than(self: Gc<Self>, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
         unreachable!();
     }
 
     /// Is this `Val` less than or equal to `other`?
-    fn less_than_equals(&self, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
+    fn less_than_equals(self: Gc<Self>, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
         unreachable!();
     }
 }

--- a/src/lib/vm/objects/string_.rs
+++ b/src/lib/vm/objects/string_.rs
@@ -24,11 +24,11 @@ pub struct String_ {
 }
 
 impl Obj for String_ {
-    fn dyn_objtype(&self) -> ObjType {
+    fn dyn_objtype(self: Gc<Self>) -> ObjType {
         ObjType::String_
     }
 
-    fn get_class(&self, _: &mut VM) -> Val {
+    fn get_class(self: Gc<Self>, _: &mut VM) -> Val {
         debug_assert!(
             self.cls.get().valkind() != crate::vm::val::ValKind::ILLEGAL,
             "{}",
@@ -37,7 +37,7 @@ impl Obj for String_ {
         self.cls.get()
     }
 
-    fn to_strval(&self, vm: &mut VM) -> Result<Val, Box<VMError>> {
+    fn to_strval(self: Gc<Self>, vm: &mut VM) -> Result<Val, Box<VMError>> {
         Ok(Val::from_obj(
             vm,
             String_ {
@@ -47,21 +47,21 @@ impl Obj for String_ {
         ))
     }
 
-    fn hashcode(&self) -> u64 {
+    fn hashcode(self: Gc<Self>) -> u64 {
         let mut s = DefaultHasher::new();
         self.s.hash(&mut s);
         s.finish()
     }
 
-    fn length(&self) -> usize {
+    fn length(self: Gc<Self>) -> usize {
         self.s.chars().count()
     }
 
-    fn ref_equals(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn ref_equals(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         self.equals(vm, other)
     }
 
-    fn equals(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn equals(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         let b = match other.downcast::<String_>(vm) {
             Ok(other_str) => (self.cls == other_str.cls) && (self.s == other_str.s),
             Err(_) => false,
@@ -122,7 +122,7 @@ impl String_ {
     }
 
     /// Concatenate this string with another string and return the result.
-    pub fn concatenate(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
+    pub fn concatenate(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         let other_str: Gc<String_> = other.downcast(vm)?;
 
         // Since strings are immutable, concatenating an empty string means we don't need to


### PR DESCRIPTION
VM objects are all allocated on the heap. The Val::recover function turns an object back into a `Val`, but is deeply unsafe: if you didn't allocate the object via `Val::from_obj` all sorts of bad, weird things will happen. Previously we entirely relied on the programmer doing The Right Thing in order that the bad case didn't occur.

This commit makes it *much* clearer that objects are `Gc`d things by making their `self` types `self: Gc<Self>`. For example this means that String::concatenate function previously looked like this:

```rust
pub fn concatenate(&self, ...) -> Result<Val, Box<VMError>> {
    ...
    Val::recover(self)
    ...
}
```

But you could call that with a non-GCd `&self` and then things would explode. This function now looks like:

```rust
pub fn concatenate(self: Gc<Self>, ...) -> Result<Val, Box<VMError>> {
    ...
    Val::recover(self)
    ...
}
```

and `Val::recover` now looks like:

```rust
pub fn recover<T: Obj + 'static>(obj: Gc<T>) -> Self {
```

so we can statically guarantee that you can't `recover` something that wasn't Gc'd.rs

There is more to do to squeeze more static guarantees out of the codebase, but this is the minimal change which starts that process off.