### PR TITLE
Add support for rustc_boehm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,9 @@ name = "lang_tests"
 path = "lang_tests/run.rs"
 harness = false
 
+[features]
+rustc_boehm = ["rboehm/rustc_boehm"]
+
 [build-dependencies]
 cfgrammar = "0.9"
 lrlex = "0.9"

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -19,6 +19,7 @@
 #![feature(entry_insert)]
 #![feature(raw_ref_op)]
 #![feature(unsize)]
+#![cfg_attr(feature = "rustc_boehm", feature(gc))]
 #![allow(clippy::cognitive_complexity)]
 #![allow(clippy::float_cmp)]
 #![allow(clippy::missing_safety_doc)]

--- a/src/lib/vm/objects/block.rs
+++ b/src/lib/vm/objects/block.rs
@@ -2,6 +2,9 @@
 
 use std::{collections::hash_map::DefaultHasher, hash::Hasher};
 
+#[cfg(feature = "rustc_boehm")]
+use std::gc::NoFinalize;
+
 use rboehm::Gc;
 
 use crate::vm::{
@@ -66,6 +69,9 @@ pub struct Block {
     /// cart that around with the Block.
     pub method_stack_base: usize,
 }
+
+#[cfg(feature = "rustc_boehm")]
+impl NoFinalize for Block {}
 
 impl Obj for Block {
     fn dyn_objtype(self: Gc<Self>) -> ObjType {

--- a/src/lib/vm/objects/string_.rs
+++ b/src/lib/vm/objects/string_.rs
@@ -7,6 +7,9 @@ use std::{
     str,
 };
 
+#[cfg(feature = "rustc_boehm")]
+use std::gc::NoFinalize;
+
 use rboehm::Gc;
 use smartstring::alias::String as SmartString;
 
@@ -28,6 +31,9 @@ pub struct String_ {
     chars_len: Cell<usize>,
     s: SmartString,
 }
+
+#[cfg(feature = "rustc_boehm")]
+impl NoFinalize for String_ {}
 
 impl Obj for String_ {
     fn dyn_objtype(self: Gc<Self>) -> ObjType {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![feature(allocator_api)]
+#![cfg_attr(feature = "rustc_boehm", feature(gc))]
 #![feature(box_patterns)]
 
 use std::{


### PR DESCRIPTION
This PR adds support for yksom to be used with rustc_boehm. If rustc_boehm is used to build yksom, the `rustc_boehm` feature flag can be passed to enable additional optimizations. E.g.:

`cargo build --release --features "rustc_boehm"`

I've identified two types in yksom which will benefit from the `NoFinalize` marker trait in `rustc_boehm`: `Block`; and `String_`. With that in place, we perform a lot better than ToT in the rebench suite: 

```
----------------------------------------------------------------------------------------------------
  Benchmark     Executor                  Suite   Extra                 #Samples   Mean (ms)
----------------------------------------------------------------------------------------------------
  Bounce        baseline      micro       2      1                      10         109
  Bounce        rustc_boehm   micro       2      1                      10          29
  BubbleSort    baseline      micro       3      1                      10         103
  BubbleSort    rustc_boehm   micro       3      1                      10          31
  DeltaBlue     baseline      macro      50      1                      10         114
  DeltaBlue     rustc_boehm   macro      50      1                      10          24
  Dispatch      baseline      micro       2      1                      10          73
  Dispatch      rustc_boehm   micro       2      1                      10          21
  Fannkuch      baseline      micro       6      1                      10          52
  Fannkuch      rustc_boehm   micro       6      1                      10          17
  Fibonacci     baseline      micro       3      1                      10         237
  Fibonacci     rustc_boehm   micro       3      1                      10          52
  FieldLoop     baseline      micro       1      1                      10          53
  FieldLoop     rustc_boehm   micro       1      1                      10          25
  GraphSearch   baseline      macro       4      1                      10          29
  GraphSearch   rustc_boehm   macro       4      1                      10          11
  IntegerLoop   baseline      micro       2      1                      10         139
  IntegerLoop   rustc_boehm   micro       2      1                      10          34
  JsonSmall     baseline      macro       1      1                      10         105
  JsonSmall     rustc_boehm   macro       1      1                      10          42
  List          baseline      micro       2      1                      10         112
  List          rustc_boehm   micro       2      1                      10          31
  Loop          baseline      micro       5      1                      10         183
  Loop          rustc_boehm   micro       5      1                      10          47
  Mandelbrot    baseline      micro      30      1                      10         182
  Mandelbrot    rustc_boehm   micro      30      1                      10          58
  NBody         baseline      macro     500      1                      10          88
  NBody         rustc_boehm   macro     500      1                      10          41
  PageRank      baseline      macro      40      1                      10         110
  PageRank      rustc_boehm   macro      40      1                      10          35
  Permute       baseline      micro       3      1                      10          96
  Permute       rustc_boehm   micro       3      1                      10          29
  Queens        baseline      micro       2      1                      10          84
  Queens        rustc_boehm   micro       2      1                      10          26
  QuickSort     baseline      micro       1      1                      10          42
  QuickSort     rustc_boehm   micro       1      1                      10          12
  Recurse       baseline      micro       3      1                      10         107
  Recurse       rustc_boehm   micro       3      1                      10          27
  Richards      baseline      macro       1      1                      10        2183
  Richards      rustc_boehm   macro       1      1                      10         637
  Sieve         baseline      micro       4      1                      10         177
  Sieve         rustc_boehm   micro       4      1                      10          47
  Storage       baseline      micro       1      1                      10          57
  Storage       rustc_boehm   micro       1      1                      10          13
  Sum           baseline      micro       2      1                      10          74
  Sum           rustc_boehm   micro       2      1                      10          18
  Towers        baseline      micro       2      1                      10         123
  Towers        rustc_boehm   micro       2      1                      10          31
  TreeSort      baseline      micro       1      1                      10         135
  TreeSort      rustc_boehm   micro       1      1                      10          24
  WhileLoop     baseline      micro      10      1                      10         173
  WhileLoop     rustc_boehm   micro      10      1                      10          45
```
