### PR TITLE
yksom takes a while to build so allow up to 30 minutes.

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,6 @@
 status = ["buildbot/buildbot-build-script"]
 
-timeout_sec = 600 # 10 minutes
+timeout_sec = 1800 # 30 minutes
 
 # Have bors delete auto-merged branches
 delete_merged_branches = true


### PR DESCRIPTION
Especially if the build server is performing other tasks at the same time, 10 minutes is starting to cut things a bit fine, and may explain the occasional bors timeouts we've seen recently.