### PR TITLE
Minimally add support for arbitrary sized integer constants.

### DIFF
--- a/src/lib/compiler/instrs.rs
+++ b/src/lib/compiler/instrs.rs
@@ -6,6 +6,7 @@ pub struct UpVarDef {
 
 #[derive(Clone, Copy, Debug)]
 pub enum Instr {
+    ArbInt(usize),
     Array(usize),
     Block(usize),
     GlobalLookup(usize),


### PR DESCRIPTION
This is needed to support a recent test added to the SOM test suite.

I could do a more sophisticated job here (such as caching the ArbInt objects), but this is good enough to pass the test suite, which is the first step.