### PR TITLE
Update for symmetric `=`.

### DIFF
--- a/lang_tests/string_equal_nonstring.som
+++ b/lang_tests/string_equal_nonstring.som
@@ -4,7 +4,7 @@ VM:
   stdout:
     true
     false
-    false
+    true
     false
 "
 

--- a/lang_tests/symbol.som
+++ b/lang_tests/symbol.som
@@ -4,10 +4,12 @@ VM:
   stdout:
     #ab
     true
-    false
+    true
     true
     String
-    String
+    Symbol
+    true
+    true
     #ab:
     #ab
     #+
@@ -23,6 +25,8 @@ symbol = (
         (('a' + 'b') asSymbol == #ab) println.
         (('a' + #ab) class) println.
         ((#ab + 'a') class) println.
+        (#ab = 'ab') println.
+        ('ab' = #ab) println.
 
         #ab: println.
 

--- a/src/lib/vm/objects/string_.rs
+++ b/src/lib/vm/objects/string_.rs
@@ -76,12 +76,16 @@ impl Obj for String_ {
     }
 
     fn ref_equals(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
-        self.equals(vm, other)
+        let b = match other.downcast::<String_>(vm) {
+            Ok(other_str) => (self.cls == other_str.cls) && (self.s == other_str.s),
+            Err(_) => false,
+        };
+        Ok(Val::from_bool(vm, b))
     }
 
     fn equals(self: Gc<Self>, vm: &mut VM, other: Val) -> Result<Val, Box<VMError>> {
         let b = match other.downcast::<String_>(vm) {
-            Ok(other_str) => (self.cls == other_str.cls) && (self.s == other_str.s),
+            Ok(other_str) => self.s == other_str.s,
             Err(_) => false,
         };
         Ok(Val::from_bool(vm, b))


### PR DESCRIPTION
This commit updates us to the latest SOM library and also adapts to the new semantics of `=` for `String`/`Symbol` (see https://github.com/SOM-st/SOM/pull/106).

I believe that most (all?) SOMs currently cache symbols so two instances of `#a` in different parts of the source code always point to the same underlying object, so `=` (nominally "reference equality") will return true when those two seemingly separate objects are compared. yksom does not cache symbols, so we have to override `=` to compare `Symbol`s by their contents. This commit also does that for `String`s -- I don't think the SOM spec says anything about this either way, and all the tests pass so...

CC @smarr 