### PR TITLE
Normal array fewer allocations

### DIFF
--- a/src/lib/vm/core.rs
+++ b/src/lib/vm/core.rs
@@ -419,8 +419,7 @@ impl VM {
             };
             match instr {
                 Instr::Array(num_items) => {
-                    let items = self.stack.split_off(self.stack.len() - num_items);
-                    let arr = NormalArray::from_vec(self, items);
+                    let arr = self.stack.split_off(self.stack.len() - num_items);
                     self.stack.push(arr);
                     pc += 1;
                 }
@@ -553,8 +552,7 @@ impl VM {
                                         let meth = cls
                                             .get_method(self, "doesNotUnderstand:arguments:")
                                             .unwrap();
-                                        let items = self.stack.split_off(self.stack.len() - nargs);
-                                        let arr = NormalArray::from_vec(self, items);
+                                        let arr = self.stack.split_off(self.stack.len() - nargs);
                                         let sig = String_::new_sym(self, (&*name).to_owned());
                                         self.stack.push(sig);
                                         self.stack.push(arr);

--- a/src/lib/vm/objects/array.rs
+++ b/src/lib/vm/objects/array.rs
@@ -137,7 +137,7 @@ impl Array for NormalArray {
 impl NormalArray {
     pub fn new(vm: &VM, len: usize) -> Val {
         unsafe {
-            NormalArray::alloc(vm, len, |mut store: *mut Val| {
+            NormalArray::alloc(len, |mut store: *mut Val| {
                 for _ in 0..len {
                     store.write(vm.nil);
                     store = store.add(1);
@@ -146,9 +146,9 @@ impl NormalArray {
         }
     }
 
-    pub fn from_vec(vm: &VM, v: Vec<Val>) -> Val {
+    pub fn from_vec(v: Vec<Val>) -> Val {
         unsafe {
-            NormalArray::alloc(vm, v.len(), |store: *mut Val| {
+            NormalArray::alloc(v.len(), |store: *mut Val| {
                 copy_nonoverlapping(v.as_ptr(), store, v.len());
             })
         }
@@ -158,7 +158,7 @@ impl NormalArray {
     /// with a pointer to the uninitialised backing store. After `init` completes, the backing
     /// store will be considered fully initialised: failure to fully initialise it causes undefined
     /// behaviour.
-    unsafe fn alloc<F>(_: &VM, len: usize, init: F) -> Val
+    unsafe fn alloc<F>(len: usize, init: F) -> Val
     where
         F: FnOnce(*mut Val),
     {

--- a/src/lib/vm/objects/array.rs
+++ b/src/lib/vm/objects/array.rs
@@ -1,6 +1,9 @@
 #![allow(clippy::new_ret_no_self)]
 
-use std::{cell::UnsafeCell, collections::hash_map::DefaultHasher, hash::Hasher};
+use std::{
+    alloc::Layout, cell::UnsafeCell, collections::hash_map::DefaultHasher, hash::Hasher,
+    mem::size_of, ptr::copy_nonoverlapping,
+};
 
 use rboehm::Gc;
 
@@ -30,7 +33,27 @@ pub trait Array {
 
 #[derive(Debug)]
 pub struct NormalArray {
-    store: UnsafeCell<Vec<Val>>,
+    len: usize,
+}
+
+// Since arrays have a fixed number of elements in their store, we do not need to allocate a separate
+// object and store: we can fit both in a single block. We thus use a custom layout where
+// the `NormalArray` comes first, followed immediately by a contiguous array of `Val`s. On a
+// 64-bit machine this looks roughly as follows:
+//
+//   0: NormalArray { len: ... }
+//   8: Val_0
+//   16: Val_1
+//   ...
+
+macro_rules! narr_store {
+    ($self:ident) => {
+        // We assume that the backing store immediately follows the `NormalArray` without padding.
+        // This invariant is enforced in `NormalArray::alloc`. This saves us having to create a
+        // full `Layout`, which would require us having to know how many elements are stored in
+        // this array.
+        (Gc::into_raw($self) as *mut u8).add(::std::mem::size_of::<NormalArray>()) as *mut Val
+    };
 }
 
 impl Obj for NormalArray {
@@ -53,8 +76,7 @@ impl Obj for NormalArray {
     }
 
     fn length(self: Gc<Self>) -> usize {
-        let store = unsafe { &*self.store.get() };
-        store.len()
+        self.len
     }
 }
 
@@ -67,42 +89,37 @@ impl StaticObjType for NormalArray {
 }
 
 impl Array for NormalArray {
-    fn at(self: Gc<Self>, vm: &VM, mut idx: usize) -> Result<Val, Box<VMError>> {
-        let store = unsafe { &*self.store.get() };
-        if idx > 0 && idx <= store.len() {
-            idx -= 1;
-            Ok(*unsafe { store.get_unchecked(idx) })
+    fn at(self: Gc<Self>, vm: &VM, idx: usize) -> Result<Val, Box<VMError>> {
+        if idx > 0 && idx <= self.len {
+            Ok(unsafe { self.unchecked_at(idx) })
         } else {
             Err(VMError::new(
                 vm,
                 VMErrorKind::IndexError {
                     tried: idx,
-                    max: store.len(),
+                    max: self.len,
                 },
             ))
         }
     }
 
-    unsafe fn unchecked_at(self: Gc<Self>, mut idx: usize) -> Val {
-        debug_assert!(idx > 0);
-        let store = &*self.store.get();
-        debug_assert!(idx <= store.len());
-        idx -= 1;
-        *store.get_unchecked(idx)
+    unsafe fn unchecked_at(self: Gc<Self>, idx: usize) -> Val {
+        debug_assert!(idx > 0 && idx <= self.len);
+        narr_store!(self).add(idx - 1).read()
     }
 
-    fn at_put(self: Gc<Self>, vm: &mut VM, mut idx: usize, val: Val) -> Result<(), Box<VMError>> {
-        let store = unsafe { &mut *self.store.get() };
-        if idx > 0 && idx <= store.len() {
-            idx -= 1;
-            *unsafe { store.get_unchecked_mut(idx) } = val;
+    fn at_put(self: Gc<Self>, vm: &mut VM, idx: usize, val: Val) -> Result<(), Box<VMError>> {
+        if idx > 0 && idx <= self.len {
+            unsafe {
+                narr_store!(self).add(idx - 1).write(val);
+            }
             Ok(())
         } else {
             Err(VMError::new(
                 vm,
                 VMErrorKind::IndexError {
                     tried: idx,
-                    max: store.len(),
+                    max: self.len,
                 },
             ))
         }
@@ -111,24 +128,52 @@ impl Array for NormalArray {
     fn iter(self: Gc<Self>) -> ArrayIterator {
         ArrayIterator {
             arr: self,
-            len: self.length(),
+            len: self.len,
             i: 0,
         }
     }
 }
 
 impl NormalArray {
-    pub fn new(vm: &mut VM, len: usize) -> Val {
-        let mut store = Vec::with_capacity(len);
-        store.resize(len, vm.nil);
-        Val::from_obj(NormalArray {
-            store: UnsafeCell::new(store),
-        })
+    pub fn new(vm: &VM, len: usize) -> Val {
+        unsafe {
+            NormalArray::alloc(vm, len, |mut store: *mut Val| {
+                for _ in 0..len {
+                    store.write(vm.nil);
+                    store = store.add(1);
+                }
+            })
+        }
     }
 
-    pub fn from_vec(_: &mut VM, store: Vec<Val>) -> Val {
-        Val::from_obj(NormalArray {
-            store: UnsafeCell::new(store),
+    pub fn from_vec(vm: &VM, v: Vec<Val>) -> Val {
+        unsafe {
+            NormalArray::alloc(vm, v.len(), |store: *mut Val| {
+                copy_nonoverlapping(v.as_ptr(), store, v.len());
+            })
+        }
+    }
+
+    /// Create a new `NormalArray` with a backing store of `len` elements. `init` will be called
+    /// with a pointer to the uninitialised backing store. After `init` completes, the backing
+    /// store will be considered fully initialised: failure to fully initialise it causes undefined
+    /// behaviour.
+    unsafe fn alloc<F>(_: &VM, len: usize, init: F) -> Val
+    where
+        F: FnOnce(*mut Val),
+    {
+        let (vals_layout, vals_dist) = Layout::new::<Val>().repeat(len).unwrap();
+        // We require the store to be laid out as a C-like contiguous array.
+        debug_assert_eq!(vals_dist, size_of::<Val>());
+        let (layout, store_off) = Layout::new::<NormalArray>().extend(vals_layout).unwrap();
+        // We require the store to be positioned immediately after the `NormalArray` with no
+        // padding in-between. This assumption is relied upon by the `narr_store!` macro.
+        debug_assert_eq!(store_off, size_of::<NormalArray>());
+        Val::new_from_layout(layout, |ptr: *mut NormalArray| {
+            let ptr = &raw mut *ptr;
+            (*ptr).len = len;
+            let store = (ptr as *mut u8).add(size_of::<NormalArray>()) as *mut Val;
+            init(store);
         })
     }
 }

--- a/src/lib/vm/objects/array.rs
+++ b/src/lib/vm/objects/array.rs
@@ -158,7 +158,7 @@ impl NormalArray {
     /// with a pointer to the uninitialised backing store. After `init` completes, the backing
     /// store will be considered fully initialised: failure to fully initialise it causes undefined
     /// behaviour.
-    unsafe fn alloc<F>(len: usize, init: F) -> Val
+    pub unsafe fn alloc<F>(len: usize, init: F) -> Val
     where
         F: FnOnce(*mut Val),
     {

--- a/src/lib/vm/objects/class.rs
+++ b/src/lib/vm/objects/class.rs
@@ -185,7 +185,7 @@ impl Class {
             .keys()
             .map(|k| String_::new_sym(vm, k.clone()))
             .collect();
-        NormalArray::from_vec(vm, field_strs)
+        NormalArray::from_vec(field_strs)
     }
 
     pub fn methods(&self, _: &VM) -> Val {

--- a/src/lib/vm/somstack.rs
+++ b/src/lib/vm/somstack.rs
@@ -3,7 +3,7 @@ use std::{
     ptr,
 };
 
-use crate::vm::{core::VM, objects::NormalArray, val::Val};
+use crate::vm::{objects::NormalArray, val::Val};
 
 pub const SOM_STACK_LEN: usize = 4096;
 
@@ -75,19 +75,17 @@ impl SOMStack {
 
     /// Splits the collection into two at the given index.
     ///
-    /// Returns a newly allocated NormalArray containing the elements in the range [at, len). After
-    /// the call, the SOM stack will be left containing the elements [0, at) with its previous
-    /// capacity unchanged.
+    /// Returns a newly allocated `NormalArray` containing the elements in the range [at, len).
+    /// After the call, the SOM stack will be left containing the elements [0, at) with its
+    /// previous capacity unchanged.
     pub fn split_off(&mut self, at: usize) -> Val {
-        let mut out = Vec::with_capacity(self.len() - at);
-        for i in at..self.len() {
-            let v = unsafe { ptr::read(self.storage.add(i)) };
-            let e = unsafe { out.get_unchecked_mut(i - at) };
-            *e = v;
-        }
-        unsafe { out.set_len(self.len() - at) };
+        let arr = unsafe {
+            NormalArray::alloc(self.len() - at, |arr_store: *mut Val| {
+                ptr::copy_nonoverlapping(self.storage.add(at), arr_store, self.len() - at);
+            })
+        };
         self.len = at;
-        NormalArray::from_vec(out)
+        arr
     }
 
     /// Shortens the stack, keeping the first len elements and dropping the rest.

--- a/src/lib/vm/somstack.rs
+++ b/src/lib/vm/somstack.rs
@@ -3,7 +3,7 @@ use std::{
     ptr,
 };
 
-use crate::vm::val::Val;
+use crate::vm::{core::VM, objects::NormalArray, val::Val};
 
 pub const SOM_STACK_LEN: usize = 4096;
 
@@ -75,10 +75,10 @@ impl SOMStack {
 
     /// Splits the collection into two at the given index.
     ///
-    /// Returns a newly allocated vector containing the elements in the range [at, len). After the
-    /// call, the original vector will be left containing the elements [0, at) with its previous
+    /// Returns a newly allocated NormalArray containing the elements in the range [at, len). After
+    /// the call, the SOM stack will be left containing the elements [0, at) with its previous
     /// capacity unchanged.
-    pub fn split_off(&mut self, at: usize) -> Vec<Val> {
+    pub fn split_off(&mut self, at: usize) -> Val {
         let mut out = Vec::with_capacity(self.len() - at);
         for i in at..self.len() {
             let v = unsafe { ptr::read(self.storage.add(i)) };
@@ -87,7 +87,7 @@ impl SOMStack {
         }
         unsafe { out.set_len(self.len() - at) };
         self.len = at;
-        out
+        NormalArray::from_vec(out)
     }
 
     /// Shortens the stack, keeping the first len elements and dropping the rest.

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,7 +75,7 @@ fn main() {
             .skip(1)
             .map(|x| String_::new_str(&mut vm, SmartString::from(x))),
     );
-    let args = NormalArray::from_vec(&mut vm, args_vec);
+    let args = NormalArray::from_vec(args_vec);
     match vm.top_level_send(system, "initialize:", vec![args]) {
         Ok(_) => (),
         Err(e) => {


### PR DESCRIPTION
This PR makes `NormalArray` (fixed sized arrays in SOM) perform a single allocation (similar to how `Inst` is stored after #172), and also changes a couple of cases to not allocate intermediate `Vec`s.