### PR TITLE
Remove use of `std::gc::ReferenceFree` trait

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+exit 0
+
 git submodule init
 git pull --recurse-submodules
 

--- a/src/lib/vm/objects/mod.rs
+++ b/src/lib/vm/objects/mod.rs
@@ -40,7 +40,6 @@ pub use string_::String_;
 
 use natrob::narrowable_alloy;
 use std::gc::Gc;
-use std::gc::ReferenceFree;
 
 use crate::vm::{
     core::VM,
@@ -81,7 +80,7 @@ impl ObjType {
 /// The main SOM Object trait. Notice that code should almost never call these functions directly:
 /// you should instead call the equivalent function in the `Val` struct.
 #[narrowable_alloy(ThinObj)]
-pub trait Obj: std::fmt::Debug + Send + Sync + FinalizerSafe + ReferenceFree {
+pub trait Obj: std::fmt::Debug + Send + Sync + FinalizerSafe {
     /// What `ObjType` does this `Val` represent?
     fn dyn_objtype(self: Gc<Self>) -> ObjType;
 


### PR DESCRIPTION
This trait no longer exists in Alloy.

Note that we must disable CI for this one to land :face_with_diagonal_mouth:, this is because Alloy uses yksom in its CI and we have a chicken and egg problem. Once https://github.com/softdevteam/alloy/pull/137 lands I will raise another yksom PR to re-enable CI.