### PR TITLE
Null entries on the SOMStack after they're removed.

### DIFF
--- a/src/lib/vm/somstack.rs
+++ b/src/lib/vm/somstack.rs
@@ -156,7 +156,8 @@ impl SOMStack {
         debug_assert!(len <= self.len());
         for i in len..self.len() {
             unsafe {
-                ptr::read(storage!(self).add(i));
+                // Since `Val`s don't have a `drop` implementation, we can simply discard them
+                // without worrying about them being dropped.
                 ptr::write(storage!(self).add(i), Val::illegal());
             }
         }


### PR DESCRIPTION
This prevents the GC thinking they're still alive. It would be preferable to tell the GC "only scan the first N words of the stack" but we don't have any way of doing that at the moment AFAIK.

This doesn't have any performance difference that I can measure either way.