### PR TITLE
Remove all uses of Gc::new_from_layout.

### DIFF
--- a/src/lib/vm/objects/instance.rs
+++ b/src/lib/vm/objects/instance.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::new_ret_no_self)]
 
-use std::{alloc::Layout, collections::hash_map::DefaultHasher, hash::Hasher, mem::size_of};
+use std::{cell::UnsafeCell, collections::hash_map::DefaultHasher, hash::Hasher};
 
 use std::gc::Gc;
 
@@ -14,27 +14,10 @@ use crate::vm::{
 #[derive(Debug)]
 pub struct Inst {
     class: Val,
+    inst_vars: UnsafeCell<Vec<Val>>,
 }
 
-// Since instances have a fixed number of instance variables, we do not need to allocate a separate
-// object and backing store: we can fit both in a single block.  We thus use a custom layout where
-// the `Inst` comes first, followed immediately by the `Val`s representing instance variables. On a
-// 64-bit machine this looks roughly as follows:
-//
-//   0: Inst
-//   8: Val [representing instance field 0]
-//   16: Val [representing instance field 1]
-//   ...
-
-macro_rules! inst_vars {
-    ($self:ident) => {
-        // We assume that the instance variables immediately follow the `Inst` without padding.
-        // This invariant is enforced in `Inst::new`. This saves us having to create a full
-        // `Layout`, which would require us having to know how many instance variables this
-        // particular `Inst` has.
-        (Gc::into_raw($self) as *mut u8).add(::std::mem::size_of::<Inst>()) as *mut Val
-    };
-}
+impl std::gc::NoFinalize for Inst {}
 
 impl Obj for Inst {
     fn dyn_objtype(self: Gc<Self>) -> ObjType {
@@ -52,14 +35,14 @@ impl Obj for Inst {
 
     unsafe fn unchecked_inst_var_get(self: Gc<Self>, vm: &VM, n: usize) -> Val {
         debug_assert!(n < self.num_inst_vars(vm));
-        let v = inst_vars!(self).add(n).read();
+        let v = (&*self.inst_vars.get()).get_unchecked(n);
         debug_assert!(v.valkind() != ValKind::ILLEGAL);
-        v
+        *v
     }
 
     unsafe fn unchecked_inst_var_set(self: Gc<Self>, vm: &VM, n: usize, v: Val) {
         debug_assert!(n < self.num_inst_vars(vm));
-        inst_vars!(self).add(n).write(v);
+        *(&mut *self.inst_vars.get()).get_unchecked_mut(n) = v;
     }
 
     fn hashcode(self: Gc<Self>) -> u64 {
@@ -82,22 +65,9 @@ impl Inst {
         let cls: Gc<Class> = class.downcast(vm).unwrap();
         let len = cls.inst_vars_map.len();
         debug_assert!(vm.nil.valkind() != ValKind::ILLEGAL || len == 0);
-        let (vals_layout, vals_dist) = Layout::new::<Val>().repeat(len).unwrap();
-        // We require the instance variables to be laid out as a C-like contiguous array.
-        debug_assert_eq!(vals_dist, size_of::<Val>());
-        let (layout, inst_vars_off) = Layout::new::<Inst>().extend(vals_layout).unwrap();
-        // We require the instance variables to be positioned immediately after the `Inst` with no
-        // padding in-between. This assumption is relied upon by the `inst_vars!` macro.
-        debug_assert_eq!(inst_vars_off, size_of::<Inst>());
-        unsafe {
-            Val::new_from_layout(layout, |basep: *mut Inst| {
-                *basep = Inst { class };
-                let mut inst_vars = (basep as *mut u8).add(size_of::<Inst>()) as *mut Val;
-                for _ in 0..len {
-                    inst_vars.write(vm.nil);
-                    inst_vars = inst_vars.add(1);
-                }
-            })
-        }
+        Val::from_obj(Inst {
+            class,
+            inst_vars: UnsafeCell::new(vec![vm.nil; len]),
+        })
     }
 }

--- a/src/lib/vm/val.rs
+++ b/src/lib/vm/val.rs
@@ -2,12 +2,7 @@
 
 #![allow(clippy::new_ret_no_self)]
 
-use std::{
-    alloc::Layout,
-    convert::TryFrom,
-    mem::{align_of, size_of},
-    ops::Deref,
-};
+use std::{convert::TryFrom, mem::size_of, ops::Deref};
 
 use num_bigint::BigInt;
 use num_enum::{IntoPrimitive, UnsafeFromPrimitive};
@@ -73,30 +68,6 @@ impl Val {
     /// Create a new `Val` from an object that should be allocated on the heap.
     pub fn from_obj<T: Obj + 'static>(obj: T) -> Val {
         let p = Gc::into_raw(ThinObj::new(obj));
-        Val {
-            val: (p as usize) | (ValKind::GCBOX as usize),
-        }
-    }
-
-    /// Allocate memory on the heap into which an object (and, optionally, additional memory) can
-    /// be stored.
-    ///
-    /// # Safety
-    ///
-    /// `layout` must be at least big enough for an object of type `T` (but may optionally be
-    /// bigger) and must have at least the same alignment that `T requires (but may optionally have
-    /// a bigger alignment). `init` will be called with a pointer to uninitialised memory into
-    /// which a fully initialised object of type `T` *must* be written. After `init` completes, the
-    /// object will be considered fully initialised: failure to fully initialise it leads to
-    /// undefined behaviour. Note that if additional memory was requested beyond that needed to
-    /// store `T` then that extra memory does not have to be initialised after `init` completes.
-    pub unsafe fn new_from_layout<T: Obj + 'static, F>(layout: Layout, init: F) -> Val
-    where
-        F: FnOnce(*mut T),
-    {
-        debug_assert!(layout.size() >= size_of::<T>() && layout.align() >= align_of::<T>());
-        let gcp = ThinObj::new_from_layout::<T, _>(layout, |p| init(p));
-        let p = Gc::into_raw(gcp);
         Val {
             val: (p as usize) | (ValKind::GCBOX as usize),
         }


### PR DESCRIPTION
**DON'T MERGE YET**

Mostly these are very simple changes. The only slightly -- but, fortunately, not very -- tricky case is SOMStack. To minimise changes, I have chosen to use a fixed size array *within* `SOMStack`. Because upvars use interior pointers to the SOM stack, this design is fine, but it does impose a requirement (which we happened to already meet) that `SOMStack` is only ever used as `GC<SOMStack>`.

However, we shouldn't merge this until the performance bugs in rustgc (e.g. over `Vec<Val>`) are fixed, and then we can properly measure whether this PR has any useful effect or not.