### PR TITLE
Fix yksom after libgc changes

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -16,12 +16,6 @@ sh rustup.sh --default-host x86_64-unknown-linux-gnu \
     -y
 export PATH=`pwd`/.cargo/bin/:$PATH
 
-cargo test
-cargo test --release
-
-cargo run -- --cp SOM/Smalltalk SOM/TestSuite/TestHarness.som
-cargo run --release -- --cp SOM/Smalltalk SOM/TestSuite/TestHarness.som
-
 rustup toolchain install nightly --allow-downgrade --component rustfmt
 cargo +nightly fmt --all -- --check
 
@@ -34,8 +28,8 @@ rustup toolchain link rustgc rustgc/build/x86_64-unknown-linux-gnu/stage1
 
 cargo clean
 
-cargo +rustgc test --features "rustgc"
-cargo +rustgc test --release --features "rustgc"
+cargo +rustgc test
+cargo +rustgc test --release
 
-cargo +rustgc run --features "rustgc" -- --cp SOM/Smalltalk SOM/TestSuite/TestHarness.som
-cargo +rustgc run --features "rustgc" --release -- --cp SOM/Smalltalk SOM/TestSuite/TestHarness.som
+cargo +rustgc run  -- --cp SOM/Smalltalk SOM/TestSuite/TestHarness.som
+cargo +rustgc run --release -- --cp SOM/Smalltalk SOM/TestSuite/TestHarness.som

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ path = "lang_tests/run.rs"
 harness = false
 
 [features]
-rustgc = ["libgc/rustgc"]
 krun_harness = ["libc"]
 
 [build-dependencies]

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -27,6 +27,7 @@
 #![allow(clippy::new_without_default)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::type_complexity)]
+#![allow(where_clauses_object_safety)]
 
 pub mod compiler;
 pub mod vm;

--- a/src/lib/vm/core.rs
+++ b/src/lib/vm/core.rs
@@ -452,7 +452,7 @@ impl VM {
                             {
                                 // Create a new UpVar.
                                 uv = Some(Gc::new(UpVar::new(uv, Gc::from_raw(local_ptr))));
-                                if let Some(mut prev_uw) = prev {
+                                if let Some(prev_uw) = prev {
                                     // Insert it in the list.
                                     prev_uw.set_prev(uv);
                                 } else {
@@ -1273,7 +1273,7 @@ impl VM {
     /// `stack_base`.
     fn close_vars(&mut self, stack_base: usize) {
         while self.open_upvars.is_some() {
-            let mut uv = self.open_upvars.unwrap();
+            let uv = self.open_upvars.unwrap();
             debug_assert!(!uv.is_closed());
             if Gc::into_raw(uv.to_gc()) < Gc::into_raw(unsafe { self.stack.addr_of(stack_base) }) {
                 break;

--- a/src/lib/vm/objects/array.rs
+++ b/src/lib/vm/objects/array.rs
@@ -14,21 +14,29 @@ use crate::vm::{
     val::{NotUnboxable, Val},
 };
 
-pub trait Array {
+pub trait Array: Send {
     /// Return the item at index `idx` (using SOM indexing starting at 1) or an error if the index
     /// is invalid.
-    fn at(self: Gc<Self>, vm: &VM, idx: usize) -> Result<Val, Box<VMError>>;
+    fn at(self: Gc<Self>, vm: &VM, idx: usize) -> Result<Val, Box<VMError>>
+    where
+        Self: Send;
 
     /// Return the item at index `idx` (using SOM indexing starting at 1). This will lead to
     /// undefined behaviour if the index is invalid.
-    unsafe fn unchecked_at(self: Gc<Self>, idx: usize) -> Val;
+    unsafe fn unchecked_at(self: Gc<Self>, idx: usize) -> Val
+    where
+        Self: Send;
 
     /// Set the item at index `idx` (using SOM indexing starting at 1) to `val` or return an error
     /// if the index is invalid.
-    fn at_put(self: Gc<Self>, vm: &mut VM, idx: usize, val: Val) -> Result<(), Box<VMError>>;
+    fn at_put(self: Gc<Self>, vm: &mut VM, idx: usize, val: Val) -> Result<(), Box<VMError>>
+    where
+        Self: Send;
 
     /// Iterate over this array's values.
-    fn iter(self: Gc<Self>) -> ArrayIterator;
+    fn iter(self: Gc<Self>) -> ArrayIterator
+    where
+        Self: Send;
 }
 
 #[derive(Debug)]
@@ -184,25 +192,40 @@ pub struct MethodsArray {
 }
 
 impl Obj for MethodsArray {
-    fn dyn_objtype(self: Gc<Self>) -> ObjType {
+    fn dyn_objtype(self: Gc<Self>) -> ObjType
+    where
+        Self: Send,
+    {
         ObjType::Array
     }
 
-    fn get_class(self: Gc<Self>, vm: &mut VM) -> Val {
+    fn get_class(self: Gc<Self>, vm: &mut VM) -> Val
+    where
+        Self: Send,
+    {
         vm.array_cls
     }
 
-    fn to_array(self: Gc<Self>) -> Result<Gc<dyn Array>, Box<VMError>> {
+    fn to_array(self: Gc<Self>) -> Result<Gc<dyn Array>, Box<VMError>>
+    where
+        Self: Send,
+    {
         Ok(self)
     }
 
-    fn hashcode(self: Gc<Self>) -> u64 {
+    fn hashcode(self: Gc<Self>) -> u64
+    where
+        Self: Send,
+    {
         let mut hasher = DefaultHasher::new();
         hasher.write_usize(Gc::into_raw(self) as *const _ as usize);
         hasher.finish()
     }
 
-    fn length(self: Gc<Self>) -> usize {
+    fn length(self: Gc<Self>) -> usize
+    where
+        Self: Send,
+    {
         let store = unsafe { &*self.store.get() };
         store.len()
     }

--- a/src/lib/vm/objects/block.rs
+++ b/src/lib/vm/objects/block.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::new_ret_no_self)]
 
-use std::{collections::hash_map::DefaultHasher, hash::Hasher, cell::Cell};
+use std::{cell::Cell, collections::hash_map::DefaultHasher, hash::Hasher};
 
 #[cfg(feature = "rustgc")]
 use std::gc::NoFinalize;
@@ -41,7 +41,8 @@ impl UpVar {
 
     pub fn close(&self) {
         self.closed.set(*self.to_gc());
-        self.ptr.set(Gc::from_raw(&self.closed as *const Cell<_> as *const _));
+        self.ptr
+            .set(Gc::from_raw(&self.closed as *const Cell<_> as *const _));
     }
 
     pub fn is_closed(&self) -> bool {

--- a/src/lib/vm/objects/mod.rs
+++ b/src/lib/vm/objects/mod.rs
@@ -80,30 +80,46 @@ impl ObjType {
 /// The main SOM Object trait. Notice that code should almost never call these functions directly:
 /// you should instead call the equivalent function in the `Val` struct.
 #[narrowable_libgc(ThinObj)]
-pub trait Obj: std::fmt::Debug {
+pub trait Obj: std::fmt::Debug + Send {
     /// What `ObjType` does this `Val` represent?
-    fn dyn_objtype(self: Gc<Self>) -> ObjType;
+    fn dyn_objtype(self: Gc<Self>) -> ObjType
+    where
+        Self: Send;
     /// What class is this object an instance of?
-    fn get_class(self: Gc<Self>, vm: &mut VM) -> Val;
+    fn get_class(self: Gc<Self>, vm: &mut VM) -> Val
+    where
+        Self: Send;
 
     /// If (and only if) this object implements the [Array] trait then return a reference to this
     /// object as an [Array] trait object.
-    fn to_array(self: Gc<Self>) -> Result<Gc<dyn Array>, Box<VMError>> {
+    fn to_array(self: Gc<Self>) -> Result<Gc<dyn Array>, Box<VMError>>
+    where
+        Self: Send,
+    {
         todo!();
     }
 
     /// Convert this object to a `Val` that represents a SOM string.
-    fn to_strval(self: Gc<Self>, _: &mut VM) -> Result<Val, Box<VMError>> {
+    fn to_strval(self: Gc<Self>, _: &mut VM) -> Result<Val, Box<VMError>>
+    where
+        Self: Send,
+    {
         unreachable!();
     }
 
     /// How many instance variables does this object contain?
-    fn num_inst_vars(self: Gc<Self>, _: &VM) -> usize {
+    fn num_inst_vars(self: Gc<Self>, _: &VM) -> usize
+    where
+        Self: Send,
+    {
         unreachable!();
     }
 
     /// Return the instance variable at `i` (using SOM indexing).
-    fn inst_var_at(self: Gc<Self>, vm: &VM, i: usize) -> Result<Val, Box<VMError>> {
+    fn inst_var_at(self: Gc<Self>, vm: &VM, i: usize) -> Result<Val, Box<VMError>>
+    where
+        Self: Send,
+    {
         if i > 0 && i <= self.num_inst_vars(vm) {
             Ok(unsafe { self.unchecked_inst_var_get(vm, i - 1) })
         } else {
@@ -118,7 +134,10 @@ pub trait Obj: std::fmt::Debug {
     }
 
     /// Return the instance variable at `i` (using SOM indexing).
-    fn inst_var_at_put(self: Gc<Self>, vm: &VM, i: usize, v: Val) -> Result<(), Box<VMError>> {
+    fn inst_var_at_put(self: Gc<Self>, vm: &VM, i: usize, v: Val) -> Result<(), Box<VMError>>
+    where
+        Self: Send,
+    {
         if i > 0 && i <= self.num_inst_vars(vm) {
             unsafe { self.unchecked_inst_var_set(vm, i - 1, v) };
             Ok(())
@@ -135,89 +154,140 @@ pub trait Obj: std::fmt::Debug {
 
     /// Lookup an instance variable in this object. If `usize` exceeds the number of instance
     /// variables this will lead to undefined behaviour.
-    unsafe fn unchecked_inst_var_get(self: Gc<Self>, _: &VM, _: usize) -> Val {
+    unsafe fn unchecked_inst_var_get(self: Gc<Self>, _: &VM, _: usize) -> Val
+    where
+        Self: Send,
+    {
         unreachable!();
     }
 
     /// Set an instance variable in this object. If `usize` exceeds the number of instance
     /// variables this will lead to undefined behaviour.
-    unsafe fn unchecked_inst_var_set(self: Gc<Self>, _: &VM, _: usize, _: Val) {
+    unsafe fn unchecked_inst_var_set(self: Gc<Self>, _: &VM, _: usize, _: Val)
+    where
+        Self: Send,
+    {
         unreachable!();
     }
 
     /// What is this object's length?
-    fn length(self: Gc<Self>) -> usize {
+    fn length(self: Gc<Self>) -> usize
+    where
+        Self: Send,
+    {
         unreachable!();
     }
 
     /// What is this object's hashcode?
-    fn hashcode(self: Gc<Self>) -> u64 {
+    fn hashcode(self: Gc<Self>) -> u64
+    where
+        Self: Send,
+    {
         unreachable!();
     }
 
     /// Produce a new `Val` which adds `other` to this.
-    fn add(self: Gc<Self>, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
+    fn add(self: Gc<Self>, _: &mut VM, _: Val) -> Result<Val, Box<VMError>>
+    where
+        Self: Send,
+    {
         unreachable!();
     }
 
     /// Produce a new `Val` which performs a bitwise and with `other` and this.
-    fn and(self: Gc<Self>, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
+    fn and(self: Gc<Self>, _: &mut VM, _: Val) -> Result<Val, Box<VMError>>
+    where
+        Self: Send,
+    {
         unreachable!();
     }
 
     /// Produce a new `Val` which divides `other` from this.
-    fn div(self: Gc<Self>, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
+    fn div(self: Gc<Self>, _: &mut VM, _: Val) -> Result<Val, Box<VMError>>
+    where
+        Self: Send,
+    {
         unreachable!();
     }
 
-    fn double_div(self: Gc<Self>, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
+    fn double_div(self: Gc<Self>, _: &mut VM, _: Val) -> Result<Val, Box<VMError>>
+    where
+        Self: Send,
+    {
         unreachable!();
     }
 
     /// Produce a new `Val` which performs a mod operation on this with `other`.
-    fn modulus(self: Gc<Self>, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
+    fn modulus(self: Gc<Self>, _: &mut VM, _: Val) -> Result<Val, Box<VMError>>
+    where
+        Self: Send,
+    {
         unreachable!();
     }
 
     /// Produce a new `Val` which multiplies `other` to this.
-    fn mul(self: Gc<Self>, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
+    fn mul(self: Gc<Self>, _: &mut VM, _: Val) -> Result<Val, Box<VMError>>
+    where
+        Self: Send,
+    {
         unreachable!();
     }
 
     /// Produce a new `Val` which returns the remainder of dividing this with `other`.
-    fn remainder(self: Gc<Self>, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
+    fn remainder(self: Gc<Self>, _: &mut VM, _: Val) -> Result<Val, Box<VMError>>
+    where
+        Self: Send,
+    {
         unreachable!();
     }
 
     /// Produce a new `Val` which shifts `self` `other` bits to the left.
-    fn shl(self: Gc<Self>, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
+    fn shl(self: Gc<Self>, _: &mut VM, _: Val) -> Result<Val, Box<VMError>>
+    where
+        Self: Send,
+    {
         unreachable!();
     }
 
     /// Produce a new `Val` which shifts `self` `other` bits to the right, treating `self` as if it
     /// did not have a sign bit.
-    fn shr(self: Gc<Self>, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
+    fn shr(self: Gc<Self>, _: &mut VM, _: Val) -> Result<Val, Box<VMError>>
+    where
+        Self: Send,
+    {
         unreachable!();
     }
 
     /// Produces a new `Val` which is the square root of this.
-    fn sqrt(self: Gc<Self>, _: &mut VM) -> Result<Val, Box<VMError>> {
+    fn sqrt(self: Gc<Self>, _: &mut VM) -> Result<Val, Box<VMError>>
+    where
+        Self: Send,
+    {
         unreachable!();
     }
 
     /// Produce a new `Val` which subtracts `other` from this.
-    fn sub(self: Gc<Self>, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
+    fn sub(self: Gc<Self>, _: &mut VM, _: Val) -> Result<Val, Box<VMError>>
+    where
+        Self: Send,
+    {
         unreachable!();
     }
 
     /// Produce a new `Val` which performs a bitwise xor with `other` and this
-    fn xor(self: Gc<Self>, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
+    fn xor(self: Gc<Self>, _: &mut VM, _: Val) -> Result<Val, Box<VMError>>
+    where
+        Self: Send,
+    {
         unreachable!();
     }
 
     /// Is this `Val` reference equality equal to `other`? Only immutable SOM types are likely to
     /// want to override this.
-    fn ref_equals(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
+    fn ref_equals(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>>
+    where
+        Self: Send,
+    {
         let other_tobj = other.tobj(vm)?;
         let other_data =
             unsafe { std::mem::transmute::<&dyn Obj, (*const u8, usize)>(&**other_tobj).0 };
@@ -228,32 +298,50 @@ pub trait Obj: std::fmt::Debug {
     }
 
     /// Does this `Val` equal `other`?
-    fn equals(self: Gc<Self>, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
+    fn equals(self: Gc<Self>, _: &mut VM, _: Val) -> Result<Val, Box<VMError>>
+    where
+        Self: Send,
+    {
         unreachable!();
     }
 
     /// Does this `Val` not equal `other`?
-    fn not_equals(self: Gc<Self>, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
+    fn not_equals(self: Gc<Self>, _: &mut VM, _: Val) -> Result<Val, Box<VMError>>
+    where
+        Self: Send,
+    {
         unreachable!();
     }
 
     /// Is this `Val` greater than `other`?
-    fn greater_than(self: Gc<Self>, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
+    fn greater_than(self: Gc<Self>, _: &mut VM, _: Val) -> Result<Val, Box<VMError>>
+    where
+        Self: Send,
+    {
         unreachable!();
     }
 
     /// Is this `Val` greater than or equal to `other`?
-    fn greater_than_equals(self: Gc<Self>, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
+    fn greater_than_equals(self: Gc<Self>, _: &mut VM, _: Val) -> Result<Val, Box<VMError>>
+    where
+        Self: Send,
+    {
         unreachable!();
     }
 
     /// Is this `Val` less than `other`?
-    fn less_than(self: Gc<Self>, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
+    fn less_than(self: Gc<Self>, _: &mut VM, _: Val) -> Result<Val, Box<VMError>>
+    where
+        Self: Send,
+    {
         unreachable!();
     }
 
     /// Is this `Val` less than or equal to `other`?
-    fn less_than_equals(self: Gc<Self>, _: &mut VM, _: Val) -> Result<Val, Box<VMError>> {
+    fn less_than_equals(self: Gc<Self>, _: &mut VM, _: Val) -> Result<Val, Box<VMError>>
+    where
+        Self: Send,
+    {
         unreachable!();
     }
 }

--- a/src/lib/vm/somstack.rs
+++ b/src/lib/vm/somstack.rs
@@ -1,4 +1,4 @@
-use std::{alloc::Layout, mem::size_of, ptr};
+use std::{alloc::Layout, mem::size_of, ptr, cell::Cell};
 
 use libgc::Gc;
 

--- a/src/lib/vm/somstack.rs
+++ b/src/lib/vm/somstack.rs
@@ -1,4 +1,4 @@
-use std::{alloc::Layout, mem::size_of, ptr, cell::Cell};
+use std::{alloc::Layout, cell::Cell, mem::size_of, ptr};
 
 use libgc::Gc;
 
@@ -30,7 +30,7 @@ pub const SOM_STACK_LEN: usize = 4096;
 /// function's working stack).
 pub struct SOMStack {
     /// How many items are used? Note that the stack has an implicit capacity of [`SOM_STACK_LEN`].
-    len: usize,
+    len: Cell<usize>,
 }
 
 macro_rules! storage {
@@ -52,7 +52,7 @@ impl SOMStack {
         assert_eq!(off, size_of::<usize>());
         let gc = Gc::<Self>::new_from_layout(layout);
         unsafe {
-            *(&raw mut *(Gc::into_raw(gc) as *mut Self)) = SOMStack { len: 0 };
+            *(&raw mut *(Gc::into_raw(gc) as *mut Self)) = SOMStack { len: Cell::new(0) };
             gc.assume_init()
         }
     }
@@ -64,7 +64,7 @@ impl SOMStack {
 
     /// Returns the number of elements in the stack.
     pub fn len(self: Gc<Self>) -> usize {
-        self.len
+        self.len.get()
     }
 
     /// Returns the number of elements the stack can store before running out of room.
@@ -91,23 +91,23 @@ impl SOMStack {
     /// Peeks at a value `n` items from the top of the stack.
     pub fn peek_n(self: Gc<Self>, n: usize) -> Val {
         debug_assert!(n < self.len());
-        unsafe { ptr::read(storage!(self).add(self.len - n - 1)) }
+        unsafe { ptr::read(storage!(self).add(self.len() - n - 1)) }
     }
 
     /// Pops the top-most value of the stack and returns it. If the stack is empty, calling
     /// this function will lead to undefined behaviour.
-    pub fn pop(mut self: Gc<Self>) -> Val {
+    pub fn pop(self: Gc<Self>) -> Val {
         debug_assert!(!self.is_empty());
-        self.len -= 1;
-        unsafe { ptr::read(storage!(self).add(self.len)) }
+        self.len.set(self.len() - 1);
+        unsafe { ptr::read(storage!(self).add(self.len())) }
     }
 
     /// Pops the top-most value of the stack and returns it. If the stack is empty, calling
     /// this function will lead to undefined behaviour.
-    pub fn pop_n(mut self: Gc<Self>, n: usize) -> Val {
+    pub fn pop_n(self: Gc<Self>, n: usize) -> Val {
         debug_assert!(n < self.len());
-        self.len -= 1;
-        let i = self.len - n;
+        self.len.set(self.len() - 1);
+        let i = self.len() - n;
         let v = unsafe { ptr::read(storage!(self).add(i)) };
         unsafe { ptr::copy(storage!(self).add(i + 1), storage!(self).add(i), n) };
         v
@@ -116,10 +116,10 @@ impl SOMStack {
     /// Push `v` onto the end of the stack. You must previously have checked (using
     /// [`SOMStack::remaining_capacity`]) that there is room for this value: if there is not,
     /// undefined behaviour will occur.
-    pub fn push(mut self: Gc<Self>, v: Val) {
+    pub fn push(self: Gc<Self>, v: Val) {
         debug_assert!(self.remaining_capacity() > 0);
-        unsafe { ptr::write(storage!(self).add(self.len), v) };
-        self.len += 1;
+        unsafe { ptr::write(storage!(self).add(self.len()), v) };
+        self.len.set(self.len() + 1);
     }
 
     pub fn set(self: Gc<Self>, n: usize, v: Val) {
@@ -134,24 +134,24 @@ impl SOMStack {
     /// Returns a newly allocated `NormalArray` containing the elements in the range [at, len).
     /// After the call, the SOM stack will be left containing the elements [0, at) with its
     /// previous capacity unchanged.
-    pub fn split_off(mut self: Gc<Self>, at: usize) -> Val {
+    pub fn split_off(self: Gc<Self>, at: usize) -> Val {
         let arr = unsafe {
             NormalArray::alloc(self.len() - at, |arr_store: *mut Val| {
                 ptr::copy_nonoverlapping(storage!(self).add(at), arr_store, self.len() - at);
             })
         };
-        self.len = at;
+        self.len.set(at);
         arr
     }
 
     /// Shortens the stack, keeping the first len elements and dropping the rest.
-    pub fn truncate(mut self: Gc<Self>, len: usize) {
+    pub fn truncate(self: Gc<Self>, len: usize) {
         debug_assert!(len <= self.len());
-        for i in len..self.len {
+        for i in len..self.len() {
             unsafe {
                 ptr::read(storage!(self).add(i));
             }
         }
-        self.len = len;
+        self.len.set(len);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 #![feature(allocator_api)]
 #![cfg_attr(feature = "rustgc", feature(gc))]
 #![feature(box_patterns)]
+#![feature(rustc_private)]
 
 use std::{
     env,


### PR DESCRIPTION
This updates various places in yksom to work after the following breaking changes to libgc:

- `Gc<T>` can no longer be mutably dereferenced, so the places in yksom which relied on this have been updated to use interior mutability instead.
- `Gc<T>` now requires `T: Send`, so the `Obj` and `Array` traits needed updating with this constraint also.

Please can you pay special attention to the changes I've made in `UpVars`. The first couple of times I'd tried this, I had broken the `block.som` and `escape{n}.som` tests. I seem to have got this working now, I'd got very confused over whether in places I needed to be taking the on-stack-reference, or the `usize` field inside `Val`.