### PR TITLE
Move from rboehm to libgc.

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -25,17 +25,17 @@ cargo run --release -- --cp SOM/Smalltalk SOM/TestSuite/TestHarness.som
 rustup toolchain install nightly --allow-downgrade --component rustfmt
 cargo +nightly fmt --all -- --check
 
-# Build rustc_boehm
-git clone https://github.com/softdevteam/rustc_boehm
-mkdir -p rustc_boehm/build/rustc_boehm
-(cd rustc_boehm && ./x.py build --config ../.buildbot.config.toml)
+# Build rustgc
+git clone https://github.com/softdevteam/rustgc
+mkdir -p rustgc/build/rustgc
+(cd rustgc && ./x.py build --config ../.buildbot.config.toml)
 
-rustup toolchain link rustc_boehm rustc_boehm/build/x86_64-unknown-linux-gnu/stage1
+rustup toolchain link rustgc rustgc/build/x86_64-unknown-linux-gnu/stage1
 
 cargo clean
 
-cargo +rustc_boehm test --features "rustc_boehm"
-cargo +rustc_boehm test --release --features "rustc_boehm"
+cargo +rustgc test --features "rustgc"
+cargo +rustgc test --release --features "rustgc"
 
-cargo +rustc_boehm run --features "rustc_boehm" -- --cp SOM/Smalltalk SOM/TestSuite/TestHarness.som
-cargo +rustc_boehm run --features "rustc_boehm" --release -- --cp SOM/Smalltalk SOM/TestSuite/TestHarness.som
+cargo +rustgc run --features "rustgc" -- --cp SOM/Smalltalk SOM/TestSuite/TestHarness.som
+cargo +rustgc run --features "rustgc" --release -- --cp SOM/Smalltalk SOM/TestSuite/TestHarness.som

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ path = "lang_tests/run.rs"
 harness = false
 
 [features]
-rustc_boehm = ["rboehm/rustc_boehm"]
+rustgc = ["libgc/rustgc"]
 krun_harness = ["libc"]
 
 [build-dependencies]
@@ -35,14 +35,14 @@ lazy_static = "1.3"
 regex = "1.1"
 
 [dependencies]
-rboehm = { git = "https://github.com/softdevteam/rboehm", features=["use_boehm"] }
 arrayvec = "0.5"
 cfgrammar = "0.9"
 getopts = "0.2"
 itertools = "0.9"
+libgc = { git = "https://github.com/softdevteam/libgc" }
 lrlex = "0.9"
 lrpar = "0.9"
-natrob = { git="https://github.com/softdevteam/natrob", features=["rboehm"] }
+natrob = { git="https://github.com/softdevteam/natrob", features=["libgc"] }
 num-bigint = "0.3"
 num-integer = "0.1"
 num_enum = "0.5"

--- a/src/lib/compiler/ast_to_instrs.rs
+++ b/src/lib/compiler/ast_to_instrs.rs
@@ -5,9 +5,9 @@ use std::{
 };
 
 use itertools::Itertools;
+use libgc::Gc;
 use lrpar::{NonStreamingLexer, Span};
 use num_bigint::BigInt;
-use rboehm::Gc;
 use smartstring::alias::String as SmartString;
 
 use crate::{

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -19,7 +19,7 @@
 #![feature(entry_insert)]
 #![feature(raw_ref_op)]
 #![feature(unsize)]
-#![cfg_attr(feature = "rustc_boehm", feature(gc))]
+#![cfg_attr(feature = "rustgc", feature(gc))]
 #![allow(clippy::cognitive_complexity)]
 #![allow(clippy::float_cmp)]
 #![allow(clippy::missing_safety_doc)]

--- a/src/lib/vm/core.rs
+++ b/src/lib/vm/core.rs
@@ -10,9 +10,9 @@ use std::{
     time::Instant,
 };
 
+use libgc::Gc;
 use lrpar::Span;
 use num_bigint::BigInt;
-use rboehm::Gc;
 use smartstring::alias::String as SmartString;
 use static_assertions::const_assert;
 

--- a/src/lib/vm/error.rs
+++ b/src/lib/vm/error.rs
@@ -1,7 +1,7 @@
 use std::{fs::read_to_string, io::stderr};
 
+use libgc::Gc;
 use lrpar::Span;
-use rboehm::Gc;
 use smartstring::alias::String as SmartString;
 use termion::{is_tty, style};
 

--- a/src/lib/vm/function.rs
+++ b/src/lib/vm/function.rs
@@ -1,6 +1,6 @@
 use std::cell::Cell;
 
-use rboehm::Gc;
+use libgc::Gc;
 
 use crate::{
     compiler::instrs::{Primitive, UpVarDef},

--- a/src/lib/vm/objects/array.rs
+++ b/src/lib/vm/objects/array.rs
@@ -5,7 +5,7 @@ use std::{
     mem::size_of, ptr::copy_nonoverlapping,
 };
 
-use rboehm::Gc;
+use libgc::Gc;
 
 use crate::vm::{
     core::VM,

--- a/src/lib/vm/objects/block.rs
+++ b/src/lib/vm/objects/block.rs
@@ -2,10 +2,10 @@
 
 use std::{collections::hash_map::DefaultHasher, hash::Hasher};
 
-#[cfg(feature = "rustc_boehm")]
+#[cfg(feature = "rustgc")]
 use std::gc::NoFinalize;
 
-use rboehm::Gc;
+use libgc::Gc;
 
 use crate::vm::{
     core::VM,
@@ -70,7 +70,7 @@ pub struct Block {
     pub method_stack_base: usize,
 }
 
-#[cfg(feature = "rustc_boehm")]
+#[cfg(feature = "rustgc")]
 impl NoFinalize for Block {}
 
 impl Obj for Block {

--- a/src/lib/vm/objects/class.rs
+++ b/src/lib/vm/objects/class.rs
@@ -8,7 +8,7 @@ use std::{
     str,
 };
 
-use rboehm::Gc;
+use libgc::Gc;
 use smartstring::alias::String as SmartString;
 
 use crate::vm::{

--- a/src/lib/vm/objects/double.rs
+++ b/src/lib/vm/objects/double.rs
@@ -2,9 +2,9 @@
 
 use std::{collections::hash_map::DefaultHasher, hash::Hasher};
 
+use libgc::Gc;
 use num_bigint::BigInt;
 use num_traits::{FromPrimitive, ToPrimitive, Zero};
-use rboehm::Gc;
 use smartstring::alias::String as SmartString;
 
 use crate::vm::{

--- a/src/lib/vm/objects/instance.rs
+++ b/src/lib/vm/objects/instance.rs
@@ -2,7 +2,7 @@
 
 use std::{alloc::Layout, collections::hash_map::DefaultHasher, hash::Hasher, mem::size_of};
 
-use rboehm::Gc;
+use libgc::Gc;
 
 use crate::vm::{
     core::VM,

--- a/src/lib/vm/objects/integers.rs
+++ b/src/lib/vm/objects/integers.rs
@@ -13,9 +13,9 @@
 
 use std::convert::TryFrom;
 
+use libgc::Gc;
 use num_bigint::BigInt;
 use num_traits::{FromPrimitive, Signed, ToPrimitive, Zero};
-use rboehm::Gc;
 
 use crate::vm::{
     core::VM,

--- a/src/lib/vm/objects/method.rs
+++ b/src/lib/vm/objects/method.rs
@@ -2,7 +2,7 @@
 
 use std::{cell::Cell, collections::hash_map::DefaultHasher, hash::Hasher};
 
-use rboehm::Gc;
+use libgc::Gc;
 
 use crate::vm::{
     core::VM,

--- a/src/lib/vm/objects/mod.rs
+++ b/src/lib/vm/objects/mod.rs
@@ -38,8 +38,8 @@ pub use integers::{ArbInt, Int};
 pub use method::Method;
 pub use string_::String_;
 
-use natrob::narrowable_rboehm;
-use rboehm::Gc;
+use libgc::Gc;
+use natrob::narrowable_libgc;
 
 use crate::vm::{
     core::VM,
@@ -79,7 +79,7 @@ impl ObjType {
 
 /// The main SOM Object trait. Notice that code should almost never call these functions directly:
 /// you should instead call the equivalent function in the `Val` struct.
-#[narrowable_rboehm(ThinObj)]
+#[narrowable_libgc(ThinObj)]
 pub trait Obj: std::fmt::Debug {
     /// What `ObjType` does this `Val` represent?
     fn dyn_objtype(self: Gc<Self>) -> ObjType;

--- a/src/lib/vm/objects/string_.rs
+++ b/src/lib/vm/objects/string_.rs
@@ -7,10 +7,10 @@ use std::{
     str,
 };
 
-#[cfg(feature = "rustc_boehm")]
+#[cfg(feature = "rustgc")]
 use std::gc::NoFinalize;
 
-use rboehm::Gc;
+use libgc::Gc;
 use smartstring::alias::String as SmartString;
 
 use crate::vm::{
@@ -32,7 +32,7 @@ pub struct String_ {
     s: SmartString,
 }
 
-#[cfg(feature = "rustc_boehm")]
+#[cfg(feature = "rustgc")]
 impl NoFinalize for String_ {}
 
 impl Obj for String_ {

--- a/src/lib/vm/somstack.rs
+++ b/src/lib/vm/somstack.rs
@@ -1,6 +1,6 @@
 use std::{alloc::Layout, mem::size_of, ptr};
 
-use rboehm::Gc;
+use libgc::Gc;
 
 use crate::vm::{objects::NormalArray, val::Val};
 

--- a/src/lib/vm/val.rs
+++ b/src/lib/vm/val.rs
@@ -9,10 +9,10 @@ use std::{
     ops::Deref,
 };
 
+use libgc::{self, Gc};
 use num_bigint::BigInt;
 use num_enum::{IntoPrimitive, UnsafeFromPrimitive};
 use num_traits::{FromPrimitive, ToPrimitive};
-use rboehm::{self, Gc};
 
 use super::{
     core::VM,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 #![feature(allocator_api)]
-#![cfg_attr(feature = "rustc_boehm", feature(gc))]
+#![cfg_attr(feature = "rustgc", feature(gc))]
 #![feature(box_patterns)]
 
 use std::{
@@ -18,10 +18,10 @@ use yksom::vm::{
     VMError, VMErrorKind, VM,
 };
 
-use rboehm::BoehmAllocator;
+use libgc::GcAllocator;
 
 #[global_allocator]
-static ALLOCATOR: BoehmAllocator = BoehmAllocator;
+static ALLOCATOR: GcAllocator = GcAllocator;
 
 fn usage(prog: &str) -> ! {
     let path = Path::new(prog);


### PR DESCRIPTION
This PR tries to move yksom from `rboehm` to `libgc`. However it fails to compile with:

```   Compiling libgc v0.1.0 (/home/ltratt/libgc)
error[E0603]: trait `GlobalAlloc` is private
  --> src/lib.rs:23:25
   |
23 | pub use libgc_internal::GlobalAlloc;
   |                         ^^^^^^^^^^^ private trait
   |
note: the trait `GlobalAlloc` is defined here
  --> /home/ltratt/.cargo/git/checkouts/libgc_internal-b80cf56d30ac30df/7e79d84/src/lib.rs:14:36
   |
14 |     alloc::{AllocError, Allocator, GlobalAlloc, Layout},
   |                                    ^^^^^^^^^^^

error[E0603]: trait `GlobalAlloc` is private
  --> src/lib.rs:23:25
   |
23 | pub use libgc_internal::GlobalAlloc;
   |                         ^^^^^^^^^^^ private trait
   |
note: the trait `GlobalAlloc` is defined here
  --> /home/ltratt/.cargo/git/checkouts/libgc_internal-b80cf56d30ac30df/7e79d84/src/lib.rs:14:36
   |
14 |     alloc::{AllocError, Allocator, GlobalAlloc, Layout},
   |                                    ^^^^^^^^^^^

warning: trait objects without an explicit `dyn` are deprecated
   --> src/gc.rs:323:23
    |
323 |         let s1gcd: Gc<T> = s1gc;
    |                       ^ help: use `dyn`: `dyn T`
    |
    = note: `#[warn(bare_trait_objects)]` on by default

warning: trait objects without an explicit `dyn` are deprecated
   --> src/gc.rs:324:23
    |
324 |         let s2gcd: Gc<T> = s2gc;
    |                       ^ help: use `dyn`: `dyn T`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0603`.
error: aborting due to previous error; 2 warnings emitted

For more information about this error, try `rustc --explain E0603`.
error: could not compile `libgc`

To learn more, run the command again with --verbose.
warning: build failed, waiting for other jobs to finish...
error: build failed
```

I wonder if this is because `libgc` should be using `#[global_allocator]` or similar?