### PR TITLE
Ensure yksom works safely with untraceable allocation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 Cargo.lock
 target/
 *.core
+rebench.conf
+rebench.data

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,6 @@ arrayvec = "0.5"
 cfgrammar = "0.9"
 getopts = "0.2"
 itertools = "0.9"
-libgc = { git = "https://github.com/softdevteam/libgc" }
 lrlex = "0.9"
 lrpar = "0.9"
 natrob = { git="https://github.com/softdevteam/natrob", features=["libgc"] }

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -15,6 +15,7 @@
 #![feature(arbitrary_self_types)]
 #![feature(box_patterns)]
 #![feature(coerce_unsized)]
+#![feature(negative_impls)]
 #![feature(dispatch_from_dyn)]
 #![feature(entry_insert)]
 #![feature(raw_ref_op)]

--- a/src/lib/vm/objects/array.rs
+++ b/src/lib/vm/objects/array.rs
@@ -7,6 +7,8 @@ use std::{
 
 use std::gc::Gc;
 
+use std::gc::NoTrace;
+
 use crate::vm::{
     core::VM,
     error::{VMError, VMErrorKind},
@@ -43,6 +45,8 @@ pub trait Array: Send {
 pub struct NormalArray {
     len: usize,
 }
+
+impl !NoTrace for NormalArray {}
 
 // Since arrays have a fixed number of elements in their store, we do not need to allocate a separate
 // object and store: we can fit both in a single block. We thus use a custom layout where

--- a/src/lib/vm/somstack.rs
+++ b/src/lib/vm/somstack.rs
@@ -4,6 +4,8 @@ use std::gc::Gc;
 
 use crate::vm::{objects::NormalArray, val::Val};
 
+use std::gc::NoTrace;
+
 pub const SOM_STACK_LEN: usize = 4096;
 
 /// A contiguous stack of SOM values. This stack does minimal or no checking on important
@@ -33,6 +35,8 @@ pub struct SOMStack {
     /// How many items are used? Note that the stack has an implicit capacity of [`SOM_STACK_LEN`].
     len: Cell<usize>,
 }
+
+impl !NoTrace for SOMStack {}
 
 macro_rules! storage {
     ($self:ident) => {

--- a/src/lib/vm/val.rs
+++ b/src/lib/vm/val.rs
@@ -14,6 +14,8 @@ use num_enum::{IntoPrimitive, UnsafeFromPrimitive};
 use num_traits::{FromPrimitive, ToPrimitive};
 use std::gc::Gc;
 
+use std::gc::NoTrace;
+
 use super::{
     core::VM,
     error::{VMError, VMErrorKind},
@@ -64,6 +66,8 @@ pub struct Val {
     // several parts of the code to cooperate in order to be correct.
     pub val: usize,
 }
+
+impl !NoTrace for Val {}
 
 impl Val {
     /// Create a new `Val` from an object that should be allocated on the heap.


### PR DESCRIPTION
Some types (e.g. `Val`) have opaque pointers which are hidden from type system. This ensures that the GC can see them and still treats them as potential pointers during marking.