### PR TITLE
Fix integer multiplication.

### DIFF
--- a/lang_tests/int32.som
+++ b/lang_tests/int32.som
@@ -1,0 +1,36 @@
+"
+VM:
+  status: success
+  stdout:
+    4
+    256
+    65536
+    4294967296
+    9223372036854775808
+    18446744073709551616
+    1267650600228229401496703205376
+    -128
+    256
+"
+
+int32 = (
+    run = (
+        (self raisedTo: 2 exponent: 2) println.
+        (self raisedTo: 2 exponent: 8) println.
+        (self raisedTo: 2 exponent: 16) println.
+        (self raisedTo: 2 exponent: 32) println.
+        (self raisedTo: 2 exponent: 63) println.
+        (self raisedTo: 2 exponent: 64) println.
+        (self raisedTo: 2 exponent: 100) println.
+
+        (self raisedTo: -2 exponent: 7) println.
+        (self raisedTo: -2 exponent: 8) println.
+    )
+
+    raisedTo: v exponent: e = (
+        | x |
+        x := 1.
+        e timesRepeat: [ x := x * v ].
+        ^ x
+    )
+)

--- a/src/lib/vm/val.rs
+++ b/src/lib/vm/val.rs
@@ -449,8 +449,10 @@ impl Val {
     pub fn mul(&self, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         debug_assert_eq!(ValKind::INT as usize, 0);
         if self.valkind() == ValKind::INT && other.valkind() == ValKind::INT {
-            if let Some(val) = self.val.checked_mul(other.val / (1 << TAG_BITSIZE)) {
-                return Ok(Val { val });
+            if let Some(val) = self.val.checked_mul(other.val) {
+                return Ok(Val {
+                    val: val >> TAG_BITSIZE,
+                });
             }
         }
         self.tobj(vm).unwrap().as_gc().mul(vm, other)


### PR DESCRIPTION
Previously we didn't detect some cases of overflow properly due to integer tagging.

Spotted indirectly by @smarr in #217.