### PR TITLE
We need to check BigInt::to_f64() for infinity explicitly.

### DIFF
--- a/src/lib/vm/objects/double.rs
+++ b/src/lib/vm/objects/double.rs
@@ -51,10 +51,7 @@ impl Obj for Double {
         } else if let Some(rhs) = other.try_downcast::<Double>(vm) {
             Ok(Double::new(vm, self.val + rhs.val))
         } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
-            match rhs.bigint().to_f64() {
-                Some(i) => Ok(Double::new(vm, self.val + i)),
-                None => Err(VMError::new(vm, VMErrorKind::CantRepresentAsDouble)),
-            }
+            Ok(Double::new(vm, self.val + rhs.to_f64(vm)?))
         } else {
             let got = other.dyn_objtype(vm);
             Err(VMError::new(vm, VMErrorKind::NotANumber { got }))
@@ -78,10 +75,7 @@ impl Obj for Double {
             if Zero::is_zero(rhs.bigint()) {
                 Err(VMError::new(vm, VMErrorKind::DivisionByZero))
             } else {
-                match rhs.bigint().to_f64() {
-                    Some(i) => Ok(Double::new(vm, self.val / i)),
-                    None => Err(VMError::new(vm, VMErrorKind::CantRepresentAsDouble)),
-                }
+                Ok(Double::new(vm, self.val / rhs.to_f64(vm)?))
             }
         } else {
             let got = other.dyn_objtype(vm);
@@ -95,10 +89,7 @@ impl Obj for Double {
         } else if let Some(rhs) = other.try_downcast::<Double>(vm) {
             Ok(Double::new(vm, self.val % rhs.val))
         } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
-            match rhs.bigint().to_f64() {
-                Some(i) => Ok(Double::new(vm, self.val % i)),
-                None => Err(VMError::new(vm, VMErrorKind::CantRepresentAsDouble)),
-            }
+            Ok(Double::new(vm, self.val % rhs.to_f64(vm)?))
         } else {
             let got = other.dyn_objtype(vm);
             Err(VMError::new(vm, VMErrorKind::NotANumber { got }))
@@ -111,10 +102,7 @@ impl Obj for Double {
         } else if let Some(rhs) = other.try_downcast::<Double>(vm) {
             Ok(Double::new(vm, self.val * rhs.val))
         } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
-            match rhs.bigint().to_f64() {
-                Some(i) => Ok(Double::new(vm, self.val * i)),
-                None => Err(VMError::new(vm, VMErrorKind::CantRepresentAsDouble)),
-            }
+            Ok(Double::new(vm, self.val * rhs.to_f64(vm)?))
         } else {
             let got = other.dyn_objtype(vm);
             Err(VMError::new(vm, VMErrorKind::NotANumber { got }))
@@ -131,10 +119,7 @@ impl Obj for Double {
         } else if let Some(rhs) = other.try_downcast::<Double>(vm) {
             Ok(Double::new(vm, self.val - rhs.val))
         } else if let Some(rhs) = other.try_downcast::<ArbInt>(vm) {
-            match rhs.bigint().to_f64() {
-                Some(i) => Ok(Double::new(vm, self.val - i)),
-                None => Err(VMError::new(vm, VMErrorKind::CantRepresentAsDouble)),
-            }
+            Ok(Double::new(vm, self.val - rhs.to_f64(vm)?))
         } else {
             let got = other.dyn_objtype(vm);
             Err(VMError::new(vm, VMErrorKind::NotANumber { got }))


### PR DESCRIPTION
Other SOMs that I've tried error (whether deliberately or not) when a big integer is too big to be represented as a floating point number. The `BigInt::to_f64()` function used to return `None` in such cases but now they always return `Some::(f64::INFINITY)` (see https://github.com/rust-num/num-bigint/pull/163). This PR handles that explicitly.

On the plus side, we can simplify our code a little bit; on the downside we'll also probably be a tiny bit slower in the common case.