### PR TITLE
Create variable sized objects

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -4,3 +4,5 @@ timeout_sec = 600 # 10 minutes
 
 # Have bors delete auto-merged branches
 delete_merged_branches = true
+
+cut_body_after = ""

--- a/src/lib/compiler/ast_to_instrs.rs
+++ b/src/lib/compiler/ast_to_instrs.rs
@@ -249,8 +249,7 @@ impl<'a, 'input> Compiler<'a, 'input> {
                 let name = pairs
                     .iter()
                     .map(|x| self.lexer.span_str(x.0))
-                    .collect::<SmartString>()
-                    .into();
+                    .collect::<SmartString>();
                 let args = pairs.iter().map(|x| x.1).collect::<Vec<_>>();
                 ((pairs[0].0, name), args)
             }

--- a/src/lib/compiler/ast_to_instrs.rs
+++ b/src/lib/compiler/ast_to_instrs.rs
@@ -213,7 +213,7 @@ impl<'a, 'input> Compiler<'a, 'input> {
 
         let name_val = String_::new_str(vm, name);
         let methods = MethodsArray::from_vec(vm, methods);
-        let cls = Class::new(
+        let cls_val = Class::new(
             vm,
             vm.cls_cls,
             name_val,
@@ -224,7 +224,6 @@ impl<'a, 'input> Compiler<'a, 'input> {
             methods,
             methods_map,
         );
-        let cls_val = Val::from_obj(vm, cls);
         let cls: Gc<Class> = cls_val.downcast(vm).unwrap();
         cls.set_methods_class(vm, cls_val);
         Ok(cls_val)
@@ -260,7 +259,7 @@ impl<'a, 'input> Compiler<'a, 'input> {
         let body = self.c_body(vm, astmeth.span, (name.0, &name.1), args, &astmeth.body)?;
         let sig = String_::new_sym(vm, name.1.clone());
         let meth = Method::new(vm, sig, args_len, body);
-        Ok((name.1, Val::from_obj(vm, meth)))
+        Ok((name.1, meth))
     }
 
     fn c_body(

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -16,6 +16,7 @@
 #![feature(box_patterns)]
 #![feature(coerce_unsized)]
 #![feature(dispatch_from_dyn)]
+#![feature(raw_ref_op)]
 #![feature(unsize)]
 #![allow(clippy::cognitive_complexity)]
 #![allow(clippy::float_cmp)]

--- a/src/lib/vm/core.rs
+++ b/src/lib/vm/core.rs
@@ -275,7 +275,7 @@ impl VM {
     fn compile(&mut self, path: &Path, inst_vars_allowed: bool) -> Val {
         let (name, cls_val) = compile(self, path);
         let cls: Gc<Class> = cls_val.downcast(self).unwrap();
-        if !inst_vars_allowed && cls.inst_vars_map.len() > 0 {
+        if !inst_vars_allowed && !cls.inst_vars_map.is_empty() {
             panic!("No instance vars allowed in {}", path.to_str().unwrap());
         }
         self.set_global(&name, cls_val);

--- a/src/lib/vm/core.rs
+++ b/src/lib/vm/core.rs
@@ -495,12 +495,15 @@ impl VM {
                 Instr::InstVarLookup(n) => {
                     let inst = stry!(rcv.tobj(self));
                     self.stack
-                        .push(unsafe { inst.as_gc().unchecked_inst_var_get(n) });
+                        .push(unsafe { inst.as_gc().unchecked_inst_var_get(self, n) });
                     pc += 1;
                 }
                 Instr::InstVarSet(n) => {
                     let inst = stry!(rcv.tobj(self));
-                    unsafe { inst.as_gc().unchecked_inst_var_set(n, self.stack.peek()) };
+                    unsafe {
+                        inst.as_gc()
+                            .unchecked_inst_var_set(self, n, self.stack.peek())
+                    };
                     pc += 1;
                 }
                 Instr::Int(i) => {

--- a/src/lib/vm/objects/array.rs
+++ b/src/lib/vm/objects/array.rs
@@ -121,21 +121,15 @@ impl NormalArray {
     pub fn new(vm: &mut VM, len: usize) -> Val {
         let mut store = Vec::with_capacity(len);
         store.resize(len, vm.nil);
-        Val::from_obj(
-            vm,
-            NormalArray {
-                store: UnsafeCell::new(store),
-            },
-        )
+        Val::from_obj(NormalArray {
+            store: UnsafeCell::new(store),
+        })
     }
 
-    pub fn from_vec(vm: &mut VM, store: Vec<Val>) -> Val {
-        Val::from_obj(
-            vm,
-            NormalArray {
-                store: UnsafeCell::new(store),
-            },
-        )
+    pub fn from_vec(_: &mut VM, store: Vec<Val>) -> Val {
+        Val::from_obj(NormalArray {
+            store: UnsafeCell::new(store),
+        })
     }
 }
 
@@ -230,13 +224,10 @@ impl Array for MethodsArray {
 }
 
 impl MethodsArray {
-    pub fn from_vec(vm: &mut VM, store: Vec<Val>) -> Val {
-        Val::from_obj(
-            vm,
-            MethodsArray {
-                store: UnsafeCell::new(store),
-            },
-        )
+    pub fn from_vec(_vm: &mut VM, store: Vec<Val>) -> Val {
+        Val::from_obj(MethodsArray {
+            store: UnsafeCell::new(store),
+        })
     }
 }
 

--- a/src/lib/vm/objects/block.rs
+++ b/src/lib/vm/objects/block.rs
@@ -71,15 +71,13 @@ impl Block {
             2 => vm.block3_cls,
             _ => unimplemented!(),
         };
-        Val::from_obj(
-            vm,
-            Block {
-                method,
-                inst,
-                blockn_cls,
-                blockinfo_off,
-                parent_closure,
-            },
-        )
+
+        Val::from_obj(Block {
+            method,
+            inst,
+            blockn_cls,
+            blockinfo_off,
+            parent_closure,
+        })
     }
 }

--- a/src/lib/vm/objects/double.rs
+++ b/src/lib/vm/objects/double.rs
@@ -188,8 +188,8 @@ impl StaticObjType for Double {
 }
 
 impl Double {
-    pub fn new(vm: &mut VM, val: f64) -> Val {
-        Val::from_obj(vm, Double { val })
+    pub fn new(_: &mut VM, val: f64) -> Val {
+        Val::from_obj(Double { val })
     }
 
     pub fn double(&self) -> f64 {

--- a/src/lib/vm/objects/instance.rs
+++ b/src/lib/vm/objects/instance.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::new_ret_no_self)]
 
-use std::{cell::UnsafeCell, collections::hash_map::DefaultHasher, hash::Hasher};
+use std::{alloc::Layout, collections::hash_map::DefaultHasher, hash::Hasher, mem::size_of};
 
 use rboehm::Gc;
 
@@ -14,7 +14,26 @@ use crate::vm::{
 #[derive(Debug)]
 pub struct Inst {
     class: Val,
-    inst_vars: UnsafeCell<Vec<Val>>,
+}
+
+// Since instances have a fixed number of instance variables, we do not need to allocate a separate
+// object and backing store: we can fit both in a single block.  We thus use a custom layout where
+// the `Inst` comes first, followed immediately by the `Val`s representing instance variables. On a
+// 64-bit machine this looks roughly as follows:
+//
+//   0: Inst
+//   8: Val [representing instance field 0]
+//   16: Val [representing instance field 1]
+//   ...
+
+macro_rules! inst_vars {
+    ($self:ident) => {
+        // We assume that the instance variables immediately follow the `Inst` without padding.
+        // This invariant is enforced in `Inst::new`. This saves us having to create a full
+        // `Layout`, which would require us having to know how many instance variables this
+        // particular `Inst` has.
+        (Gc::into_raw($self) as *mut u8).add(::std::mem::size_of::<Inst>()) as *mut Val
+    };
 }
 
 impl Obj for Inst {
@@ -26,21 +45,21 @@ impl Obj for Inst {
         self.class
     }
 
-    fn num_inst_vars(self: Gc<Self>) -> usize {
-        unsafe { &*self.inst_vars.get() }.len()
+    fn num_inst_vars(self: Gc<Self>, vm: &VM) -> usize {
+        let cls: Gc<Class> = self.class.downcast(vm).unwrap();
+        cls.inst_vars_map.len()
     }
 
-    unsafe fn unchecked_inst_var_get(self: Gc<Self>, n: usize) -> Val {
-        let inst_vars = &mut *self.inst_vars.get();
-        debug_assert!(n < inst_vars.len());
-        debug_assert!(inst_vars[n].valkind() != ValKind::ILLEGAL);
-        inst_vars[n]
+    unsafe fn unchecked_inst_var_get(self: Gc<Self>, vm: &VM, n: usize) -> Val {
+        debug_assert!(n < self.num_inst_vars(vm));
+        let v = inst_vars!(self).add(n).read();
+        debug_assert!(v.valkind() != ValKind::ILLEGAL);
+        v
     }
 
-    unsafe fn unchecked_inst_var_set(self: Gc<Self>, n: usize, v: Val) {
-        let inst_vars = &mut *self.inst_vars.get();
-        debug_assert!(n < inst_vars.len());
-        inst_vars[n] = v;
+    unsafe fn unchecked_inst_var_set(self: Gc<Self>, vm: &VM, n: usize, v: Val) {
+        debug_assert!(n < self.num_inst_vars(vm));
+        inst_vars!(self).add(n).write(v);
     }
 
     fn hashcode(self: Gc<Self>) -> u64 {
@@ -61,12 +80,24 @@ impl StaticObjType for Inst {
 impl Inst {
     pub fn new(vm: &mut VM, class: Val) -> Val {
         let cls: Gc<Class> = class.downcast(vm).unwrap();
-        let mut inst_vars = Vec::with_capacity(cls.inst_vars_map.len());
-        inst_vars.resize(cls.inst_vars_map.len(), vm.nil);
-        let inst = Inst {
-            class,
-            inst_vars: UnsafeCell::new(inst_vars),
-        };
-        Val::from_obj(vm, inst)
+        let len = cls.inst_vars_map.len();
+        debug_assert!(vm.nil.valkind() != ValKind::ILLEGAL || len == 0);
+        let (vals_layout, vals_dist) = Layout::new::<Val>().repeat(len).unwrap();
+        // We require the instance variables to be laid out as a C-like contiguous array.
+        debug_assert_eq!(vals_dist, size_of::<Val>());
+        let (layout, inst_vars_off) = Layout::new::<Inst>().extend(vals_layout).unwrap();
+        // We require the instance variables to be positioned immediately after the `Inst` with no
+        // padding in-between. This assumption is relied upon by the `inst_vars!` macro.
+        debug_assert_eq!(inst_vars_off, size_of::<Inst>());
+        unsafe {
+            Val::new_from_layout(layout, |basep: *mut Inst| {
+                *(&raw mut *basep) = Inst { class };
+                let mut inst_vars = (basep as *mut u8).add(size_of::<Inst>()) as *mut Val;
+                for _ in 0..len {
+                    inst_vars.write(vm.nil);
+                    inst_vars = inst_vars.add(1);
+                }
+            })
+        }
     }
 }

--- a/src/lib/vm/objects/integers.rs
+++ b/src/lib/vm/objects/integers.rs
@@ -381,7 +381,7 @@ impl ArbInt {
         if let Some(i) = val.to_isize() {
             Val::from_isize(vm, i)
         } else {
-            Val::from_obj(vm, ArbInt { val })
+            Val::from_obj(ArbInt { val })
         }
     }
 
@@ -506,8 +506,8 @@ impl StaticObjType for Int {
 impl Int {
     /// Create a `Val` representing the `usize` integer `i`. The `Val` is guaranteed to be boxed
     /// internally.
-    pub fn boxed_isize(vm: &mut VM, i: isize) -> Val {
-        Val::from_obj(vm, Int { val: i })
+    pub fn boxed_isize(_: &mut VM, i: isize) -> Val {
+        Val::from_obj(Int { val: i })
     }
 
     pub fn as_isize(&self) -> isize {

--- a/src/lib/vm/objects/method.rs
+++ b/src/lib/vm/objects/method.rs
@@ -60,13 +60,13 @@ impl StaticObjType for Method {
 }
 
 impl Method {
-    pub fn new(vm: &VM, sig: Val, num_params: usize, body: MethodBody) -> Method {
-        Method {
+    pub fn new(vm: &VM, sig: Val, num_params: usize, body: MethodBody) -> Val {
+        Val::from_obj(Method {
             sig: Cell::new(sig),
             num_params,
             body,
             holder: Cell::new(vm.nil),
-        }
+        })
     }
 
     pub fn holder(&self) -> Val {

--- a/src/lib/vm/objects/mod.rs
+++ b/src/lib/vm/objects/mod.rs
@@ -98,20 +98,20 @@ pub trait Obj: std::fmt::Debug {
     }
 
     /// How many instance variables does this object contain?
-    fn num_inst_vars(self: Gc<Self>) -> usize {
+    fn num_inst_vars(self: Gc<Self>, _: &VM) -> usize {
         unreachable!();
     }
 
     /// Return the instance variable at `i` (using SOM indexing).
     fn inst_var_at(self: Gc<Self>, vm: &VM, i: usize) -> Result<Val, Box<VMError>> {
-        if i > 0 && i <= self.num_inst_vars() {
-            Ok(unsafe { self.unchecked_inst_var_get(i - 1) })
+        if i > 0 && i <= self.num_inst_vars(vm) {
+            Ok(unsafe { self.unchecked_inst_var_get(vm, i - 1) })
         } else {
             Err(VMError::new(
                 vm,
                 VMErrorKind::IndexError {
                     tried: i,
-                    max: self.num_inst_vars(),
+                    max: self.num_inst_vars(vm),
                 },
             ))
         }
@@ -119,15 +119,15 @@ pub trait Obj: std::fmt::Debug {
 
     /// Return the instance variable at `i` (using SOM indexing).
     fn inst_var_at_put(self: Gc<Self>, vm: &VM, i: usize, v: Val) -> Result<(), Box<VMError>> {
-        if i > 0 && i <= self.num_inst_vars() {
-            unsafe { self.unchecked_inst_var_set(i - 1, v) };
+        if i > 0 && i <= self.num_inst_vars(vm) {
+            unsafe { self.unchecked_inst_var_set(vm, i - 1, v) };
             Ok(())
         } else {
             Err(VMError::new(
                 vm,
                 VMErrorKind::IndexError {
                     tried: i,
-                    max: self.num_inst_vars(),
+                    max: self.num_inst_vars(vm),
                 },
             ))
         }
@@ -135,13 +135,13 @@ pub trait Obj: std::fmt::Debug {
 
     /// Lookup an instance variable in this object. If `usize` exceeds the number of instance
     /// variables this will lead to undefined behaviour.
-    unsafe fn unchecked_inst_var_get(self: Gc<Self>, _: usize) -> Val {
+    unsafe fn unchecked_inst_var_get(self: Gc<Self>, _: &VM, _: usize) -> Val {
         unreachable!();
     }
 
     /// Set an instance variable in this object. If `usize` exceeds the number of instance
     /// variables this will lead to undefined behaviour.
-    unsafe fn unchecked_inst_var_set(self: Gc<Self>, _: usize, _: Val) {
+    unsafe fn unchecked_inst_var_set(self: Gc<Self>, _: &VM, _: usize, _: Val) {
         unreachable!();
     }
 

--- a/src/lib/vm/objects/string_.rs
+++ b/src/lib/vm/objects/string_.rs
@@ -43,15 +43,12 @@ impl Obj for String_ {
         self.cls.get()
     }
 
-    fn to_strval(self: Gc<Self>, vm: &mut VM) -> Result<Val, Box<VMError>> {
-        Ok(Val::from_obj(
-            vm,
-            String_ {
-                cls: self.cls.clone(),
-                chars_len: Cell::new(usize::MAX),
-                s: self.s.clone(),
-            },
-        ))
+    fn to_strval(self: Gc<Self>, _: &mut VM) -> Result<Val, Box<VMError>> {
+        Ok(Val::from_obj(String_ {
+            cls: self.cls.clone(),
+            chars_len: self.chars_len.clone(),
+            s: self.s.clone(),
+        }))
     }
 
     fn hashcode(self: Gc<Self>) -> u64 {
@@ -98,25 +95,19 @@ impl String_ {
     /// Create a new `String_` whose number of Unicode characters is already known. Note that it is
     /// safe to pass `usize::MAX` for `chars_len`.
     fn new_str_chars_len(vm: &mut VM, s: SmartString, chars_len: usize) -> Val {
-        Val::from_obj(
-            vm,
-            String_ {
-                cls: Cell::new(vm.str_cls),
-                chars_len: Cell::new(chars_len),
-                s,
-            },
-        )
+        Val::from_obj(String_ {
+            cls: Cell::new(vm.str_cls),
+            chars_len: Cell::new(chars_len),
+            s,
+        })
     }
 
     pub fn new_sym(vm: &mut VM, s: SmartString) -> Val {
-        Val::from_obj(
-            vm,
-            String_ {
-                cls: Cell::new(vm.sym_cls),
-                chars_len: Cell::new(usize::MAX),
-                s,
-            },
-        )
+        Val::from_obj(String_ {
+            cls: Cell::new(vm.sym_cls),
+            chars_len: Cell::new(usize::MAX),
+            s,
+        })
     }
 
     /// If the value `v` represents a `String_` which is an instance of the SOM `Symbol` class (and


### PR DESCRIPTION
**Draft PR: we need to check that we're confident this really does what we think it should do, as it uses a new-ish Rust feature.**

Previously we created objects on the stack and then moved them into the heap. Mostly this is cheap (and most of the moves were probably optimised away), but it is clearly inefficient for large objects, and it also limits us to objects that are a fixed size.

This commit changes the object creation API substantially. Objects now request a chunk of heap via `Val::heap_obj`, to which they are handed a raw pointer, to which they must write a fully initialised object. We use a function for this, so that the bounds of uninitialisation are clear. For example previously we wrote:

```rust
    pub fn from_vec(vm: &mut VM, store: Vec<Val>) -> Val {
        Val::from_obj(
            vm,
            NormalArray {
                store: UnsafeCell::new(store),
            }
        }
    }
```

which now becomes:

```rust
    pub fn from_vec(_: &mut VM, store: Vec<Val>) -> Val {
        Val::heap_obj(
            Layout::new::<NormalArray>(),
            |ptr: *mut NormalArray| unsafe {
                let ptr = &raw mut *ptr;
                (*ptr).store = UnsafeCell::new(store);
            },
        )
    }
```

As this shows we use the new "raw reference" feature (see https://github.com/rust-lang/rfcs/pull/2582/files) to make this easier to use. [In an ideal world, the init function would take an `&raw mut *T` but that doesn't seem to be supported yet, so each init function has to do the appropriate type conversion itself.]

It is important to note that the init function *must* fully initialise the memory for the main object; however, if extra memory is requested (which we don't do yet... but will soon!), then that does not need to be initialised.

[Note that, for some reason that may once have made sense, `Class`es and `Method`s did not return `Val`s even though the functions that created them immediately converted them to `Val`s; this commit changes them too.]

There isn't any observable speed change from this commit, but it will hopefully open up opportunities for speed improvements later.