### PR TITLE
Reorganise functions

### DIFF
--- a/src/lib/compiler/instrs.rs
+++ b/src/lib/compiler/instrs.rs
@@ -20,7 +20,7 @@ pub enum Instr {
     UpVarSet(usize, usize),
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Primitive {
     Add,
     And,

--- a/src/lib/vm/core.rs
+++ b/src/lib/vm/core.rs
@@ -24,9 +24,9 @@ use crate::{
     },
     vm::{
         error::{VMError, VMErrorKind},
+        function::Function,
         objects::{
-            ArbInt, Block, BlockInfo, Class, Double, Inst, Int, Method, MethodBody, NormalArray,
-            StaticObjType, String_,
+            ArbInt, Block, Class, Double, Inst, Int, Method, NormalArray, StaticObjType, String_,
         },
         somstack::SOMStack,
         val::{Val, ValKind},
@@ -71,7 +71,6 @@ pub struct VM {
     pub nil: Val,
     pub system: Val,
     pub true_: Val,
-    blockinfos: Vec<BlockInfo>,
     /// The current known set of globals including those not yet assigned to: in other words, it is
     /// expected that some entries of this `Vec` are illegal (i.e. created by `Val::illegal`).
     globals: Vec<Val>,
@@ -128,7 +127,6 @@ impl VM {
             nil: Val::illegal(),
             system: Val::illegal(),
             true_: Val::illegal(),
-            blockinfos: Vec::new(),
             globals: Vec::new(),
             reverse_globals: HashMap::new(),
             inline_caches: Vec::new(),
@@ -323,61 +321,44 @@ impl VM {
         assert!(self.frames_len() == 0);
         let cls = rcv.get_class(self);
         let meth = cls.downcast::<Class>(self)?.get_method(self, msg)?;
-        match meth.body {
-            MethodBody::Primitive(_) => {
-                panic!("Primitives can't be called outside of a function frame.");
+        if meth.func.is_primitive() {
+            panic!("Primitives can't be called outside of a function frame.");
+        } else {
+            if args.len() != meth.func.num_params() {
+                panic!("Passed the wrong number of parameters.");
             }
-            MethodBody::User {
-                num_vars,
-                bytecode_off,
-                max_stack,
-            } => {
-                if self.stack.remaining_capacity() < max_stack {
-                    panic!("Not enough stack space to execute method.");
-                }
-                if args.len() != meth.num_params() {
-                    panic!("Passed the wrong number of parameters.");
-                }
-                for a in args {
-                    self.stack.push(a);
-                }
-                let frame = Frame::new_method(self, rcv, num_vars, meth.num_params());
-                self.frames.push(frame);
-                let r = self.exec_user(rcv, meth, bytecode_off);
-                self.frame_pop();
-                match r {
-                    SendReturn::ClosureReturn(_) => unreachable!(),
-                    SendReturn::Err(e) => Err(Box::new(*e)),
-                    SendReturn::Val => Ok(self.stack.pop()),
-                }
+            for a in args {
+                self.stack.push(a);
+            }
+            let frame = Frame::new_method(self, rcv, meth.func.num_vars(), meth.func.num_params());
+            self.frames.push(frame);
+            let r = self.exec_user(rcv, &meth.func);
+            self.frame_pop();
+            match r {
+                SendReturn::ClosureReturn(_) => unreachable!(),
+                SendReturn::Err(e) => Err(Box::new(*e)),
+                SendReturn::Val => Ok(self.stack.pop()),
             }
         }
     }
 
-    fn send_args_on_stack(&mut self, rcv: Val, method: Gc<Method>) -> SendReturn {
-        match method.body {
-            MethodBody::Primitive(p) => self.exec_primitive(p, rcv),
-            MethodBody::User {
-                num_vars,
-                bytecode_off,
-                max_stack,
-            } => {
-                if self.stack.remaining_capacity() < max_stack {
-                    panic!("Not enough stack space to execute method.");
-                }
-                let nframe = Frame::new_method(self, rcv, num_vars, method.num_params());
-                self.frames.push(nframe);
-                let r = self.exec_user(rcv, method, bytecode_off);
-                self.frame_pop();
-                r
-            }
+    fn send_args_on_stack(&mut self, rcv: Val, meth: Gc<Method>) -> SendReturn {
+        if meth.func.is_primitive() {
+            self.exec_primitive(meth.func.primitive(), rcv)
+        } else {
+            let nframe = Frame::new_method(self, rcv, meth.func.num_vars(), meth.func.num_params());
+            self.frames.push(nframe);
+            let r = self.exec_user(rcv, &meth.func);
+            self.frame_pop();
+            r
         }
     }
 
     /// Execute a SOM method. Note that the frame for this method must have been created *before*
     /// calling this function.
-    fn exec_user(&mut self, rcv: Val, method: Gc<Method>, meth_start_pc: usize) -> SendReturn {
-        let mut pc = meth_start_pc;
+    fn exec_user(&mut self, rcv: Val, func: &Function) -> SendReturn {
+        debug_assert!(!func.is_primitive());
+        let mut pc = func.bytecode_off();
 
         macro_rules! stry {
             ($elem:expr) => {{
@@ -385,7 +366,8 @@ impl VM {
                 match e {
                     Ok(o) => o,
                     Err(mut e) => {
-                        e.backtrace.push((method, self.instr_spans[pc]));
+                        e.backtrace
+                            .push((func.containing_method(), self.instr_spans[pc]));
                         return SendReturn::Err(e);
                     }
                 }
@@ -403,7 +385,8 @@ impl VM {
                         }
                     }
                     SendReturn::Err(mut e) => {
-                        e.backtrace.push((method, self.instr_spans[pc]));
+                        e.backtrace
+                            .push((func.containing_method(), self.instr_spans[pc]));
                         return SendReturn::Err(e);
                     }
                     SendReturn::Val => (),
@@ -411,6 +394,9 @@ impl VM {
             }};
         }
 
+        if self.stack.remaining_capacity() < func.max_stack() {
+            panic!("Not enough stack space to execute block.");
+        }
         let stack_base = self.stack.len();
         loop {
             let instr = {
@@ -423,15 +409,12 @@ impl VM {
                     self.stack.push(arr);
                     pc += 1;
                 }
-                Instr::Block(blkinfo_off) => {
-                    let (num_params, bytecode_end) = {
-                        let blkinfo = &self.blockinfos[blkinfo_off];
-                        (blkinfo.num_params, blkinfo.bytecode_end)
-                    };
+                Instr::Block(blkfn_idx) => {
+                    let blk_func = func.block_func(blkfn_idx);
                     let closure = self.current_frame().closure;
-                    let v = Block::new(self, rcv, blkinfo_off, closure, num_params);
+                    let v = Block::new(self, rcv, blk_func, closure);
                     self.stack.push(v);
-                    pc = bytecode_end;
+                    pc = blk_func.bytecode_end();
                 }
                 Instr::ClosureReturn(closure_depth) => {
                     // We want to do a non-local return. Before we attempt that, we need to
@@ -525,7 +508,7 @@ impl VM {
                         let lookup_cls = match instr {
                             Instr::Send(_, _) => rcv.get_class(self),
                             Instr::SuperSend(_, _) => {
-                                let method_cls_val = method.holder();
+                                let method_cls_val = func.holder();
                                 let method_cls: Gc<Class> = stry!(method_cls_val.downcast(self));
                                 method_cls.supercls(self)
                             }
@@ -567,9 +550,9 @@ impl VM {
                         (rcv, nargs, meth)
                     };
 
-                    if let MethodBody::Primitive(Primitive::Restart) = meth.body {
+                    if meth.func.is_primitive() && meth.func.primitive() == Primitive::Restart {
                         self.stack.truncate(stack_base);
-                        pc = meth_start_pc;
+                        pc = func.bytecode_off();
                         continue;
                     }
 
@@ -828,7 +811,7 @@ impl VM {
             }
             Primitive::Holder => {
                 let meth = stry!(rcv.downcast::<Method>(self));
-                let cls = meth.holder();
+                let cls = meth.func.holder();
                 self.stack.push(cls);
                 SendReturn::Val
             }
@@ -1064,23 +1047,17 @@ impl VM {
             }
             Primitive::Time => todo!(),
             Primitive::Value(nargs) => {
-                let rcv_blk: Gc<Block> = stry!(rcv.downcast(self));
-                let (num_vars, bytecode_off, max_stack, method) = {
-                    let blkinfo = &self.blockinfos[rcv_blk.blockinfo_off];
-                    (
-                        blkinfo.num_vars,
-                        blkinfo.bytecode_off,
-                        blkinfo.max_stack,
-                        blkinfo.method.unwrap(),
-                    )
-                };
-                if self.stack.remaining_capacity() < max_stack {
-                    panic!("Not enough stack space to execute block.");
-                }
-                let frame =
-                    Frame::new_block(self, rcv, rcv_blk.parent_closure, num_vars, nargs as usize);
+                let blk: Gc<Block> = stry!(rcv.downcast(self));
+                debug_assert_eq!(nargs as usize, blk.func.num_params());
+                let frame = Frame::new_block(
+                    self,
+                    rcv,
+                    blk.parent_closure,
+                    blk.func.num_vars(),
+                    blk.func.num_params(),
+                );
                 self.frames.push(frame);
-                let r = self.exec_user(rcv_blk.inst, method, bytecode_off);
+                let r = self.exec_user(blk.inst, &*blk.func);
                 self.frame_pop();
                 r
             }
@@ -1104,11 +1081,11 @@ impl VM {
         let cls = stry!(cls_val.downcast::<Class>(self));
         match cls.get_method(self, sig.as_str()) {
             Ok(m) => {
-                if args_tobj.as_gc().length() != m.num_params() {
+                if args_tobj.as_gc().length() != m.func.num_params() {
                     return SendReturn::Err(VMError::new(
                         self,
                         VMErrorKind::WrongNumberOfArgs {
-                            wanted: m.num_params(),
+                            wanted: m.func.num_params(),
                             got: args_tobj.as_gc().length(),
                         },
                     ));
@@ -1162,23 +1139,6 @@ impl VM {
 
     pub fn frames_len(&self) -> usize {
         self.frames.len()
-    }
-
-    /// The index of the last `BlockInfo`.
-    pub fn blockinfos_len(&self) -> usize {
-        self.blockinfos.len()
-    }
-
-    /// Add `blkinfo` to the set of known `BlockInfo`s and return its index.
-    pub fn push_blockinfo(&mut self, blkinfo: BlockInfo) -> usize {
-        let len = self.blockinfos.len();
-        self.blockinfos.push(blkinfo);
-        len
-    }
-
-    /// Get a mutable reference to the `BlockInfo` at index `idx`.
-    pub fn get_mut_blockinfo(&mut self, idx: usize) -> &mut BlockInfo {
-        self.blockinfos.get_mut(idx).unwrap()
     }
 
     pub fn flush_inline_caches(&mut self) {
@@ -1481,7 +1441,6 @@ impl VM {
             nil: Val::illegal(),
             system: Val::illegal(),
             true_: Val::illegal(),
-            blockinfos: Vec::new(),
             globals: Vec::new(),
             reverse_globals: HashMap::new(),
             inline_caches: Vec::new(),

--- a/src/lib/vm/error.rs
+++ b/src/lib/vm/error.rs
@@ -27,7 +27,7 @@ impl VMError {
     pub fn console_print(&self, vm: &VM) {
         eprintln!("Traceback (most recent call at bottom):");
         for (method, span) in self.backtrace.iter().rev() {
-            let cls_val = method.holder();
+            let cls_val = method.func.holder();
             let cls: Gc<Class> = cls_val.downcast(vm).unwrap();
             let cls_path = cls.path.to_str().unwrap_or("<non-UTF8 filename>");
 

--- a/src/lib/vm/function.rs
+++ b/src/lib/vm/function.rs
@@ -1,0 +1,158 @@
+use std::cell::Cell;
+
+use rboehm::Gc;
+
+use crate::{
+    compiler::instrs::Primitive,
+    vm::{core::VM, objects::Method, val::Val},
+};
+
+/// The VM's underlying notion of a SOM function. SOM has two types of functions: methods and
+/// blocks. Roughly speaking, methods have names, may reference primitives, but can't be nested;
+/// blocks are anonymous, can't reference primitives, but can be nested. Although at a SOM level
+/// methods and blocks are separate types, they share nearly everything that makes them
+/// function-esque, so to avoid having two separate internal representations, both methods and
+/// blocks store `Function`s.
+///
+/// The main complication in representation is that a `Function` can reference a SOM primitive,
+/// which is a very different type of `Function` to a non-primitive. Rather than have two types of
+/// `Function`, we store both together: the [Function::is_primitive()] can be used to differentiate
+/// the two.
+#[derive(Debug)]
+pub struct Function {
+    num_params: usize,
+    /// The class this function is contained within. Note that we ensure this is set properly for
+    /// both methods and blocks.
+    holder: Cell<Val>,
+    /// The method this function is contained within. Note that for a top-level method this simply
+    /// points to the method itself (i.e. it's effectively circular). `Option` is used here solely
+    /// to aid bootstrapping: every "live" `Function` is guaranteed to have a containing method.
+    containing_method: Cell<Option<Gc<Method>>>,
+    // If num_vars==usize::MAX then this is a Primitive function:
+    primitive: Option<Primitive>,
+    // If num_vars<usize::MAX then this is a bytecode function:
+    num_vars: usize,
+    /// The offset of this method's bytecode in its parent class.
+    bytecode_off: usize,
+    /// If this function is a block, this specifies the end of the block's bytecode.
+    bytecode_end: usize,
+    max_stack: usize,
+    /// This function's blocks.
+    block_funcs: Vec<Gc<Function>>,
+}
+
+impl Function {
+    pub fn new_bytecode(
+        vm: &VM,
+        num_params: usize,
+        num_vars: usize,
+        bytecode_off: usize,
+        bytecode_end: Option<usize>,
+        max_stack: usize,
+        block_funcs: Vec<Gc<Function>>,
+    ) -> Function {
+        Function {
+            num_params,
+            holder: Cell::new(vm.nil),
+            containing_method: Cell::new(None),
+            primitive: None,
+            num_vars,
+            bytecode_off,
+            bytecode_end: bytecode_end.unwrap_or(usize::MAX),
+            max_stack,
+            block_funcs,
+        }
+    }
+
+    pub fn new_primitive(vm: &VM, num_params: usize, primitive: Primitive) -> Function {
+        Function {
+            num_params,
+            holder: Cell::new(vm.nil),
+            containing_method: Cell::new(None),
+            primitive: Some(primitive),
+            num_vars: usize::MAX,
+            bytecode_off: usize::MAX,
+            bytecode_end: usize::MAX,
+            max_stack: usize::MAX,
+            block_funcs: Vec::new(),
+        }
+    }
+
+    /// Is this `Function` a SOM primitive?
+    pub fn is_primitive(&self) -> bool {
+        self.num_vars == usize::MAX
+    }
+
+    /// If this `Function` is a SOM primitive, return the `Primitive`. Calling this function
+    /// without first having confirmed that this `Function` is a SOM primitive is undefined
+    /// behaviour.
+    pub fn primitive(&self) -> Primitive {
+        debug_assert!(self.is_primitive());
+        self.primitive.unwrap()
+    }
+
+    pub fn num_params(&self) -> usize {
+        self.num_params
+    }
+
+    pub fn holder(&self) -> Val {
+        self.holder.get()
+    }
+
+    /// Set this function, and recursively all its nested functions, holder.
+    pub fn set_holder(&self, vm: &VM, class: Val) {
+        self.holder.set(class);
+        for blk in &self.block_funcs {
+            blk.set_holder(vm, class);
+        }
+    }
+
+    pub fn containing_method(&self) -> Gc<Method> {
+        self.containing_method.get().unwrap()
+    }
+
+    pub fn set_containing_method(&self, meth: Gc<Method>) {
+        self.containing_method.set(Some(meth));
+    }
+
+    /// If this `Function` is not a SOM primitive, return its number of local variables. Calling
+    /// this function without first having confirmed that this `Function` is not a SOM primitive is
+    /// undefined behaviour.
+    pub fn num_vars(&self) -> usize {
+        debug_assert!(!self.is_primitive());
+        self.num_vars
+    }
+
+    /// If this `Function` is not a SOM primitive, return the start of its bytecode. Calling this
+    /// function without first having confirmed that this `Function` is not a SOM primitive is
+    /// undefined behaviour.
+    pub fn bytecode_off(&self) -> usize {
+        debug_assert!(!self.is_primitive());
+        self.bytecode_off
+    }
+
+    /// If this `Function` is not a SOM primitive, and if this `Function` represents a block,
+    /// return the end of its bytecode. Calling this function without first having confirmed that
+    /// this `Function` is not a SOM primitive and that it is a block is undefined behaviour.
+    pub fn bytecode_end(&self) -> usize {
+        debug_assert!(!self.is_primitive());
+        self.bytecode_end
+    }
+
+    /// If this `Function` is not a SOM primitive, return the maximum number of SOM stack entries
+    /// it requires. Calling this function without first having confirmed that this `Function` is
+    /// not a SOM primitive is undefined behaviour.
+    pub fn max_stack(&self) -> usize {
+        debug_assert!(!self.is_primitive());
+        self.max_stack
+    }
+
+    pub fn block_func(&self, idx: usize) -> Gc<Function> {
+        debug_assert!(idx < self.block_funcs.len());
+        *unsafe { self.block_funcs.get_unchecked(idx) }
+    }
+
+    pub fn block_funcs(&self) -> &Vec<Gc<Function>> {
+        &self.block_funcs
+    }
+}

--- a/src/lib/vm/mod.rs
+++ b/src/lib/vm/mod.rs
@@ -10,6 +10,7 @@
 
 pub mod core;
 pub mod error;
+pub mod function;
 pub mod objects;
 pub mod somstack;
 pub mod val;

--- a/src/lib/vm/objects/class.rs
+++ b/src/lib/vm/objects/class.rs
@@ -163,7 +163,7 @@ impl Class {
     pub fn set_methods_class(&self, vm: &VM, cls: Val) {
         for meth_val in self.methods.downcast::<MethodsArray>(vm).unwrap().iter() {
             let meth = meth_val.downcast::<Method>(vm).unwrap();
-            meth.set_holder(vm, cls);
+            meth.func.set_holder(vm, cls);
         }
     }
 

--- a/src/lib/vm/objects/mod.rs
+++ b/src/lib/vm/objects/mod.rs
@@ -30,12 +30,12 @@ mod method;
 mod string_;
 
 pub use array::{Array, MethodsArray, NormalArray};
-pub use block::{Block, BlockInfo};
+pub use block::Block;
 pub use class::Class;
 pub use double::Double;
 pub use instance::Inst;
 pub use integers::{ArbInt, Int};
-pub use method::{Method, MethodBody};
+pub use method::Method;
 pub use string_::String_;
 
 use natrob::narrowable_rboehm;


### PR DESCRIPTION
This PR aims to sort out the internal representation of SOM functions. The basic problem is that we previously had quite separate representations of SOM methods and blocks, and that hinders o. The major work is done in https://github.com/softdevteam/yksom/commit/9cbe414650907d79366d4f30db6c7486d8148f0e (https://github.com/softdevteam/yksom/commit/cb5b342d35032008ac332d8c7c0c967a5075459d is a simple stand-alone improvement).