### PR TITLE
Store SOM variables on the SOM stack.

### DIFF
--- a/lang_tests/block11.som
+++ b/lang_tests/block11.som
@@ -1,0 +1,27 @@
+"
+VM:
+  stdout:
+    3
+    3
+"
+
+block11 = (
+    f = (
+        | x y |
+        x := 1.
+        y := [
+            x := 2.
+            [
+                x println.
+                ^ x
+            ]
+        ] value.
+        x := 3.
+        y value.
+        'unreachable' println.
+    )
+
+    run = (
+        self f println.
+    )
+)

--- a/lang_tests/block12.som
+++ b/lang_tests/block12.som
@@ -1,0 +1,32 @@
+"
+VM:
+  stdout:
+    false 0
+    instance of block12
+"
+
+block12 = (
+    | i |
+    r: b = (
+        | x |
+        x := i.
+        b ifTrue: [
+            [
+                'true ' print.
+                x println.
+                ^b
+            ]
+          ]
+          ifFalse: [
+            'false ' print.
+            x println.
+            x := 1.
+            (self r: true) value
+        ].
+    )
+
+    run = (
+        i := 0.
+        (self r: false) println.
+    )
+)

--- a/lang_tests/escaped3.som
+++ b/lang_tests/escaped3.som
@@ -1,0 +1,34 @@
+"
+VM:
+  status: success
+  stdout:
+    5
+    6
+    6
+"
+
+escaped3 = (
+    f: x = (
+        | b c |
+        b := [
+            x := x + 1.
+            x
+        ].
+        c := [ x ].
+        x := x + 1.
+        ^(b, c)
+    )
+
+    g = (
+        | a b c |
+    )
+
+    run = (
+        | arr |
+        arr := self f: 3.
+        self g.
+        (arr at: 1) value println.
+        (arr at: 1) value println.
+        (arr at: 2) value println.
+    )
+)

--- a/src/lib/compiler/instrs.rs
+++ b/src/lib/compiler/instrs.rs
@@ -1,3 +1,9 @@
+#[derive(Clone, Debug)]
+pub struct UpVarDef {
+    pub capture_local: bool,
+    pub upidx: usize,
+}
+
 #[derive(Clone, Copy, Debug)]
 pub enum Instr {
     Array(usize),
@@ -5,6 +11,7 @@ pub enum Instr {
     GlobalLookup(usize),
     ClosureReturn(usize),
     Double(f64),
+    Dummy,
     InstVarLookup(usize),
     InstVarSet(usize),
     Int(isize),
@@ -16,8 +23,8 @@ pub enum Instr {
     Symbol(usize),
     LocalVarLookup(usize),
     LocalVarSet(usize),
-    UpVarLookup(usize, usize),
-    UpVarSet(usize, usize),
+    UpVarLookup(usize),
+    UpVarSet(usize),
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -16,6 +16,7 @@
 #![feature(box_patterns)]
 #![feature(coerce_unsized)]
 #![feature(dispatch_from_dyn)]
+#![feature(entry_insert)]
 #![feature(raw_ref_op)]
 #![feature(unsize)]
 #![allow(clippy::cognitive_complexity)]

--- a/src/lib/vm/error.rs
+++ b/src/lib/vm/error.rs
@@ -19,8 +19,8 @@ pub struct VMError {
 }
 
 impl VMError {
-    pub fn new(vm: &VM, kind: VMErrorKind) -> Box<Self> {
-        let backtrace = Vec::with_capacity(vm.frames_len());
+    pub fn new(_: &VM, kind: VMErrorKind) -> Box<Self> {
+        let backtrace = Vec::new();
         Box::new(VMError { kind, backtrace })
     }
 

--- a/src/lib/vm/objects/block.rs
+++ b/src/lib/vm/objects/block.rs
@@ -5,11 +5,54 @@ use std::{collections::hash_map::DefaultHasher, hash::Hasher};
 use rboehm::Gc;
 
 use crate::vm::{
-    core::{Closure, VM},
+    core::VM,
     function::Function,
     objects::{Obj, ObjType, StaticObjType},
-    val::{NotUnboxable, Val},
+    val::{NotUnboxable, Val, ValKind},
 };
+
+/// An UpVar references either a variable on the stack or, if the UpVar is closed, a copy of that
+/// variable inside the struct itself (the `closed` field). This scheme is very similar to that
+/// used in Lua; the best explanation I know of can
+/// be found at: http://www.craftinginterpreters.com/closures.html.
+#[derive(Clone, Debug)]
+pub struct UpVar {
+    prev: Option<Gc<UpVar>>,
+    ptr: Gc<Val>,
+    closed: Val,
+}
+
+impl UpVar {
+    pub fn new(prev: Option<Gc<UpVar>>, ptr: Gc<Val>) -> Self {
+        UpVar {
+            prev,
+            ptr,
+            closed: Val::illegal(),
+        }
+    }
+
+    pub fn to_gc(&self) -> Gc<Val> {
+        debug_assert_ne!(self.ptr.valkind(), ValKind::ILLEGAL);
+        self.ptr
+    }
+
+    pub fn close(&mut self) {
+        self.closed = *self.to_gc();
+        self.ptr = Gc::from_raw(&self.closed);
+    }
+
+    pub fn is_closed(&self) -> bool {
+        Gc::into_raw(self.ptr) == &self.closed
+    }
+
+    pub fn prev(&self) -> Option<Gc<UpVar>> {
+        self.prev
+    }
+
+    pub fn set_prev(&mut self, prev: Option<Gc<UpVar>>) {
+        self.prev = prev;
+    }
+}
 
 #[derive(Debug)]
 pub struct Block {
@@ -17,7 +60,11 @@ pub struct Block {
     /// variables.
     pub inst: Val,
     pub func: Gc<Function>,
-    pub parent_closure: Gc<Closure>,
+    pub upvars: Vec<Gc<UpVar>>,
+    /// For closures which perform a method return (i.e. they cause the method they are contained
+    /// within to return), we have to reset the stack to the method's stack base, so we have to
+    /// cart that around with the Block.
+    pub method_stack_base: usize,
 }
 
 impl Obj for Block {
@@ -27,9 +74,9 @@ impl Obj for Block {
 
     fn get_class(self: Gc<Self>, vm: &mut VM) -> Val {
         match self.func.num_params() {
-            0 => vm.block1_cls,
-            1 => vm.block2_cls,
-            2 => vm.block3_cls,
+            1 => vm.block1_cls,
+            2 => vm.block2_cls,
+            3 => vm.block3_cls,
             _ => unreachable!(),
         }
     }
@@ -50,11 +97,18 @@ impl StaticObjType for Block {
 }
 
 impl Block {
-    pub fn new(_: &mut VM, inst: Val, func: Gc<Function>, parent_closure: Gc<Closure>) -> Val {
+    pub fn new(
+        _: &mut VM,
+        inst: Val,
+        func: Gc<Function>,
+        upvars: Vec<Gc<UpVar>>,
+        method_stack_base: usize,
+    ) -> Val {
         Val::from_obj(Block {
             inst,
             func,
-            parent_closure,
+            upvars,
+            method_stack_base,
         })
     }
 }

--- a/src/lib/vm/objects/mod.rs
+++ b/src/lib/vm/objects/mod.rs
@@ -30,7 +30,7 @@ mod method;
 mod string_;
 
 pub use array::{Array, MethodsArray, NormalArray};
-pub use block::Block;
+pub use block::{Block, UpVar};
 pub use class::Class;
 pub use double::Double;
 pub use instance::Inst;

--- a/src/lib/vm/somstack.rs
+++ b/src/lib/vm/somstack.rs
@@ -1,76 +1,132 @@
-use std::{
-    alloc::{alloc, dealloc, Layout},
-    ptr,
-};
+use std::{alloc::Layout, mem::size_of, ptr};
+
+use rboehm::Gc;
 
 use crate::vm::{objects::NormalArray, val::Val};
 
 pub const SOM_STACK_LEN: usize = 4096;
 
-/// A fixed size stack of SOM values. This stack does minimal or no checking on important
+/// A contiguous stack of SOM values. This stack does minimal or no checking on important
 /// operations and users must ensure that they obey the constraints on each function herein, or
 /// undefined behaviour will occur.
+///
+/// The basic layout of the stack is as a series of function frames growing from the beginning of
+/// the stack upwards. On a 64-bit machine, a function frame looks roughly like:
+///
+///   0    :     <arg 0>
+///               ...
+///              <arg n>
+///   n * 8:     <var 0>
+///              ...
+///              <var m>
+///   (n+m) * 8: <working stack>
+///
+/// The compiler and VM treat <arg 0> as special: it always contains a reference to `self` (hence
+/// all functions have 1 extra parameter over those specified by the user). Functions are expected
+/// to be called with their arguments already in place on the stack, and the stack pointer pointing
+/// to after the arguments but before the variables (i.e. the function will then set up its
+/// variables however it wants). Similarly, when a function is returned, the return value is
+/// expected to be placed where <arg 0> was originally found (i.e. at the end of the previous
+/// function's working stack).
 pub struct SOMStack {
-    storage: *mut Val,
     /// How many items are used? Note that the stack has an implicit capacity of [`SOM_STACK_LEN`].
     len: usize,
 }
 
+macro_rules! storage {
+    ($self:ident) => {
+        // We assume that the stack immediately follows the `SOMStack` without padding. This
+        // invariant is enforced in `SOMStack::new`. This saves us having to create a full `Layout`
+        // each time.
+        (Gc::into_raw($self) as *mut u8).add(::std::mem::size_of::<SOMStack>()) as *mut Val
+    };
+}
+
 impl SOMStack {
-    pub fn new() -> SOMStack {
+    pub fn new() -> Gc<Self> {
         #![allow(clippy::cast_ptr_alignment)]
-        let storage = unsafe { alloc(Layout::array::<Val>(SOM_STACK_LEN).unwrap()) as *mut Val };
-        SOMStack { storage, len: 0 }
+        let layout = Layout::new::<Self>();
+        let (layout, off) = layout
+            .extend(Layout::array::<Val>(SOM_STACK_LEN).unwrap())
+            .unwrap();
+        assert_eq!(off, size_of::<usize>());
+        let gc = Gc::<Self>::new_from_layout(layout);
+        unsafe {
+            *(&raw mut *(Gc::into_raw(gc) as *mut Self)) = SOMStack { len: 0 };
+            gc.assume_init()
+        }
     }
 
     /// Returns `true` if the stack contains no elements.
-    pub fn is_empty(&self) -> bool {
+    pub fn is_empty(self: Gc<Self>) -> bool {
         self.len() == 0
     }
 
     /// Returns the number of elements in the stack.
-    pub fn len(&self) -> usize {
+    pub fn len(self: Gc<Self>) -> usize {
         self.len
     }
 
     /// Returns the number of elements the stack can store before running out of room.
-    pub fn remaining_capacity(&self) -> usize {
+    pub fn remaining_capacity(self: Gc<Self>) -> usize {
         SOM_STACK_LEN - self.len()
+    }
+
+    pub unsafe fn addr_of(self: Gc<Self>, n: usize) -> Gc<Val> {
+        Gc::from_raw(storage!(self).add(n))
     }
 
     /// Returns the top-most value of the stack without removing it. If the stack is empty, calling
     /// this function will lead to undefined behaviour.
-    pub fn peek(&self) -> Val {
-        debug_assert!(!self.is_empty());
-        unsafe { ptr::read(self.storage.add(self.len - 1)) }
+    pub fn peek(self: Gc<Self>) -> Val {
+        self.peek_n(0)
+    }
+
+    /// Peeks at a value `n` items from the top of the stack.
+    pub fn peek_at(self: Gc<Self>, off: usize) -> Val {
+        debug_assert!(off < self.len());
+        unsafe { ptr::read(storage!(self).add(off)) }
+    }
+
+    /// Peeks at a value `n` items from the top of the stack.
+    pub fn peek_n(self: Gc<Self>, n: usize) -> Val {
+        debug_assert!(n < self.len());
+        unsafe { ptr::read(storage!(self).add(self.len - n - 1)) }
     }
 
     /// Pops the top-most value of the stack and returns it. If the stack is empty, calling
     /// this function will lead to undefined behaviour.
-    pub fn pop(&mut self) -> Val {
+    pub fn pop(mut self: Gc<Self>) -> Val {
         debug_assert!(!self.is_empty());
         self.len -= 1;
-        unsafe { ptr::read(self.storage.add(self.len)) }
+        unsafe { ptr::read(storage!(self).add(self.len)) }
     }
 
     /// Pops the top-most value of the stack and returns it. If the stack is empty, calling
     /// this function will lead to undefined behaviour.
-    pub fn pop_n(&mut self, n: usize) -> Val {
+    pub fn pop_n(mut self: Gc<Self>, n: usize) -> Val {
         debug_assert!(n < self.len());
         self.len -= 1;
         let i = self.len - n;
-        let v = unsafe { ptr::read(self.storage.add(i)) };
-        unsafe { ptr::copy(self.storage.add(i + 1), self.storage.add(i), n) };
+        let v = unsafe { ptr::read(storage!(self).add(i)) };
+        unsafe { ptr::copy(storage!(self).add(i + 1), storage!(self).add(i), n) };
         v
     }
 
     /// Push `v` onto the end of the stack. You must previously have checked (using
     /// [`SOMStack::remaining_capacity`]) that there is room for this value: if there is not,
     /// undefined behaviour will occur.
-    pub fn push(&mut self, v: Val) {
+    pub fn push(mut self: Gc<Self>, v: Val) {
         debug_assert!(self.remaining_capacity() > 0);
-        unsafe { ptr::write(self.storage.add(self.len), v) };
+        unsafe { ptr::write(storage!(self).add(self.len), v) };
         self.len += 1;
+    }
+
+    pub fn set(self: Gc<Self>, n: usize, v: Val) {
+        debug_assert!(n < self.len());
+        unsafe {
+            ptr::write(storage!(self).add(n), v);
+        }
     }
 
     /// Splits the collection into two at the given index.
@@ -78,10 +134,10 @@ impl SOMStack {
     /// Returns a newly allocated `NormalArray` containing the elements in the range [at, len).
     /// After the call, the SOM stack will be left containing the elements [0, at) with its
     /// previous capacity unchanged.
-    pub fn split_off(&mut self, at: usize) -> Val {
+    pub fn split_off(mut self: Gc<Self>, at: usize) -> Val {
         let arr = unsafe {
             NormalArray::alloc(self.len() - at, |arr_store: *mut Val| {
-                ptr::copy_nonoverlapping(self.storage.add(at), arr_store, self.len() - at);
+                ptr::copy_nonoverlapping(storage!(self).add(at), arr_store, self.len() - at);
             })
         };
         self.len = at;
@@ -89,24 +145,13 @@ impl SOMStack {
     }
 
     /// Shortens the stack, keeping the first len elements and dropping the rest.
-    pub fn truncate(&mut self, len: usize) {
+    pub fn truncate(mut self: Gc<Self>, len: usize) {
         debug_assert!(len <= self.len());
         for i in len..self.len {
             unsafe {
-                ptr::read(self.storage.add(i));
+                ptr::read(storage!(self).add(i));
             }
         }
         self.len = len;
-    }
-}
-
-impl Drop for SOMStack {
-    fn drop(&mut self) {
-        unsafe {
-            dealloc(
-                self.storage as *mut _,
-                Layout::array::<Val>(SOM_STACK_LEN).unwrap(),
-            )
-        };
     }
 }


### PR DESCRIPTION
Previously each function call allocated memory for variables on the heap. This commit moves things so that most variables live and die on the SOM stack. This then enables doing many more operations on the stack, including passing function arguments in on the stack rather than through intermediate `Vec`s (see the comment in `somtack.rs`). This is a substantial speed-up (a little under 2x).

The scheme we use is, more-or-less, that of Lua's. The most approachable explanation I know of is:

  http://www.craftinginterpreters.com/closures.html

though it's not something I'd expect anyone to understand in 5 minutes. The basic idea is that methods (and blocks which don't reference variables in outer methods / closures) don't require any heap allocation of variables. Blocks which reference variables in outer methods / closures pre-allocate memory on the heap and, if necessary, move variables into that memory when the outer method / block completes. More sophisticated schemes are possible, but this scheme has the advantage of relative simplicity.

Note that there is a known case of UB in this code (which Jake and I are musing how best to solve in the longer term): we currently don't have a way of sensibly allowing mutation in interior pointers to `Gc` things, which makes the `UpVar` struct dangerous. In practise, at the moment, I can't observe the UB causing us problems, and I think we'll have a fix for it before it becomes a bigger problem. I think, for the time being, it's probably easiest to review this commit as if that wasn't an issue, as the enabling fix will have to happen in external libraries.