### PR TITLE
Move from `Gc::into_raw` to `Gc::as_ptr`.

### DIFF
--- a/src/lib/vm/core.rs
+++ b/src/lib/vm/core.rs
@@ -432,7 +432,7 @@ impl VM {
                             let mut uv = self.open_upvars;
                             let mut prev = None;
                             let local_ptr =
-                                Gc::into_raw(unsafe { self.stack.addr_of(stack_base + u.upidx) });
+                                Gc::as_ptr(&unsafe { self.stack.addr_of(stack_base + u.upidx) });
 
                             // Search for an existing UpVar.
                             while let Some(uv_uw) = uv {
@@ -441,14 +441,14 @@ impl VM {
                                 //   * the stack is contiguous
                                 // we can stop searching if this UpVar is for a variable lower on
                                 // the stack than the one we're looking for.
-                                if Gc::into_raw(uv_uw.to_gc()) <= local_ptr {
+                                if Gc::as_ptr(&uv_uw.to_gc()) <= local_ptr {
                                     break;
                                 }
                                 prev = uv;
                                 uv = uv_uw.prev();
                             }
 
-                            if (uv.is_some() && Gc::into_raw(uv.unwrap().to_gc()) < local_ptr)
+                            if (uv.is_some() && Gc::as_ptr(&uv.unwrap().to_gc()) < local_ptr)
                                 || uv.is_none()
                             {
                                 // Create a new UpVar.
@@ -461,7 +461,7 @@ impl VM {
                                     self.open_upvars = uv;
                                 }
                             } else {
-                                debug_assert_eq!(Gc::into_raw(uv.unwrap().to_gc()), local_ptr);
+                                debug_assert_eq!(Gc::as_ptr(&uv.unwrap().to_gc()), local_ptr);
                             }
                             blk_upvars.push(uv.unwrap());
                         } else {
@@ -640,7 +640,7 @@ impl VM {
                 }
                 Instr::UpVarSet(n) => {
                     let v = self.stack.peek();
-                    unsafe { (Gc::into_raw(blk.unwrap().upvars[n].to_gc()) as *mut Val).write(v) };
+                    unsafe { (Gc::as_ptr(&blk.unwrap().upvars[n].to_gc()) as *mut Val).write(v) };
                     pc += 1;
                 }
             }
@@ -1326,7 +1326,7 @@ impl VM {
         while self.open_upvars.is_some() {
             let uv = self.open_upvars.unwrap();
             debug_assert!(!uv.is_closed());
-            if Gc::into_raw(uv.to_gc()) < Gc::into_raw(unsafe { self.stack.addr_of(stack_base) }) {
+            if Gc::as_ptr(&uv.to_gc()) < Gc::as_ptr(&unsafe { self.stack.addr_of(stack_base) }) {
                 break;
             }
             uv.close();

--- a/src/lib/vm/objects/array.rs
+++ b/src/lib/vm/objects/array.rs
@@ -56,7 +56,7 @@ impl Obj for NormalArray {
 
     fn hashcode(self: Gc<Self>) -> u64 {
         let mut hasher = DefaultHasher::new();
-        hasher.write_usize(Gc::into_raw(self) as *const _ as usize);
+        hasher.write_usize(Gc::as_ptr(&self) as *const _ as usize);
         hasher.finish()
     }
 
@@ -165,7 +165,7 @@ impl Obj for MethodsArray {
         Self: Send,
     {
         let mut hasher = DefaultHasher::new();
-        hasher.write_usize(Gc::into_raw(self) as *const _ as usize);
+        hasher.write_usize(Gc::as_ptr(&self) as *const _ as usize);
         hasher.finish()
     }
 

--- a/src/lib/vm/objects/block.rs
+++ b/src/lib/vm/objects/block.rs
@@ -49,7 +49,7 @@ impl UpVar {
     }
 
     pub fn is_closed(&self) -> bool {
-        Gc::into_raw(self.ptr.get()) == &self.closed as *const Cell<_> as *const _
+        Gc::as_ptr(&self.ptr.get()) == &self.closed as *const Cell<_> as *const _
     }
 
     pub fn prev(&self) -> Option<Gc<UpVar>> {
@@ -95,7 +95,7 @@ impl Obj for Block {
 
     fn hashcode(self: Gc<Self>) -> u64 {
         let mut hasher = DefaultHasher::new();
-        hasher.write_usize(Gc::into_raw(self) as *const _ as usize);
+        hasher.write_usize(Gc::as_ptr(&self) as *const _ as usize);
         hasher.finish()
     }
 }

--- a/src/lib/vm/objects/class.rs
+++ b/src/lib/vm/objects/class.rs
@@ -73,7 +73,7 @@ impl Obj for Class {
 
     fn hashcode(self: Gc<Self>) -> u64 {
         let mut hasher = DefaultHasher::new();
-        hasher.write_usize(Gc::into_raw(self) as *const _ as usize);
+        hasher.write_usize(Gc::as_ptr(&self) as *const _ as usize);
         hasher.finish()
     }
 }

--- a/src/lib/vm/objects/instance.rs
+++ b/src/lib/vm/objects/instance.rs
@@ -47,7 +47,7 @@ impl Obj for Inst {
 
     fn hashcode(self: Gc<Self>) -> u64 {
         let mut hasher = DefaultHasher::new();
-        hasher.write_usize(Gc::into_raw(self) as *const _ as usize);
+        hasher.write_usize(Gc::as_ptr(&self) as *const _ as usize);
         hasher.finish()
     }
 }

--- a/src/lib/vm/objects/method.rs
+++ b/src/lib/vm/objects/method.rs
@@ -34,7 +34,7 @@ impl Obj for Method {
 
     fn hashcode(self: Gc<Self>) -> u64 {
         let mut hasher = DefaultHasher::new();
-        hasher.write_usize(Gc::into_raw(self) as *const _ as usize);
+        hasher.write_usize(Gc::as_ptr(&self) as *const _ as usize);
         hasher.finish()
     }
 }

--- a/src/lib/vm/objects/mod.rs
+++ b/src/lib/vm/objects/mod.rs
@@ -224,7 +224,7 @@ pub trait Obj: std::fmt::Debug + FinalizerSafe {
             unsafe { std::mem::transmute::<&dyn Obj, (*const u8, usize)>(&**other_tobj).0 };
         Ok(Val::from_bool(
             vm,
-            (Gc::into_raw(self) as *const _ as *const u8) == other_data,
+            (Gc::as_ptr(&self) as *const _ as *const u8) == other_data,
         ))
     }
 

--- a/src/lib/vm/val.rs
+++ b/src/lib/vm/val.rs
@@ -67,7 +67,7 @@ impl !NoTrace for Val {}
 impl Val {
     /// Create a new `Val` from an object that should be allocated on the heap.
     pub fn from_obj<T: Obj + 'static>(obj: T) -> Val {
-        let p = Gc::into_raw(ThinObj::new(obj));
+        let p = Gc::as_ptr(&ThinObj::new(obj));
         Val {
             val: (p as usize) | (ValKind::GCBOX as usize),
         }
@@ -78,7 +78,7 @@ impl Val {
     /// undefined behaviour.
     pub fn recover<T: Obj + 'static>(obj: Gc<T>) -> Self {
         unsafe {
-            let p = Gc::into_raw(ThinObj::recover_gc(obj));
+            let p = Gc::as_ptr(&ThinObj::recover_gc(obj));
             Val {
                 val: (p as usize) | (ValKind::GCBOX as usize),
             }


### PR DESCRIPTION
This will make the later conversion to `Rc::as_ptr` easier.

Needs https://github.com/softdevteam/rustgc/pull/72 to be merged first.