### PR TITLE
Separate out local variable lookup/set from up-variables.

### DIFF
--- a/src/lib/compiler/ast_to_instrs.rs
+++ b/src/lib/compiler/ast_to_instrs.rs
@@ -501,7 +501,7 @@ impl<'a, 'input> Compiler<'a, 'input> {
                 vm.instrs_push(Instr::Pop, span);
             }
             debug_assert_eq!(*self.vars_stack.last().unwrap().get("self").unwrap(), 0);
-            vm.instrs_push(Instr::VarLookup(0, 0), span);
+            vm.instrs_push(Instr::LocalVarLookup(0), span);
             max_stack = max(max_stack, 1);
             vm.instrs_push(Instr::Return, span);
         } else if exprs.is_empty() {
@@ -540,8 +540,10 @@ impl<'a, 'input> Compiler<'a, 'input> {
                 let max_stack = self.c_expr(vm, expr)?;
                 if depth == self.vars_stack.len() - 1 {
                     vm.instrs_push(Instr::InstVarSet(var_num), *span);
+                } else if depth == 0 {
+                    vm.instrs_push(Instr::LocalVarSet(var_num), *span);
                 } else {
-                    vm.instrs_push(Instr::VarSet(depth, var_num), *span);
+                    vm.instrs_push(Instr::UpVarSet(depth, var_num), *span);
                 }
                 debug_assert!(max_stack > 0);
                 Ok(max_stack)
@@ -727,8 +729,10 @@ impl<'a, 'input> Compiler<'a, 'input> {
                     Some((depth, var_num)) => {
                         if depth == self.vars_stack.len() - 1 {
                             vm.instrs_push(Instr::InstVarLookup(var_num), *span);
+                        } else if depth == 0 {
+                            vm.instrs_push(Instr::LocalVarLookup(var_num), *span);
                         } else {
-                            vm.instrs_push(Instr::VarLookup(depth, var_num), *span);
+                            vm.instrs_push(Instr::UpVarLookup(depth, var_num), *span);
                         }
                     }
                     None => {

--- a/src/lib/compiler/instrs.rs
+++ b/src/lib/compiler/instrs.rs
@@ -14,8 +14,10 @@ pub enum Instr {
     String(usize),
     SuperSend(usize, usize),
     Symbol(usize),
-    VarLookup(usize, usize),
-    VarSet(usize, usize),
+    LocalVarLookup(usize),
+    LocalVarSet(usize),
+    UpVarLookup(usize, usize),
+    UpVarSet(usize, usize),
 }
 
 #[derive(Clone, Copy, Debug)]


### PR DESCRIPTION
"Up variables" is the Lua terminology for "variables in an outer closure". By separating out variables local to the current closure from those in an outer closure, we do get a small speed increase (3-4% on the JSON benchmark), but more importantly we start to move the VM in a direction where we can put variables on the stack.