### PR TITLE
Homogenise as_isize's return types

### DIFF
--- a/src/lib/vm/core.rs
+++ b/src/lib/vm/core.rs
@@ -687,7 +687,7 @@ impl VM {
             }
             Primitive::As32BitSignedValue => {
                 let rcv = self.stack.pop();
-                let i = if let Some(i) = rcv.as_isize(self) {
+                let i = if let Ok(i) = rcv.as_isize(self) {
                     i as i32 as isize
                 } else {
                     rcv.downcast::<ArbInt>(self)
@@ -702,7 +702,7 @@ impl VM {
             }
             Primitive::As32BitUnsignedValue => {
                 let rcv = self.stack.pop();
-                let i = if let Some(i) = rcv.as_isize(self) {
+                let i = if let Ok(i) = rcv.as_isize(self) {
                     i as u32
                 } else {
                     rcv.downcast::<ArbInt>(self)
@@ -790,7 +790,7 @@ impl VM {
                 // integers are unboxed, boxed, or big ints. Just because we can't convert the
                 // value to an isize doesn't mean that the user hasn't handed us an integer: we
                 // have to craft a special error message below to capture this.
-                if let Some(c) = c_val.as_isize(self) {
+                if let Ok(c) = c_val.as_isize(self) {
                     if let Ok(c) = i32::try_from(c) {
                         return SendReturn::Err(VMError::new(self, VMErrorKind::Exit(c)));
                     }

--- a/src/lib/vm/objects/double.rs
+++ b/src/lib/vm/objects/double.rs
@@ -46,7 +46,7 @@ impl Obj for Double {
     }
 
     fn add(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
-        if let Some(rhs) = other.as_isize(vm) {
+        if let Ok(rhs) = other.as_isize(vm) {
             Ok(Double::new(vm, self.val + (rhs as f64)))
         } else if let Some(rhs) = other.try_downcast::<Double>(vm) {
             Ok(Double::new(vm, self.val + rhs.val))
@@ -62,7 +62,7 @@ impl Obj for Double {
     }
 
     fn double_div(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
-        if let Some(rhs) = other.as_isize(vm) {
+        if let Ok(rhs) = other.as_isize(vm) {
             if rhs == 0 {
                 Err(VMError::new(vm, VMErrorKind::DivisionByZero))
             } else {
@@ -90,7 +90,7 @@ impl Obj for Double {
     }
 
     fn modulus(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
-        if let Some(rhs) = other.as_isize(vm) {
+        if let Ok(rhs) = other.as_isize(vm) {
             Ok(Double::new(vm, self.val % (rhs as f64)))
         } else if let Some(rhs) = other.try_downcast::<Double>(vm) {
             Ok(Double::new(vm, self.val % rhs.val))
@@ -106,7 +106,7 @@ impl Obj for Double {
     }
 
     fn mul(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
-        if let Some(rhs) = other.as_isize(vm) {
+        if let Ok(rhs) = other.as_isize(vm) {
             Ok(Double::new(vm, self.val * (rhs as f64)))
         } else if let Some(rhs) = other.try_downcast::<Double>(vm) {
             Ok(Double::new(vm, self.val * rhs.val))
@@ -126,7 +126,7 @@ impl Obj for Double {
     }
 
     fn sub(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
-        if let Some(rhs) = other.as_isize(vm) {
+        if let Ok(rhs) = other.as_isize(vm) {
             Ok(Double::new(vm, self.val - (rhs as f64)))
         } else if let Some(rhs) = other.try_downcast::<Double>(vm) {
             Ok(Double::new(vm, self.val - rhs.val))
@@ -146,7 +146,7 @@ impl Obj for Double {
     }
 
     fn equals(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
-        let b = if let Some(rhs) = other.as_isize(vm) {
+        let b = if let Ok(rhs) = other.as_isize(vm) {
             self.val == (rhs as f64)
         } else if let Some(rhs) = other.try_downcast::<Double>(vm) {
             self.val == rhs.double()
@@ -163,7 +163,7 @@ impl Obj for Double {
     }
 
     fn less_than(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
-        let b = if let Some(rhs) = other.as_isize(vm) {
+        let b = if let Ok(rhs) = other.as_isize(vm) {
             self.val < (rhs as f64)
         } else if let Some(rhs) = other.try_downcast::<Double>(vm) {
             self.val < rhs.double()

--- a/src/lib/vm/objects/integers.rs
+++ b/src/lib/vm/objects/integers.rs
@@ -46,7 +46,7 @@ impl Obj for ArbInt {
     }
 
     fn add(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
-        if let Some(rhs) = other.as_isize(vm) {
+        if let Ok(rhs) = other.as_isize(vm) {
             Ok(ArbInt::new(vm, &self.val + rhs))
         } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
             Ok(ArbInt::new(vm, &self.val + &rhs.val))
@@ -62,7 +62,7 @@ impl Obj for ArbInt {
     }
 
     fn and(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
-        if let Some(rhs) = other.as_isize(vm) {
+        if let Ok(rhs) = other.as_isize(vm) {
             Ok(ArbInt::new(
                 vm,
                 &self.val & BigInt::from_isize(rhs).unwrap(),
@@ -80,7 +80,7 @@ impl Obj for ArbInt {
     }
 
     fn div(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
-        if let Some(rhs) = other.as_isize(vm) {
+        if let Ok(rhs) = other.as_isize(vm) {
             if rhs == 0 {
                 Err(VMError::new(vm, VMErrorKind::DivisionByZero))
             } else {
@@ -107,7 +107,7 @@ impl Obj for ArbInt {
     }
 
     fn double_div(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
-        if let Some(rhs) = other.as_isize(vm) {
+        if let Ok(rhs) = other.as_isize(vm) {
             if rhs == 0 {
                 Err(VMError::new(vm, VMErrorKind::DivisionByZero))
             } else if let Some(lhs) = self.val.to_f64() {
@@ -142,7 +142,7 @@ impl Obj for ArbInt {
     }
 
     fn modulus(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
-        if let Some(rhs) = other.as_isize(vm) {
+        if let Ok(rhs) = other.as_isize(vm) {
             Ok(ArbInt::new(vm, ((&self.val % rhs) + rhs) % rhs))
         } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
             Ok(ArbInt::new(
@@ -164,7 +164,7 @@ impl Obj for ArbInt {
     }
 
     fn mul(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
-        if let Some(rhs) = other.as_isize(vm) {
+        if let Ok(rhs) = other.as_isize(vm) {
             Ok(ArbInt::new(vm, &self.val * rhs))
         } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
             Ok(ArbInt::new(vm, &self.val * &rhs.val))
@@ -184,7 +184,7 @@ impl Obj for ArbInt {
     }
 
     fn shl(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
-        if let Some(rhs) = other.as_isize(vm) {
+        if let Ok(rhs) = other.as_isize(vm) {
             if rhs < 0 {
                 Err(VMError::new(vm, VMErrorKind::NegativeShift))
             } else {
@@ -201,7 +201,7 @@ impl Obj for ArbInt {
     }
 
     fn shr(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
-        if let Some(rhs) = other.as_isize(vm) {
+        if let Ok(rhs) = other.as_isize(vm) {
             if rhs < 0 {
                 Err(VMError::new(vm, VMErrorKind::NegativeShift))
             } else {
@@ -235,7 +235,7 @@ impl Obj for ArbInt {
     }
 
     fn sub(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
-        if let Some(rhs) = other.as_isize(vm) {
+        if let Ok(rhs) = other.as_isize(vm) {
             Ok(ArbInt::new(vm, &self.val - rhs))
         } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
             Ok(ArbInt::new(vm, &self.val - &rhs.val))
@@ -251,7 +251,7 @@ impl Obj for ArbInt {
     }
 
     fn xor(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
-        if let Some(rhs) = other.as_isize(vm) {
+        if let Ok(rhs) = other.as_isize(vm) {
             Ok(ArbInt::new(
                 vm,
                 &self.val ^ BigInt::from_isize(rhs).unwrap(),
@@ -410,7 +410,7 @@ impl Obj for Int {
     }
 
     fn add(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
-        if let Some(rhs) = other.as_isize(vm) {
+        if let Ok(rhs) = other.as_isize(vm) {
             match self.val.checked_add(rhs) {
                 Some(i) => Ok(Val::from_isize(vm, i)),
                 None => Ok(ArbInt::new(vm, BigInt::from_isize(self.val).unwrap() + rhs)),
@@ -429,7 +429,7 @@ impl Obj for Int {
     }
 
     fn div(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
-        if let Some(rhs) = other.as_isize(vm) {
+        if let Ok(rhs) = other.as_isize(vm) {
             if rhs == 0 {
                 Err(VMError::new(vm, VMErrorKind::DivisionByZero))
             } else {
@@ -459,7 +459,7 @@ impl Obj for Int {
     }
 
     fn mul(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
-        if let Some(rhs) = other.as_isize(vm) {
+        if let Ok(rhs) = other.as_isize(vm) {
             match self.val.checked_mul(rhs) {
                 Some(i) => Ok(Val::from_isize(vm, i)),
                 None => Ok(ArbInt::new(vm, BigInt::from_isize(self.val).unwrap() * rhs)),
@@ -478,7 +478,7 @@ impl Obj for Int {
     }
 
     fn sub(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
-        if let Some(rhs) = other.as_isize(vm) {
+        if let Ok(rhs) = other.as_isize(vm) {
             match self.val.checked_sub(rhs) {
                 Some(i) => Ok(Val::from_isize(vm, i)),
                 None => Ok(ArbInt::new(vm, BigInt::from_isize(self.val).unwrap() - rhs)),

--- a/src/lib/vm/val.rs
+++ b/src/lib/vm/val.rs
@@ -241,17 +241,18 @@ impl Val {
     }
 
     /// If this `Val` represents a non-bigint integer, return its value as an `isize`.
-    pub fn as_isize(&self, _: &mut VM) -> Option<isize> {
+    pub fn as_isize(&self, vm: &mut VM) -> Result<isize, Box<VMError>> {
         match self.valkind() {
-            ValKind::GCBOX => unsafe { self.gcbox_to_tobj() }
-                .downcast::<Int>()
-                .map(|tobj| tobj.as_isize()),
+            ValKind::GCBOX => match unsafe { self.gcbox_to_tobj() }.downcast::<Int>() {
+                Some(tobj) => Ok(tobj.as_isize()),
+                None => Err(VMError::new(vm, VMErrorKind::CantRepresentAsIsize)),
+            },
             ValKind::INT => {
                 if self.val & 1 << (BITSIZE - 1) == 0 {
-                    Some((self.val >> TAG_BITSIZE) as isize)
+                    Ok((self.val >> TAG_BITSIZE) as isize)
                 } else {
                     // For negative integers we need to pad the top TAG_BITSIZE bits with 1s.
-                    Some(
+                    Ok(
                         ((self.val >> TAG_BITSIZE) | (TAG_BITMASK << (BITSIZE - TAG_BITSIZE)))
                             as isize,
                     )
@@ -265,7 +266,7 @@ impl Val {
     pub fn as_usize(&self, vm: &mut VM) -> Result<usize, Box<VMError>> {
         match self.valkind() {
             ValKind::GCBOX => match unsafe { self.gcbox_to_tobj() }.downcast::<Int>() {
-                Some(x) => x.as_usize(vm),
+                Some(tobj) => tobj.as_usize(vm),
                 None => Err(VMError::new(vm, VMErrorKind::CantRepresentAsUsize)),
             },
             ValKind::INT => {
@@ -347,8 +348,8 @@ impl Val {
 
     /// Produce a new `Val` which performs a bitwise and operation with `other` and this.
     pub fn and(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
-        if let Some(lhs) = self.as_isize(vm) {
-            if let Some(rhs) = other.as_isize(vm) {
+        if let Ok(lhs) = self.as_isize(vm) {
+            if let Ok(rhs) = other.as_isize(vm) {
                 return Ok(Val::from_isize(vm, lhs & rhs));
             } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
                 return Ok(ArbInt::new(
@@ -369,8 +370,8 @@ impl Val {
 
     /// Produce a new `Val` which divides `other` from this.
     pub fn div(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
-        if let Some(lhs) = self.as_isize(vm) {
-            if let Some(rhs) = other.as_isize(vm) {
+        if let Ok(lhs) = self.as_isize(vm) {
+            if let Ok(rhs) = other.as_isize(vm) {
                 if rhs == 0 {
                     return Err(VMError::new(vm, VMErrorKind::DivisionByZero));
                 } else {
@@ -397,8 +398,8 @@ impl Val {
 
     /// Produce a new `Val` which perfoms a Double divide on `other` with this.
     pub fn double_div(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
-        if let Some(lhs) = self.as_isize(vm) {
-            if let Some(rhs) = other.as_isize(vm) {
+        if let Ok(lhs) = self.as_isize(vm) {
+            if let Ok(rhs) = other.as_isize(vm) {
                 if rhs == 0 {
                     return Err(VMError::new(vm, VMErrorKind::DivisionByZero));
                 } else {
@@ -428,8 +429,8 @@ impl Val {
 
     /// Produce a new `Val` which performs a mod operation on this with `other`.
     pub fn modulus(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
-        if let Some(lhs) = self.as_isize(vm) {
-            if let Some(rhs) = other.as_isize(vm) {
+        if let Ok(lhs) = self.as_isize(vm) {
+            if let Ok(rhs) = other.as_isize(vm) {
                 if rhs == 0 {
                     return Err(VMError::new(vm, VMErrorKind::DivisionByZero));
                 }
@@ -461,8 +462,8 @@ impl Val {
 
     /// Produce a new `Val` which performs a mod operation on this with `other`.
     pub fn remainder(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
-        if let Some(lhs) = self.as_isize(vm) {
-            if let Some(rhs) = other.as_isize(vm) {
+        if let Ok(lhs) = self.as_isize(vm) {
+            if let Ok(rhs) = other.as_isize(vm) {
                 match lhs.checked_rem(rhs) {
                     Some(i) => return Ok(Val::from_isize(vm, i)),
                     None => return Err(VMError::new(vm, VMErrorKind::RemainderError)),
@@ -481,8 +482,8 @@ impl Val {
 
     /// Produce a new `Val` which shifts `self` `other` bits to the left.
     pub fn shl(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
-        if let Some(lhs) = self.as_isize(vm) {
-            if let Some(rhs) = other.as_isize(vm) {
+        if let Ok(lhs) = self.as_isize(vm) {
+            if let Ok(rhs) = other.as_isize(vm) {
                 if rhs < 0 {
                     return Err(VMError::new(vm, VMErrorKind::NegativeShift));
                 } else {
@@ -518,8 +519,8 @@ impl Val {
     /// Produce a new `Val` which shifts `self` `other` bits to the right, treating `self` as if it
     /// did not have a sign bit.
     pub fn shr(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
-        if let Some(lhs) = self.as_isize(vm) {
-            if let Some(rhs) = other.as_isize(vm) {
+        if let Ok(lhs) = self.as_isize(vm) {
+            if let Ok(rhs) = other.as_isize(vm) {
                 if rhs < 0 {
                     return Err(VMError::new(vm, VMErrorKind::NegativeShift));
                 } else {
@@ -540,7 +541,7 @@ impl Val {
 
     /// Produces a new `Val` which is the square root of this.
     pub fn sqrt(&self, vm: &mut VM) -> Result<Val, Box<VMError>> {
-        if let Some(lhs) = self.as_isize(vm) {
+        if let Ok(lhs) = self.as_isize(vm) {
             if lhs < 0 {
                 return Err(VMError::new(vm, VMErrorKind::DomainError));
             } else {
@@ -569,8 +570,8 @@ impl Val {
 
     /// Produce a new `Val` which performs a bitwise xor operation with `other` and this.
     pub fn xor(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
-        if let Some(lhs) = self.as_isize(vm) {
-            if let Some(rhs) = other.as_isize(vm) {
+        if let Ok(lhs) = self.as_isize(vm) {
+            if let Ok(rhs) = other.as_isize(vm) {
                 return Ok(Val::from_isize(vm, lhs ^ rhs));
             } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
                 return Ok(ArbInt::new(
@@ -606,8 +607,8 @@ macro_rules! binop_all {
     ($name:ident, $op:tt, $tf:ident) => {
         impl Val {
             pub fn $name(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
-                if let Some(lhs) = self.as_isize(vm) {
-                    if let Some(rhs) = other.as_isize(vm) {
+                if let Ok(lhs) = self.as_isize(vm) {
+                    if let Ok(rhs) = other.as_isize(vm) {
                         Ok(Val::from_bool(vm, lhs $op rhs))
                     } else if let Some(rhs) = other.try_downcast::<Double>(vm) {
                         Ok(Val::from_bool(vm, (lhs as f64) $op rhs.double()))
@@ -630,8 +631,8 @@ macro_rules! binop_typeerror {
     ($name:ident, $op:tt) => {
         impl Val {
             pub fn $name(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
-                if let Some(lhs) = self.as_isize(vm) {
-                    if let Some(rhs) = other.as_isize(vm) {
+                if let Ok(lhs) = self.as_isize(vm) {
+                    if let Ok(rhs) = other.as_isize(vm) {
                         Ok(Val::from_bool(vm, lhs $op rhs))
                     } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
                         Ok(Val::from_bool(vm,

--- a/src/lib/vm/val.rs
+++ b/src/lib/vm/val.rs
@@ -241,11 +241,9 @@ impl Val {
     }
 
     /// If this `Val` represents a non-bigint integer, return its value as an `isize`.
-    pub fn as_isize(&self, vm: &mut VM) -> Option<isize> {
+    pub fn as_isize(&self, _: &mut VM) -> Option<isize> {
         match self.valkind() {
-            ValKind::GCBOX => self
-                .tobj(vm)
-                .unwrap()
+            ValKind::GCBOX => unsafe { self.gcbox_to_tobj() }
                 .downcast::<Int>()
                 .map(|tobj| tobj.as_isize()),
             ValKind::INT => {
@@ -266,7 +264,7 @@ impl Val {
     /// If this `Val` represents a non-bigint integer, return its value as an `usize`.
     pub fn as_usize(&self, vm: &mut VM) -> Result<usize, Box<VMError>> {
         match self.valkind() {
-            ValKind::GCBOX => match self.tobj(vm).unwrap().downcast::<Int>() {
+            ValKind::GCBOX => match unsafe { self.gcbox_to_tobj() }.downcast::<Int>() {
                 Some(x) => x.as_usize(vm),
                 None => Err(VMError::new(vm, VMErrorKind::CantRepresentAsUsize)),
             },


### PR DESCRIPTION
The main objective of this PR is to  make `Val::as_isize` return `Result<...>`.

This not only brings it in line with as_usize, but means that if the user makes a dynamic type error that passes a non-int to code that calls as_isize, they'll get a backtrace rather than an internal compiler error!

@jacob-hughes It might be interesting for you (and me!) to do a Krun run before and after this PR? The first commit (probably) reduces overhead while the second commit *might* introduce some overhead. [The second commit is arguably a correctness fit, so I wouldn't reject it for performance reasons; but it might still be interesting to know what the overall effect is!]