### PR TITLE
Lazily store the number of Unicode characters a string contains.

### DIFF
--- a/src/lib/vm/objects/string_.rs
+++ b/src/lib/vm/objects/string_.rs
@@ -156,18 +156,11 @@ impl String_ {
         let mut new = String::new();
         new.push_str(&self.s);
         new.push_str(&other_str.s);
-        if self.chars_len.get() != usize::MAX && other_str.chars_len.get() != usize::MAX {
-            // If both strings have had their number of characters initialised then we can
-            // initialise the new string with its `chars_len` eagerly initialised.
-            let chars_len = self
-                .chars_len
-                .get()
-                .checked_add(other_str.chars_len.get())
-                .unwrap();
-            Ok(String_::new_str_chars_len(vm, new.into(), chars_len))
-        } else {
-            Ok(String_::new_str(vm, new.into()))
-        }
+        let chars_len = self
+            .chars_len
+            .get()
+            .saturating_add(other_str.chars_len.get());
+        Ok(String_::new_str_chars_len(vm, new.into(), chars_len))
     }
 
     pub fn substring(&self, vm: &mut VM, start: usize, end: usize) -> Result<Val, Box<VMError>> {


### PR DESCRIPTION
Calculating the number of Unicode characters in a string is an O(n) operation. Previously everytime `String_::length` was called we iterated over the underlying string to discover how many Unicode characters it contains.

This commit adds a field to SOM strings that stores its number of Unicode characters. Since not all strings will be queried for this property, we lazily cache this property the first time that `length` is called on a `String_`. We use `usize::max` as our marker as that means the marker is "safe" in all cases.

On the JSON benchmark, with GC off, this speeds things up by about 80%.

Needs https://github.com/softdevteam/rboehm/pull/19 to be merged first.