### PR TITLE
Remove the Vec allocation in `Block`.

### DIFF
--- a/src/lib/vm/objects/block.rs
+++ b/src/lib/vm/objects/block.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::new_ret_no_self)]
 
-use std::{collections::hash_map::DefaultHasher, hash::Hasher};
+use std::{alloc::Layout, collections::hash_map::DefaultHasher, hash::Hasher, mem::size_of};
 
 use rboehm::Gc;
 
@@ -54,13 +54,30 @@ impl UpVar {
     }
 }
 
+// Since blocks have a fixed number of upvars, we do not need to allocate a separate vector: we can
+// fit both in a single allocation. We thus use a custom layout where the `Block` comes first,
+// followed immediately by the `UpVar`s. On a 64-bit machine this looks roughly as follows:
+//
+//   0: Inst
+//   8: Val [representing UpVar 0]
+//   16: Val [representing UpVar 1]
+//   ...
+
+macro_rules! upvars_store {
+    ($self:ident) => {
+        // We assume that the pvars immediately follow the `Block` without padding. This invariant
+        // is enforced in `Block::new`. This saves us having to create a full `Layout`, which would
+        // require us having to know how many upvars this particular `Block` has.
+        (Gc::into_raw($self) as *mut u8).add(::std::mem::size_of::<Block>()) as *const Gc<UpVar>
+    };
+}
+
 #[derive(Debug)]
 pub struct Block {
     /// This `Block`'s `self` val. XXX This should probably be part of the corresponding closure's
     /// variables.
     pub inst: Val,
     pub func: Gc<Function>,
-    pub upvars: Vec<Gc<UpVar>>,
     /// For closures which perform a method return (i.e. they cause the method they are contained
     /// within to return), we have to reset the stack to the method's stack base, so we have to
     /// cart that around with the Block.
@@ -97,18 +114,38 @@ impl StaticObjType for Block {
 }
 
 impl Block {
-    pub fn new(
-        _: &mut VM,
+    pub fn new<F>(
+        vm: &mut VM,
         inst: Val,
         func: Gc<Function>,
-        upvars: Vec<Gc<UpVar>>,
         method_stack_base: usize,
-    ) -> Val {
-        Val::from_obj(Block {
-            inst,
-            func,
-            upvars,
-            method_stack_base,
-        })
+        upvars_gen: F,
+    ) -> Val
+    where
+        F: FnOnce(&mut VM, *mut Gc<UpVar>),
+    {
+        let len = func.upvar_defs().len();
+        let (upvars_layout, upvars_dist) = Layout::new::<Val>().repeat(len).unwrap();
+        // We require the Upvars to be laid out as a C-like contiguous array.
+        debug_assert_eq!(upvars_dist, size_of::<Val>());
+        let (layout, upvars_off) = Layout::new::<Block>().extend(upvars_layout).unwrap();
+        // We require the upvars to be positioned immediately after the `Block` with no padding
+        // in-between. This assumption is relied upon by the `upvars!` macro.
+        debug_assert_eq!(upvars_off, size_of::<Block>());
+        unsafe {
+            Val::new_from_layout(layout, |basep: *mut Block| {
+                *basep = Block {
+                    inst,
+                    func,
+                    method_stack_base,
+                };
+                let upvars_store = (basep as *mut u8).add(size_of::<Block>()) as *mut Gc<UpVar>;
+                upvars_gen(vm, upvars_store);
+            })
+        }
+    }
+
+    pub fn upvar(self: Gc<Self>, n: usize) -> Gc<UpVar> {
+        unsafe { *upvars_store!(self).add(n) }
     }
 }

--- a/src/lib/vm/objects/instance.rs
+++ b/src/lib/vm/objects/instance.rs
@@ -17,9 +17,9 @@ pub struct Inst {
 }
 
 // Since instances have a fixed number of instance variables, we do not need to allocate a separate
-// object and backing store: we can fit both in a single block.  We thus use a custom layout where
-// the `Inst` comes first, followed immediately by the `Val`s representing instance variables. On a
-// 64-bit machine this looks roughly as follows:
+// object and backing store: we can fit both in a single allocation. We thus use a custom layout
+// where the `Inst` comes first, followed immediately by the `Val`s representing instance
+// variables. On a 64-bit machine this looks roughly as follows:
 //
 //   0: Inst
 //   8: Val [representing instance field 0]


### PR DESCRIPTION
This is our now "standard" optimisation. However, it can, and does create, cycles which then causes Boehm to warn (endlessly...) that:

```
  GC Warning: Finalization cycle involving 0x7fa72b06aea0
```

In a sense this is really a problem for rboehm, because yksom doesn't define any `Drop` methods, and isn't in danger of violating the "don't call (directly or indirectly) anything with `Gc` in it in a `drop` method". However, until that's fixed, this commit is unmergeable.