### PR TITLE
Cache a function's blocks

### DIFF
--- a/src/lib/vm/function.rs
+++ b/src/lib/vm/function.rs
@@ -152,6 +152,10 @@ impl Function {
         self.max_stack
     }
 
+    pub fn num_blocks(&self) -> usize {
+        self.block_funcs.len()
+    }
+
     pub fn block_func(&self, idx: usize) -> Gc<Function> {
         debug_assert!(idx < self.block_funcs.len());
         *unsafe { self.block_funcs.get_unchecked(idx) }

--- a/src/lib/vm/somstack.rs
+++ b/src/lib/vm/somstack.rs
@@ -19,7 +19,10 @@ pub const SOM_STACK_LEN: usize = 4096;
 ///   n * 8:     <var 0>
 ///              ...
 ///              <var m>
-///   (n+m) * 8: <working stack>
+///   (n+m)*8:   <block 0>
+///              ...
+///              <block p>
+///   (n+m+p)*8: <working stack>
 ///
 /// The compiler and VM treat <arg 0> as special: it always contains a reference to `self` (hence
 /// all functions have 1 extra parameter over those specified by the user). Functions are expected
@@ -27,7 +30,8 @@ pub const SOM_STACK_LEN: usize = 4096;
 /// to after the arguments but before the variables (i.e. the function will then set up its
 /// variables however it wants). Similarly, when a function is returned, the return value is
 /// expected to be placed where <arg 0> was originally found (i.e. at the end of the previous
-/// function's working stack).
+/// function's working stack). A functions `Block`s are cached after the variables, saving us from
+/// repeatedly allocating `UpVar`s for blocks in tight loops.
 pub struct SOMStack {
     /// How many items are used? Note that the stack has an implicit capacity of [`SOM_STACK_LEN`].
     len: usize,

--- a/src/lib/vm/somstack.rs
+++ b/src/lib/vm/somstack.rs
@@ -72,8 +72,9 @@ impl SOMStack {
         SOM_STACK_LEN - self.len()
     }
 
-    pub unsafe fn addr_of(self: Gc<Self>, n: usize) -> Gc<Val> {
-        Gc::from_raw(storage!(self).add(n))
+    /// Return the address of the variable `off` items from the beginning of the stack.
+    pub unsafe fn addr_of(self: Gc<Self>, off: usize) -> Gc<Val> {
+        Gc::from_raw(storage!(self).add(off))
     }
 
     /// Returns the top-most value of the stack without removing it. If the stack is empty, calling
@@ -82,7 +83,7 @@ impl SOMStack {
         self.peek_n(0)
     }
 
-    /// Peeks at a value `n` items from the top of the stack.
+    /// Peeks at a value `n` items from the beginning of the stack.
     pub fn peek_at(self: Gc<Self>, off: usize) -> Val {
         debug_assert!(off < self.len());
         unsafe { ptr::read(storage!(self).add(off)) }
@@ -122,10 +123,11 @@ impl SOMStack {
         self.len += 1;
     }
 
-    pub fn set(self: Gc<Self>, n: usize, v: Val) {
-        debug_assert!(n < self.len());
+    /// Sets the value `off` items from the beginning of the stack to `v`.
+    pub fn set(self: Gc<Self>, off: usize, v: Val) {
+        debug_assert!(off < self.len());
         unsafe {
-            ptr::write(storage!(self).add(n), v);
+            ptr::write(storage!(self).add(off), v);
         }
     }
 


### PR DESCRIPTION
In functions with tight loops, continually allocating `Block`s (and `UpVar`s) is expensive. It's also unnecessary. Consider this contrived function:

```
    f = ( | x |
        x := 5.
        [x = 0] whileFalse: [
            (x > 2) ifTrue: [x println].
            x := x - 1.
        ].
    )
```

Each time `ifTrue` executes the inner block, it captures the same variables from the outer scope and operates on the same instance: there's no need to continually create a fresh block. This PR thus caches blocks, storing them on the SOM stack just after a function's variables.

How effective this is will depend hugely on a benchmark (a variant of the above program can easily see 30-40% improvement), but it seems to be roughly a 5-10% improvement on realistic benchmarks.